### PR TITLE
document integrity

### DIFF
--- a/ACadSharp.Tests/CadDocumentTests.cs
+++ b/ACadSharp.Tests/CadDocumentTests.cs
@@ -24,8 +24,7 @@ namespace ACadSharp.Tests
 		{
 			CadDocument doc = new CadDocument();
 
-			Assert.NotNull(doc.BlockRecords["*Model_Space"]);
-			Assert.NotNull(doc.BlockRecords["*Paper_Space"]);
+			DocumentIntegrity.AssertDocumentDefaults(doc);
 		}
 	}
 }

--- a/ACadSharp.Tests/CadDocumentTests.cs
+++ b/ACadSharp.Tests/CadDocumentTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using ACadSharp.Tables.Collections;
 using ACadSharp.Tables;
 using Xunit;
+using ACadSharp.Tests.Common;
 
 namespace ACadSharp.Tests
 {
@@ -15,30 +16,16 @@ namespace ACadSharp.Tests
 		{
 			CadDocument document = new CadDocument();
 
-			this.assertTable(document, document.AppIds);
-			this.assertTable(document, document.BlockRecords);
-			this.assertTable(document, document.DimensionStyles);
-			this.assertTable(document, document.Layers);
-			this.assertTable(document, document.LineTypes);
-			this.assertTable(document, document.TextStyles);
-			this.assertTable(document, document.UCSs);
-			this.assertTable(document, document.Views);
-			this.assertTable(document, document.VPorts);
+			DocumentIntegrity.AssertTableHirearchy(document);
 		}
 
-		private void assertTable<T>(CadDocument doc, Table<T> table)
-			where T : TableEntry
+		[Fact()]
+		public void CadDocumentDefaultTest()
 		{
-			Assert.NotNull(table);
+			CadDocument doc = new CadDocument();
 
-			Assert.NotNull(table.Document);
-			Assert.Equal(doc, table.Document);
-			Assert.Equal(doc, table.Owner);
-
-			Assert.True(table.Handle != 0);
-
-			CadObject t = doc.GetCadObject(table.Handle);
-			Assert.Equal(t, table);
+			Assert.NotNull(doc.BlockRecords["*Model_Space"]);
+			Assert.NotNull(doc.BlockRecords["*Paper_Space"]);
 		}
 	}
 }

--- a/ACadSharp.Tests/Common/DocumentIntegrity.cs
+++ b/ACadSharp.Tests/Common/DocumentIntegrity.cs
@@ -1,0 +1,62 @@
+﻿using ACadSharp.Tables;
+using ACadSharp.Tables.Collections;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace ACadSharp.Tests.Common
+{
+	public static class DocumentIntegrity
+	{
+		public static void AssertTableHirearchy(CadDocument doc)
+		{
+			//Assert all the tables in the doc
+			assertTable(doc, doc.AppIds);
+			assertTable(doc, doc.BlockRecords);
+			assertTable(doc, doc.DimensionStyles);
+			assertTable(doc, doc.Layers);
+			assertTable(doc, doc.LineTypes);
+			assertTable(doc, doc.TextStyles);
+			assertTable(doc, doc.UCSs);
+			assertTable(doc, doc.Views);
+			assertTable(doc, doc.VPorts);
+		}
+
+		public static void AssertDocumentDefaults(CadDocument doc)
+		{
+			//Assert the default values for the document
+			Assert.NotNull(doc.BlockRecords["*Model_Space"]);
+			Assert.NotNull(doc.BlockRecords["*Paper_Space"]);
+
+			//Assert linetypes
+			Assert.NotNull(doc.LineTypes["ByLayer"]);
+			Assert.NotNull(doc.LineTypes["ByBlock"]);
+			Assert.NotNull(doc.LineTypes["Continuous"]);
+
+		}
+
+		private static void assertTable<T>(CadDocument doc, Table<T> table)
+			where T : TableEntry
+		{
+			Assert.NotNull(table);
+
+			Assert.NotNull(table.Document);
+			Assert.Equal(doc, table.Document);
+			Assert.Equal(doc, table.Owner);
+
+			Assert.True(table.Handle != 0);
+
+			CadObject t = doc.GetCadObject(table.Handle);
+			Assert.Equal(t, table);
+
+			foreach (T entry in table)
+			{
+				Assert.Equal(entry.Owner.Handle, table.Handle);
+				Assert.Equal(entry.Owner, table);
+
+				Assert.NotNull(doc.GetCadObject(entry.Handle));
+			}
+		}
+	}
+}

