### PR TITLE
Dxf CadObject mapper

### DIFF
--- a/ACadSharp.Tests/DxfMapTests.cs
+++ b/ACadSharp.Tests/DxfMapTests.cs
@@ -30,7 +30,7 @@ namespace ACadSharp.Tests
 			}
 		}
 
-		[Theory(Skip = "Not implemented")]
+		[Theory]
 		[MemberData(nameof(Types))]
 		public void CreateMapTest(Type t)
 		{
@@ -121,6 +121,9 @@ namespace ACadSharp.Tests
 				case DxfFileToken.EntityLine:
 					DxfMap.Create<Line>();
 					break;
+				case DxfFileToken.EntityLwPolyline:
+					DxfMap.Create<LwPolyLine>();
+					break;
 				case DxfFileToken.EntityMLine:
 					DxfMap.Create<MLine>();
 					break;
@@ -161,7 +164,18 @@ namespace ACadSharp.Tests
 					DxfMap.Create<UCS>();
 					break;
 				case DxfFileToken.EntityVertex:
-					DxfMap.Create<Vertex>();
+					Assert.NotNull(subclass);
+					switch (subclass.ClassName)
+					{
+						case DxfSubclassMarker.PolylineVertex:
+							DxfMap.Create<Vertex2D>();
+							break;
+						case DxfSubclassMarker.Polyline3dVertex:
+							DxfMap.Create<Vertex3D>();
+							break;
+						default:
+							throw new NotImplementedException($"Test not implemented for type {t.Name}");
+					}
 					break;
 				case DxfFileToken.TableView:
 					DxfMap.Create<View>();

--- a/ACadSharp/Attributes/DxfSubClassAttribute.cs
+++ b/ACadSharp/Attributes/DxfSubClassAttribute.cs
@@ -13,9 +13,19 @@ namespace ACadSharp.Attributes
 		/// </summary>
 		public string ClassName { get; }
 
+		/// <summary>
+		/// Flag to mark the classes that don't contain any properties by itself, they are only a base for the subclasses
+		/// </summary>
+		public bool IsEmpty { get; }
+
 		public DxfSubClassAttribute(string className)
 		{
 			this.ClassName = className;
+		}
+
+		public DxfSubClassAttribute(string className, bool isEmpty) : this(className)
+		{
+			this.IsEmpty = isEmpty;
 		}
 	}
 }