--- a/ACadSharp.Tests/Common/DocumentIntegrity.cs
+++ b/ACadSharp.Tests/Common/DocumentIntegrity.cs
@@ -2,6 +2,7 @@
 using ACadSharp.Tables.Collections;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Xunit;
 
@@ -29,11 +30,38 @@ namespace ACadSharp.Tests.Common
 			Assert.NotNull(doc.BlockRecords["*Model_Space"]);
 			Assert.NotNull(doc.BlockRecords["*Paper_Space"]);
 
-			//Assert linetypes
 			Assert.NotNull(doc.LineTypes["ByLayer"]);
 			Assert.NotNull(doc.LineTypes["ByBlock"]);
 			Assert.NotNull(doc.LineTypes["Continuous"]);
 
+			Assert.NotNull(doc.Layers["0"]);
+
+			Assert.NotNull(doc.TextStyles["Standard"]);
+
+			Assert.NotNull(doc.AppIds["ACAD"]);
+
+			Assert.NotNull(doc.DimensionStyles["Standard"]);
+
+			Assert.NotNull(doc.VPorts["*Active"]);
+
+			//TODO: Change layout list to an observable collection
+			Assert.NotNull(doc.Layouts.FirstOrDefault(l => l.Name == "Model"));
+		}
+
+		public static void AssertBlockRecords(CadDocument doc)
+		{
+			foreach (BlockRecord br in doc.BlockRecords)
+			{
+				Assert.Equal(br.Name, br.BlockEntity.Name);
+
+				Assert.NotNull(doc.GetCadObject(br.BlockEntity.Handle));
+				Assert.NotNull(doc.GetCadObject(br.BlockEnd.Handle));
+
+				foreach (Entities.Entity e in br.Entities)
+				{
+					Assert.NotNull(doc.GetCadObject(e.Handle));
+				}
+			}
 		}
 
 		private static void assertTable<T>(CadDocument doc, Table<T> table)

--- a/ACadSharp.Tests/Common/DocumentIntegrity.cs
+++ b/ACadSharp.Tests/Common/DocumentIntegrity.cs
@@ -3,6 +3,7 @@ using ACadSharp.Tables.Collections;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Xunit;
 
@@ -27,25 +28,25 @@ namespace ACadSharp.Tests.Common
 		public static void AssertDocumentDefaults(CadDocument doc)
 		{
 			//Assert the default values for the document
-			Assert.NotNull(doc.BlockRecords["*Model_Space"]);
-			Assert.NotNull(doc.BlockRecords["*Paper_Space"]);
+			entryNotNull(doc.BlockRecords, "*Model_Space");
+			entryNotNull(doc.BlockRecords, "*Paper_Space");
 
-			Assert.NotNull(doc.LineTypes["ByLayer"]);
-			Assert.NotNull(doc.LineTypes["ByBlock"]);
-			Assert.NotNull(doc.LineTypes["Continuous"]);
+			entryNotNull(doc.LineTypes, "ByLayer");
+			entryNotNull(doc.LineTypes, "ByBlock");
+			entryNotNull(doc.LineTypes, "Continuous");
 
-			Assert.NotNull(doc.Layers["0"]);
+			entryNotNull(doc.Layers, "0");
 
-			Assert.NotNull(doc.TextStyles["Standard"]);
+			entryNotNull(doc.TextStyles, "Standard");
 
-			Assert.NotNull(doc.AppIds["ACAD"]);
+			entryNotNull(doc.AppIds, "ACAD");
 
-			Assert.NotNull(doc.DimensionStyles["Standard"]);
+			entryNotNull(doc.DimensionStyles, "Standard");
 
-			Assert.NotNull(doc.VPorts["*Active"]);
+			entryNotNull(doc.VPorts, "*Active");
 
 			//TODO: Change layout list to an observable collection
-			Assert.NotNull(doc.Layouts.FirstOrDefault(l => l.Name == "Model"));
+			notNull(doc.Layouts.FirstOrDefault(l => l.Name == "Model"), "Model");
 		}
 
 		public static void AssertBlockRecords(CadDocument doc)
@@ -54,12 +55,12 @@ namespace ACadSharp.Tests.Common
 			{
 				Assert.Equal(br.Name, br.BlockEntity.Name);
 
-				Assert.NotNull(doc.GetCadObject(br.BlockEntity.Handle));
-				Assert.NotNull(doc.GetCadObject(br.BlockEnd.Handle));
+				documentObjectNotNull(doc, br.BlockEntity);
+				documentObjectNotNull(doc, br.BlockEnd);
 
 				foreach (Entities.Entity e in br.Entities)
 				{
-					Assert.NotNull(doc.GetCadObject(e.Handle));
+					documentObjectNotNull(doc, e);
 				}
 			}
 		}
@@ -69,7 +70,7 @@ namespace ACadSharp.Tests.Common
 		{
 			Assert.NotNull(table);
 
-			Assert.NotNull(table.Document);
+			notNull(table.Document, $"Document not assigned to table {table}");
 			Assert.Equal(doc, table.Document);
 			Assert.Equal(doc, table.Owner);
 
@@ -83,8 +84,26 @@ namespace ACadSharp.Tests.Common
 				Assert.Equal(entry.Owner.Handle, table.Handle);
 				Assert.Equal(entry.Owner, table);
 
-				Assert.NotNull(doc.GetCadObject(entry.Handle));
+				documentObjectNotNull(doc, entry);
 			}
+		}
+
+		private static void documentObjectNotNull<T>(CadDocument doc, T o)
+			where T : CadObject
+		{
+			Assert.True(doc.GetCadObject(o.Handle) != null, $"Object of type {typeof(T)} | {o.Handle} not found in the doucment");
+
+		}
+
+		private static void notNull<T>(T o, string info)
+		{
+			Assert.True(o != null, $"Object of type {typeof(T)} should not be null:  {info}");
+		}
+
+		private static void entryNotNull<T>(Table<T> table, string entry)
+			where T : TableEntry
+		{
+			Assert.True(table[entry] != null, $"Entry with name {entry} is null for thable {table}");
 		}
 	}
 }

--- a/ACadSharp.Tests/IO/CadReaderTestsBase.cs
+++ b/ACadSharp.Tests/IO/CadReaderTestsBase.cs
@@ -1,0 +1,116 @@
+﻿using ACadSharp.Header;
+using ACadSharp.IO;
+using ACadSharp.IO.DWG;
+using ACadSharp.Tests.Common;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ACadSharp.Tests.IO
+{
+	public abstract class CadReaderTestsBase<T> : IDisposable
+		where T : CadReaderBase
+	{
+		private const string _samplesFolder = "../../../../samples/";
+
+		public static TheoryData<string> DwgFilePaths { get; }
+
+		public static TheoryData<string> DxfAsciiFiles { get; }
+
+		public static TheoryData<string> DxfBinaryFiles { get; }
+
+		protected readonly Dictionary<string, CadDocument> _documents = new Dictionary<string, CadDocument>();	//TODO: this does not store the document readed
+
+		protected readonly ITestOutputHelper _output;
+
+		static CadReaderTestsBase()
+		{
+			DwgFilePaths = new TheoryData<string>();
+			foreach (string file in Directory.GetFiles(_samplesFolder, $"*.dwg"))
+			{
+				DwgFilePaths.Add(file);
+			}
+
+			DxfAsciiFiles = new TheoryData<string>();
+			foreach (string file in Directory.GetFiles(_samplesFolder, "*_ascii.dxf"))
+			{
+				DxfAsciiFiles.Add(file);
+			}
+
+			DxfBinaryFiles = new TheoryData<string>();
+			foreach (string file in Directory.GetFiles(_samplesFolder, "*_binary.dxf"))
+			{
+				DxfBinaryFiles.Add(file);
+			}
+		}
+
+		public CadReaderTestsBase(ITestOutputHelper output)
+		{
+			this._output = output;
+		}
+
+		public virtual void ReadHeaderTest(string test)
+		{
+			using (T reader = (T)Activator.CreateInstance(typeof(T), test, null))
+			{
+				reader.OnNotificationHandler += this.onNotification;
+				CadHeader header = reader.ReadHeader();
+			}
+		}
+
+		public virtual void ReadTest(string test)
+		{
+			Assert.NotNull(getDocument(test));
+		}
+
+		public virtual void AssertDocumentDefaults(string test)
+		{
+			CadDocument doc = this.getDocument(test);
+
+			DocumentIntegrity.AssertDocumentDefaults(doc);
+		}
+
+		public virtual void AssertTableHirearchy(string test)
+		{
+			CadDocument doc = this.getDocument(test);
+
+			DocumentIntegrity.AssertTableHirearchy(doc);
+		}
+
+		public virtual void AssertBlockRecords(string test)
+		{
+			CadDocument doc = this.getDocument(test);
+
+			DocumentIntegrity.AssertBlockRecords(doc);
+		}
+
+		public void Dispose()
+		{
+			this._documents.Clear();
+		}
+
+		protected CadDocument getDocument(string path)
+		{
+			if (_documents.TryGetValue(path, out var doc))
+				return doc;
+
+			using (T reader = (T)Activator.CreateInstance(typeof(T), path, null))
+			{
+				reader.OnNotificationHandler += this.onNotification;
+				doc = reader.Read();
+			}
+
+			_documents.Add(path, doc);
+
+			return doc;
+		}
+
+		protected void onNotification(object sender, NotificationEventArgs e)
+		{
+			_output.WriteLine(e.Message);
+		}
+	}
+}