--- a/ACadSharp/DxfMap.cs
+++ b/ACadSharp/DxfMap.cs
@@ -80,31 +80,19 @@ namespace ACadSharp
 
 			for (type = typeof(T); type != null; type = type.BaseType)
 			{
+				DxfSubClassAttribute subclass = type.GetCustomAttribute<DxfSubClassAttribute>();
+
 				if (type.Equals(typeof(CadObject)))
 				{
 					addClassProperties(map, type);
 
 					break;
 				}
-				else if (type.Equals(typeof(TableEntry)))
+				else if (subclass != null && subclass.IsEmpty)
 				{
-					//TODO: Handle the names and subclasses 
 					DxfClassMap classMap = map.SubClasses.Last().Value;
 
 					addClassProperties(classMap, type);
-				}
-				else if (type.Equals(typeof(AttributeEntity)) || type.Equals(typeof(AttributeDefinition)))
-				{
-					DxfClassMap attMap = new DxfClassMap();
-					attMap.Name = type.GetCustomAttribute<DxfSubClassAttribute>().ClassName;
-
-					addClassProperties(attMap, type);
-
-					//Get the base class for both atts
-					type = type.BaseType;
-					addClassProperties(attMap, type);
-
-					map.SubClasses.Add(attMap.Name, attMap);
 				}
 				else if (type.GetCustomAttribute<DxfSubClassAttribute>() != null)
 				{

--- a/ACadSharp/Entities/AttributeBase.cs
+++ b/ACadSharp/Entities/AttributeBase.cs
@@ -23,6 +23,7 @@ namespace ACadSharp.Entities
 	/// <summary>
 	/// Common base class for <see cref="AttributeEntity" /> and <see cref="AttributeDefinition" />.
 	/// </summary>
+	[DxfSubClass(null, true)]
 	public abstract class AttributeBase : TextEntity
 	{
 		[DxfCodeValue(74)]

--- a/ACadSharp/Entities/Vertex.cs
+++ b/ACadSharp/Entities/Vertex.cs
@@ -4,9 +4,12 @@ using CSMath;
 
 namespace ACadSharp.Entities
 {
-	public class Vertex : Entity	//TODO: Create an abstract task, split in 2d and 3d
+	/// <summary>
+	/// Represents a base for <see cref="Vertex2D"/> and <see cref="Vertex3D"/>
+	/// </summary>
+	[DxfSubClass(DxfSubclassMarker.Vertex)]
+	public abstract class Vertex : Entity
 	{
-		public override ObjectType ObjectType => ObjectType.VERTEX_2D;  //Shit there is a 3d too...
 		public override string ObjectName => DxfFileToken.EntityVertex;
 
 		//100	Subclass marker(AcDbVertex)

--- a/ACadSharp/Entities/Vertex2D.cs
+++ b/ACadSharp/Entities/Vertex2D.cs
@@ -1,0 +1,18 @@
+﻿using ACadSharp.Attributes;
+
+namespace ACadSharp.Entities
+{
+	/// <summary>
+	/// Represents a <see cref="Vertex2D"/> entity
+	/// </summary>
+	/// <remarks>
+	/// Object name <see cref="DxfFileToken.EntityVertex"/> <br/>
+	/// Dxf class name <see cref="DxfSubclassMarker.PolylineVertex"/>
+	/// </remarks>
+	[DxfName(DxfFileToken.EntityVertex)]
+	[DxfSubClass(DxfSubclassMarker.PolylineVertex)]
+	public class Vertex2D : Vertex
+	{
+		public override ObjectType ObjectType => ObjectType.VERTEX_2D;
+	}
+}

--- a/ACadSharp/Entities/Vertex3D.cs
+++ b/ACadSharp/Entities/Vertex3D.cs
@@ -1,0 +1,18 @@
+﻿using ACadSharp.Attributes;
+
+namespace ACadSharp.Entities
+{
+	/// <summary>
+	/// Represents a <see cref="Vertex3D"/> entity
+	/// </summary>
+	/// <remarks>
+	/// Object name <see cref="DxfFileToken.EntityVertex"/> <br/>
+	/// Dxf class name <see cref="DxfSubclassMarker.Polyline3dVertex"/>
+	/// </remarks>
+	[DxfName(DxfFileToken.EntityVertex)]
+	[DxfSubClass(DxfSubclassMarker.Polyline3dVertex)]
+	public class Vertex3D : Vertex
+	{
+		public override ObjectType ObjectType => ObjectType.VERTEX_3D;
+	}
+}

--- a/ACadSharp/IO/DWG/DwgObjectSectionReader.cs
+++ b/ACadSharp/IO/DWG/DwgObjectSectionReader.cs
@@ -1359,7 +1359,7 @@ namespace ACadSharp.IO.DWG
 
 		private DwgTemplate readVertex2D()
 		{
-			Vertex vertex = new Vertex();
+			Vertex2D vertex = new Vertex2D();
 			DwgEntityTemplate template = new DwgEntityTemplate(vertex);
 
 			this.readCommonEntityData(template);
@@ -1401,7 +1401,7 @@ namespace ACadSharp.IO.DWG
 
 		private DwgTemplate readVertex3D()
 		{
-			Vertex vertex = new Vertex();
+			Vertex3D vertex = new Vertex3D();
 			DwgEntityTemplate template = new DwgEntityTemplate(vertex);
 
 			this.readCommonEntityData(template);
@@ -1416,8 +1416,7 @@ namespace ACadSharp.IO.DWG
 
 		private DwgTemplate readPfaceVertex()
 		{
-			//TODO: Implement poly face vertex class
-			Vertex vertex = new Vertex();
+			Vertex2D vertex = new Vertex2D();
 			DwgEntityTemplate template = new DwgEntityTemplate(vertex);
 
 			this.readCommonEntityData(template);

--- a/ACadSharp/Tables/Collections/Table.cs
+++ b/ACadSharp/Tables/Collections/Table.cs
@@ -1,4 +1,5 @@
-﻿using ACadSharp.IO.Templates;
+﻿using ACadSharp.Attributes;
+using ACadSharp.IO.Templates;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -7,6 +8,7 @@ using System.Text;
 
 namespace ACadSharp.Tables.Collections
 {
+	[DxfSubClass(DxfSubclassMarker.Table)]
 	public abstract class Table<T> : CadObject, IObservableCollection<T>
 		where T : TableEntry
 	{

--- a/ACadSharp/Tables/TableEntry.cs
+++ b/ACadSharp/Tables/TableEntry.cs
@@ -6,6 +6,7 @@ using System.Text;
 
 namespace ACadSharp.Tables
 {
+	[DxfSubClass(DxfSubclassMarker.TableRecord, true)]
 	public abstract class TableEntry : CadObject
 	{
 		/// <summary>


### PR DESCRIPTION
## Description

DxfMap allows to create a class that links all the dxf codes with each property for all CadObjects