--- a/ACadSharp.Tests/IO/DWG/DwgReaderTests.cs
+++ b/ACadSharp.Tests/IO/DWG/DwgReaderTests.cs
@@ -40,6 +40,7 @@ namespace ACadSharp.Tests.IO.DWG
 
 			DocumentIntegrity.AssertTableHirearchy(doc);
 			DocumentIntegrity.AssertDocumentDefaults(doc);
+			DocumentIntegrity.AssertBlockRecords(doc);
 		}
 
 		[Theory]

--- a/ACadSharp.Tests/IO/DWG/DwgReaderTests.cs
+++ b/ACadSharp.Tests/IO/DWG/DwgReaderTests.cs
@@ -3,70 +3,59 @@ using ACadSharp.IO;
 using ACadSharp.IO.DWG;
 using ACadSharp.Tests.Common;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace ACadSharp.Tests.IO.DWG
 {
-	public class DwgReaderTests
+	public class DwgReaderTests : CadReaderTestsBase<DwgReader>
 	{
-		private const string _samplesFolder = "../../../../samples/";
+		public DwgReaderTests(ITestOutputHelper output) : base(output) { }
 
-		public static readonly TheoryData<string> FilePaths;
-
-		private readonly ITestOutputHelper output;
-
-		static DwgReaderTests()
+		[Theory]
+		[MemberData(nameof(DwgFilePaths))]
+		public override void ReadHeaderTest(string test)
 		{
-			FilePaths = new TheoryData<string>();
-
-			foreach (string file in Directory.GetFiles(_samplesFolder, "*.dwg"))
-			{
-				FilePaths.Add(file);
-			}
-		}
-
-		public DwgReaderTests(ITestOutputHelper output)
-		{
-			this.output = output;
+			base.ReadHeaderTest(test);
 		}
 
 		[Theory]
-		[MemberData(nameof(FilePaths))]
-		public void ReadTest(string test)
+		[MemberData(nameof(DwgFilePaths))]
+		public override void ReadTest(string test)
 		{
-			CadDocument doc = DwgReader.Read(test, this.onNotification);
-
-			DocumentIntegrity.AssertTableHirearchy(doc);
-			DocumentIntegrity.AssertDocumentDefaults(doc);
-			DocumentIntegrity.AssertBlockRecords(doc);
+			base.ReadTest(test);
 		}
 
 		[Theory]
-		[MemberData(nameof(FilePaths))]
-		public void ReadHeaderTest(string test)
+		[MemberData(nameof(DwgFilePaths))]
+		public override void AssertDocumentDefaults(string test)
 		{
-			CadHeader header;
+			base.AssertDocumentDefaults(test);
+		}
 
-			using (DwgReader reader = new DwgReader(test, this.onNotification))
-			{
-				header = reader.ReadHeader();
-			}
+		[Theory]
+		[MemberData(nameof(DwgFilePaths))]
+		public override void AssertTableHirearchy(string test)
+		{
+			base.AssertTableHirearchy(test);
+		}
+
+		[Theory]
+		[MemberData(nameof(DwgFilePaths))]
+		public override void AssertBlockRecords(string test)
+		{
+			base.AssertBlockRecords(test);
 		}
 
 		[Theory(Skip = "Long time test")]
-		[MemberData(nameof(FilePaths))]
+		[MemberData(nameof(DwgFilePaths))]
 		public void ReadCrcEnabledTest(string test)
 		{
 			DwgReaderFlags flags = DwgReaderFlags.CheckCrc;
 
 			CadDocument doc = DwgReader.Read(test, flags, this.onNotification);
-		}
-
-		private void onNotification(object sender, NotificationEventArgs e)
-		{
-			output.WriteLine(e.Message);
 		}
 	}
 }

--- a/ACadSharp.Tests/IO/DWG/DwgReaderTests.cs
+++ b/ACadSharp.Tests/IO/DWG/DwgReaderTests.cs
@@ -1,6 +1,7 @@
 ﻿using ACadSharp.Header;
 using ACadSharp.IO;
 using ACadSharp.IO.DWG;
+using ACadSharp.Tests.Common;
 using System;
 using System.IO;
 using Xunit;
@@ -36,6 +37,9 @@ namespace ACadSharp.Tests.IO.DWG
 		public void ReadTest(string test)
 		{
 			CadDocument doc = DwgReader.Read(test, this.onNotification);
+
+			DocumentIntegrity.AssertTableHirearchy(doc);
+			DocumentIntegrity.AssertDocumentDefaults(doc);
 		}
 
 		[Theory]
@@ -50,7 +54,7 @@ namespace ACadSharp.Tests.IO.DWG
 			}
 		}
 
-		[Theory]
+		[Theory(Skip = "Long time test")]
 		[MemberData(nameof(FilePaths))]
 		public void ReadCrcEnabledTest(string test)
 		{

--- a/ACadSharp.Tests/IO/DXF/DxfReaderTests.cs
+++ b/ACadSharp.Tests/IO/DXF/DxfReaderTests.cs
@@ -1,6 +1,7 @@
 ﻿using ACadSharp.Header;
 using ACadSharp.IO;
 using ACadSharp.IO.DXF;
+using ACadSharp.Tests.Common;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -45,6 +46,10 @@ namespace ACadSharp.Tests.IO.DXF
 		public void ReadAsciiTest(string test)
 		{
 			CadDocument doc = DxfReader.Read(test, this.onNotification);
+
+			DocumentIntegrity.AssertTableHirearchy(doc);
+			DocumentIntegrity.AssertDocumentDefaults(doc);
+			DocumentIntegrity.AssertBlockRecords(doc);
 		}
 
 		[Theory]
@@ -52,6 +57,10 @@ namespace ACadSharp.Tests.IO.DXF
 		public void ReadBinaryTest(string test)
 		{
 			CadDocument doc = DxfReader.Read(test, this.onNotification);
+
+			DocumentIntegrity.AssertTableHirearchy(doc);
+			DocumentIntegrity.AssertDocumentDefaults(doc);
+			DocumentIntegrity.AssertBlockRecords(doc);
 		}
 
 		[Theory]

--- a/ACadSharp.Tests/IO/DXF/DxfReaderTests.cs
+++ b/ACadSharp.Tests/IO/DXF/DxfReaderTests.cs
@@ -11,85 +11,60 @@ using Xunit.Abstractions;
 
 namespace ACadSharp.Tests.IO.DXF
 {
-	public class DxfReaderTests
+	public class DxfReaderTests : CadReaderTestsBase<DxfReader>
 	{
-		private const string _samplesFolder = "../../../../samples/";
-
-		public static readonly TheoryData<string> AsciiFiles;
-
-		public static readonly TheoryData<string> BinaryFiles;
-
-		private readonly ITestOutputHelper output;
-
-		static DxfReaderTests()
-		{
-			AsciiFiles = new TheoryData<string>();
-			foreach (string file in Directory.GetFiles(_samplesFolder, "*_ascii.dxf"))
-			{
-				AsciiFiles.Add(file);
-			}
-
-			BinaryFiles = new TheoryData<string>();
-			foreach (string file in Directory.GetFiles(_samplesFolder, "*_binary.dxf"))
-			{
-				BinaryFiles.Add(file);
-			}
-		}
-
-		public DxfReaderTests(ITestOutputHelper output)
-		{
-			this.output = output;
-		}
+		public DxfReaderTests(ITestOutputHelper output) : base(output) { }
 
 		[Theory]
-		[MemberData(nameof(AsciiFiles))]
-		public void ReadAsciiTest(string test)
-		{
-			CadDocument doc = DxfReader.Read(test, this.onNotification);
-
-			DocumentIntegrity.AssertTableHirearchy(doc);
-			DocumentIntegrity.AssertDocumentDefaults(doc);
-			DocumentIntegrity.AssertBlockRecords(doc);
-		}
-
-		[Theory]
-		[MemberData(nameof(BinaryFiles))]
-		public void ReadBinaryTest(string test)
-		{
-			CadDocument doc = DxfReader.Read(test, this.onNotification);
-
-			DocumentIntegrity.AssertTableHirearchy(doc);
-			DocumentIntegrity.AssertDocumentDefaults(doc);
-			DocumentIntegrity.AssertBlockRecords(doc);
-		}
-
-		[Theory]
-		[MemberData(nameof(AsciiFiles))]
+		[MemberData(nameof(DxfAsciiFiles))]
 		public void ReadHeaderAciiTest(string test)
 		{
-			CadHeader header;
-
-			using (DxfReader reader = new DxfReader(test, this.onNotification))
-			{
-				header = reader.ReadHeader();
-			}
+			base.ReadHeaderTest(test);
 		}
 
 		[Theory]
-		[MemberData(nameof(BinaryFiles))]
+		[MemberData(nameof(DxfBinaryFiles))]
 		public void ReadHeaderBinaryTest(string test)
 		{
-			CadHeader header;
-
-			using (DxfReader reader = new DxfReader(test, this.onNotification))
-			{
-				header = reader.ReadHeader();
-			}
+			base.ReadHeaderTest(test);
 		}
 
-		private void onNotification(object sender, NotificationEventArgs e)
+		[Theory]
+		[MemberData(nameof(DxfAsciiFiles))]
+		public void ReadAsciiTest(string test)
 		{
-			output.WriteLine(e.Message);
+			base.ReadTest(test);
+		}
+
+		[Theory]
+		[MemberData(nameof(DxfBinaryFiles))]
+		public void ReadBinaryTest(string test)
+		{
+			base.ReadTest(test);
+		}
+
+		[Theory]
+		[MemberData(nameof(DxfAsciiFiles))]
+		[MemberData(nameof(DxfBinaryFiles))]
+		public override void AssertDocumentDefaults(string test)
+		{
+			base.AssertDocumentDefaults(test);
+		}
+
+		[Theory]
+		[MemberData(nameof(DxfAsciiFiles))]
+		[MemberData(nameof(DxfBinaryFiles))]
+		public override void AssertTableHirearchy(string test)
+		{
+			base.AssertTableHirearchy(test);
+		}
+
+		[Theory]
+		[MemberData(nameof(DxfAsciiFiles))]
+		[MemberData(nameof(DxfBinaryFiles))]
+		public override void AssertBlockRecords(string test)
+		{
+			base.AssertBlockRecords(test);
 		}
 	}
 }

--- a/ACadSharp/IO/CadReaderBase.cs
+++ b/ACadSharp/IO/CadReaderBase.cs
@@ -6,18 +6,18 @@ namespace ACadSharp.IO
 {
 	public abstract class CadReaderBase : ICadReader
 	{
-		protected NotificationEventHandler notificationHandler;
+		public NotificationEventHandler OnNotificationHandler;
 
 		internal readonly StreamIO _fileStream;
 
 		private CadReaderBase(NotificationEventHandler notification)
 		{
-			this.notificationHandler = notification;
+			this.OnNotificationHandler = notification;
 		}
 
 		protected CadReaderBase(string filename, NotificationEventHandler notification) : this(notification)
 		{
-			this._fileStream = new StreamIO(filename);
+			this._fileStream = new StreamIO(filename, FileMode.Open, FileAccess.Read);
 		}
 
 		protected CadReaderBase(Stream stream, NotificationEventHandler notification) : this(notification)

--- a/ACadSharp/IO/DWG/DwgReader.cs
+++ b/ACadSharp/IO/DWG/DwgReader.cs
@@ -89,7 +89,7 @@ namespace ACadSharp.IO.DWG
 		public override CadDocument Read()
 		{
 			this._document = new CadDocument();
-			this._builder = new DwgDocumentBuilder(this._document, this.Flags, this.notificationHandler);
+			this._builder = new DwgDocumentBuilder(this._document, this.Flags, this.OnNotificationHandler);
 
 			//Read the file header
 			this.readFileHeader();
@@ -410,7 +410,7 @@ namespace ACadSharp.IO.DWG
 					else
 					{
 						//0 offset, wrong reference
-						notificationHandler.Invoke(this, new NotificationEventArgs($"Warning: readHandles, negative offset: {offset}"));
+						OnNotificationHandler.Invoke(this, new NotificationEventArgs($"Warning: readHandles, negative offset: {offset}"));
 					}
 				}
 
@@ -496,7 +496,7 @@ namespace ACadSharp.IO.DWG
 				handles,
 				this._document.Classes);
 
-			sectionReader.Read(this.notificationHandler);
+			sectionReader.Read(this.OnNotificationHandler);
 		}
 
 		#region File Header reading methods

--- a/ACadSharp/IO/DXF/DxfReader.cs
+++ b/ACadSharp/IO/DXF/DxfReader.cs
@@ -110,7 +110,7 @@ namespace ACadSharp.IO.DXF
 		public override CadDocument Read()
 		{
 			this._document = new CadDocument();
-			this._builder = new DxfDocumentBuilder(this._document, this.notificationHandler);
+			this._builder = new DxfDocumentBuilder(this._document, this.OnNotificationHandler);
 
 			this._reader = this._reader ?? this.getReader();
 
@@ -147,7 +147,7 @@ namespace ACadSharp.IO.DXF
 						// this.readObjects();
 						break;
 					default:
-						this.notificationHandler(this, new NotificationEventArgs($"Section not implemented {this._reader.LastValueAsString}"));
+						this.OnNotificationHandler(this, new NotificationEventArgs($"Section not implemented {this._reader.LastValueAsString}"));
 						break;
 				}
 
@@ -288,7 +288,7 @@ namespace ACadSharp.IO.DXF
 			DxfTablesSectionReader reader = new DxfTablesSectionReader(
 				this._reader,
 				this._builder,
-				this.notificationHandler);
+				this.OnNotificationHandler);
 
 			reader.Read();
 		}
@@ -306,7 +306,7 @@ namespace ACadSharp.IO.DXF
 			DxfBlockSectionReader reader = new DxfBlockSectionReader(
 				this._reader,
 				this._builder,
-				this.notificationHandler);
+				this.OnNotificationHandler);
 
 			reader.Read();
 		}
@@ -322,7 +322,7 @@ namespace ACadSharp.IO.DXF
 			DxfEntitiesSectionReader reader = new DxfEntitiesSectionReader(
 				this._reader,
 				this._builder,
-				this.notificationHandler);
+				this.OnNotificationHandler);
 
 			reader.Read();
 		}
@@ -338,7 +338,7 @@ namespace ACadSharp.IO.DXF
 			DxfObjectsSectionReader reader = new DxfObjectsSectionReader(
 				this._reader,
 				this._builder,
-				this.notificationHandler);
+				this.OnNotificationHandler);
 
 			reader.Read();
 		}


### PR DESCRIPTION
## TODO
- CadDocument needs to create all the default objects if is not in the reader
- The document creates the tables but the handles need to be reassign during the reading
- ```BlockEnd``` and ```BlockEntity``` must be included in the document