### PR TITLE
Reading & Writing Performance Review Changes

### DIFF
--- a/ACadSharp.Tests/Tables/BlockRecordTests.cs
+++ b/ACadSharp.Tests/Tables/BlockRecordTests.cs
@@ -3,6 +3,7 @@ using ACadSharp.Tables;
 using ACadSharp.Tests.Common;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Xunit;
 
@@ -78,9 +79,15 @@ namespace ACadSharp.Tables.Tests
 
 			CadObjectTestUtils.AssertTableEntryClone(record, clone);
 
+			// Copy the state of the entities to an array as this is now using a HashMap for performance
+			// and cannot be accessed via indexes.
+
+            var recordEntities = record.Entities.ToArray();
+            var cloneEntities = clone.Entities.ToArray();
+
 			for (int i = 0; i < record.Entities.Count; i++)
 			{
-				CadObjectTestUtils.AssertEntityClone(record.Entities[i], clone.Entities[i], true);
+				CadObjectTestUtils.AssertEntityClone(recordEntities[i], cloneEntities[i], true);
 			}
 		}
 	}

--- a/ACadSharp/CadObjectCollection.cs
+++ b/ACadSharp/CadObjectCollection.cs
@@ -12,13 +12,14 @@ namespace ACadSharp
 
 		public event EventHandler<ReferenceChangedEventArgs> OnRemove;
 
-		public T this[int index] { get { return this._entries[index]; } }
+		// TODO: Investigate adding this back with a HashSet.
+		//public T this[int index] { get { return this._entries[index]; } }
 
 		public CadObject Owner { get; }
 
 		public int Count { get { return this._entries.Count; } }
 
-		private readonly List<T> _entries = new List<T>();
+		private readonly HashSet<T> _entries = new HashSet<T>();
 
 		public CadObjectCollection(CadObject owner)
 		{

--- a/ACadSharp/DxfClassMap.cs
+++ b/ACadSharp/DxfClassMap.cs
@@ -1,33 +1,63 @@
 ﻿using ACadSharp.Attributes;
 using System;
+using System.Collections.Concurrent;
 using System.Reflection;
 
 namespace ACadSharp
 {
 	public class DxfClassMap : DxfMapBase
-	{
-		public static DxfClassMap Create<T>()
+    {
+        /// <summary>
+        /// Cache of created DXF mapped classes.
+        /// </summary>
+        private static readonly ConcurrentDictionary<Type, DxfClassMap> _cache = new ConcurrentDictionary<Type, DxfClassMap>();
+
+        /// <summary>
+        /// Creates a DXF map of the passed type.
+        /// </summary>
+        /// <remarks>
+        ///   Will return a cached instance if it exists.  if not, it will be created on call.
+        /// Use the <see cref="ClearCache"/> method to clear the cache and force a new mapping to be created.
+        /// </remarks>
+        /// <typeparam name="T">Type of CadObject to map.</typeparam>
+        /// <returns>Mapped class</returns>
+        public static DxfClassMap Create<T>()
 			where T : CadObject
 		{
 			Type type = typeof(T);
-			DxfClassMap classMap = new DxfClassMap();
 
-			var att = type.GetCustomAttribute<DxfSubClassAttribute>();
-			if (att == null)
-				throw new ArgumentException($"{type.FullName} is not a dxf subclass");
+            if (!_cache.TryGetValue(type, out var classMap))
+            {
+                classMap = new DxfClassMap();
 
-			classMap.Name = type.GetCustomAttribute<DxfSubClassAttribute>().ClassName;
+                var att = type.GetCustomAttribute<DxfSubClassAttribute>();
+                if (att == null)
+                    throw new ArgumentException($"{type.FullName} is not a dxf subclass");
 
-			addClassProperties(classMap, type);
+                classMap.Name = type.GetCustomAttribute<DxfSubClassAttribute>().ClassName;
 
-			DxfSubClassAttribute baseAtt = type.BaseType.GetCustomAttribute<DxfSubClassAttribute>();
-			if (baseAtt != null && baseAtt.IsEmpty)
-			{
-				//Properties in the table seem to be embeded to the hinerit type
-				addClassProperties(classMap, type.BaseType);
-			}
+                addClassProperties(classMap, type);
 
-			return classMap;
+                DxfSubClassAttribute baseAtt = type.BaseType.GetCustomAttribute<DxfSubClassAttribute>();
+                if (baseAtt != null && baseAtt.IsEmpty)
+                {
+                    //Properties in the table seem to be embeded to the hinerit type
+                    addClassProperties(classMap, type.BaseType);
+                }
+
+                _cache.TryAdd(type, classMap);
+            }
+
+            return classMap;
 		}
-	}
+
+
+        /// <summary>
+        /// Clears the map cache.
+        /// </summary>
+        public void ClearCache()
+        {
+            _cache.Clear();
+        }
+    }
 }

--- a/ACadSharp/DxfMap.cs
+++ b/ACadSharp/DxfMap.cs
@@ -5,6 +5,7 @@ using ACadSharp.Objects;
 using ACadSharp.Tables;
 using CSMath;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -16,6 +17,11 @@ namespace ACadSharp
 {
 	public class DxfMap : DxfMapBase
 	{
+        /// <summary>
+        /// Cache of created DXF mapped classes.
+        /// </summary>
+        private static readonly ConcurrentDictionary<Type, DxfMap> _cache = new ConcurrentDictionary<Type, DxfMap>();
+
 		public Dictionary<string, DxfClassMap> SubClasses { get; private set; } = new Dictionary<string, DxfClassMap>();
 
 		public static CadObject Build<T>()
@@ -39,54 +45,69 @@ namespace ACadSharp
 		//TODO: change to public? Using the type parameter does not constraing the use of the method
 		internal static DxfMap Create(Type type)
 		{
-			DxfMap map = new DxfMap();
-			bool isDimensionStyle = false;
+            if (!_cache.TryGetValue(type, out var map))
+            {
+                map = new DxfMap();
+                bool isDimensionStyle = false;
 
-			DxfNameAttribute dxf = type.GetCustomAttribute<DxfNameAttribute>();
+                DxfNameAttribute dxf = type.GetCustomAttribute<DxfNameAttribute>();
 
-			map.Name = dxf.Name;
+                map.Name = dxf.Name;
 
-			for (Type t = type; t != null; t = t.BaseType)
-			{
-				DxfSubClassAttribute subclass = t.GetCustomAttribute<DxfSubClassAttribute>();
+                for (Type t = type; t != null; t = t.BaseType)
+                {
+                    DxfSubClassAttribute subclass = t.GetCustomAttribute<DxfSubClassAttribute>();
 
-				if (t.Equals(typeof(DimensionStyle)))
-				{
-					isDimensionStyle = true;
-				}
+                    if (t.Equals(typeof(DimensionStyle)))
+                    {
+                        isDimensionStyle = true;
+                    }
 
-				if (t.Equals(typeof(CadObject)))
-				{
-					addClassProperties(map, t);
-					break;
-				}
-				else if (subclass != null && subclass.IsEmpty)
-				{
-					DxfClassMap classMap = map.SubClasses.Last().Value;
+                    if (t.Equals(typeof(CadObject)))
+                    {
+                        addClassProperties(map, t);
+                        break;
+                    }
+                    else if (subclass != null && subclass.IsEmpty)
+                    {
+                        DxfClassMap classMap = map.SubClasses.Last().Value;
 
-					addClassProperties(classMap, t);
-				}
-				else if (t.GetCustomAttribute<DxfSubClassAttribute>() != null)
-				{
-					DxfClassMap classMap = new DxfClassMap();
-					classMap.Name = t.GetCustomAttribute<DxfSubClassAttribute>().ClassName;
+                        addClassProperties(classMap, t);
+                    }
+                    else if (t.GetCustomAttribute<DxfSubClassAttribute>() != null)
+                    {
+                        DxfClassMap classMap = new DxfClassMap();
+                        classMap.Name = t.GetCustomAttribute<DxfSubClassAttribute>().ClassName;
 
-					addClassProperties(classMap, t);
+                        addClassProperties(classMap, t);
 
-					map.SubClasses.Add(classMap.Name, classMap);
-				}
-			}
+                        map.SubClasses.Add(classMap.Name, classMap);
+                    }
+                }
 
-			if (isDimensionStyle)
-			{
-				//TODO: Dimensions use the 105 instead of the 5... try to find a better fix
-				map.DxfProperties.Add(105, map.DxfProperties[5]);
-				map.DxfProperties.Remove(5);
-			}
+                if (isDimensionStyle)
+                {
+                    //TODO: Dimensions use the 105 instead of the 5... try to find a better fix
+                    map.DxfProperties.Add(105, map.DxfProperties[5]);
+                    map.DxfProperties.Remove(5);
+                }
 
-			map.SubClasses = new Dictionary<string, DxfClassMap>(map.SubClasses.Reverse().ToDictionary(o => o.Key, o => o.Value));
+                map.SubClasses =
+                    new Dictionary<string, DxfClassMap>(map.SubClasses.Reverse()
+                        .ToDictionary(o => o.Key, o => o.Value));
 
-			return map;
+                _cache.TryAdd(type, map);
+            }
+
+            return map;
 		}
+
+        /// <summary>
+        /// Clears the map cache.
+        /// </summary>
+        public void ClearCache()
+        {
+            _cache.Clear();
+        }
 	}
 }

--- a/ACadSharp/PropertyReflection.cs
+++ b/ACadSharp/PropertyReflection.cs
@@ -2,10 +2,10 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using LinqExpression = System.Linq.Expressions.Expression;
 
 
 namespace ACadSharp
@@ -41,17 +41,17 @@ namespace ACadSharp
                 var eventLogCustomType = property.DeclaringType;
                 var propertyType = property.PropertyType;
 
-                var instance = LinqExpression.Parameter(typeof(TClass));
+                var instance = Expression.Parameter(typeof(TClass));
 
                 Func<TClass, object> getter = null;
                 var getMethod = property.GetGetMethod(true);
                 if (getMethod != null)
                 {
                     getter =
-                        LinqExpression.Lambda<Func<TClass, object>>(
-                                LinqExpression.Convert(
-                                    LinqExpression.Call(
-                                        LinqExpression.Convert(instance, eventLogCustomType),
+                        Expression.Lambda<Func<TClass, object>>(
+                                Expression.Convert(
+                                    Expression.Call(
+                                        Expression.Convert(instance, eventLogCustomType),
                                         getMethod),
                                     typeof(object)),
                                 instance)
@@ -62,13 +62,13 @@ namespace ACadSharp
                 var setMethod = property.GetSetMethod(true);
                 if (setMethod != null)
                 {
-                    var parameter = LinqExpression.Parameter(typeof(object));
+                    var parameter = Expression.Parameter(typeof(object));
                     setter =
-                        LinqExpression.Lambda<Action<TClass, object>>(
-                                LinqExpression.Call(
-                                    LinqExpression.Convert(instance, eventLogCustomType),
+                        Expression.Lambda<Action<TClass, object>>(
+                                Expression.Call(
+                                    Expression.Convert(instance, eventLogCustomType),
                                     setMethod,
-                                    LinqExpression.Convert(parameter, propertyType)),
+                                    Expression.Convert(parameter, propertyType)),
                                 instance, parameter)
                             .Compile();
                 }

--- a/ACadSharp/PropertyReflection.cs
+++ b/ACadSharp/PropertyReflection.cs
@@ -10,68 +10,81 @@ using LinqExpression = System.Linq.Expressions.Expression;
 
 namespace ACadSharp
 {
-    internal static class PropertyExpression<TClass, TAttribute>
+    internal class PropertyExpression<TClass, TAttribute>
         where TClass : class
+        where TAttribute : Attribute
     {
         public class Prop
         {
-            public Func<TClass, object> Getter { get; set; }
-            public Action<TClass, object> Setter { get; set; }
+            public Func<TClass, object> Getter { get; internal set; }
+
+            public Action<TClass, object> Setter { get; internal set; }
+
+            public TAttribute Attribute { get; internal set; }
+
+            public PropertyInfo Property { get; internal set; }
         }
 
-        private static readonly Dictionary<string, Prop> Cache = new Dictionary<string, Prop>();
+        private static readonly ConcurrentDictionary<string, Prop> _cache = new ConcurrentDictionary<string, Prop>();
 
-        static PropertyExpression()
+        public IReadOnlyDictionary<string, Prop> Cache = _cache;
+
+        public PropertyExpression(Func<PropertyInfo, TAttribute, string> keySelector)
         {
             var properties = typeof(TClass).GetProperties();
-            foreach(var property in properties)
+            foreach (var property in properties)
             {
-                Type eventLogCustomType = property.DeclaringType;
-                Type propertyType = property.PropertyType;
+                var attribute = property.GetCustomAttribute<TAttribute>();
+                if (attribute == null)
+                    continue;
+
+                var eventLogCustomType = property.DeclaringType;
+                var propertyType = property.PropertyType;
 
                 var instance = LinqExpression.Parameter(typeof(TClass));
 
                 Func<TClass, object> getter = null;
-                var getMethod = property.GetGetMethod();
+                var getMethod = property.GetGetMethod(true);
                 if (getMethod != null)
                 {
                     getter =
-                    LinqExpression.Lambda<Func<TClass, object>>(
-                      LinqExpression.Convert(
-                        LinqExpression.Call(
-                          LinqExpression.Convert(instance, eventLogCustomType),
-                          getMethod),
-                        typeof(object)),
-                      instance)
-                    .Compile();
+                        LinqExpression.Lambda<Func<TClass, object>>(
+                                LinqExpression.Convert(
+                                    LinqExpression.Call(
+                                        LinqExpression.Convert(instance, eventLogCustomType),
+                                        getMethod),
+                                    typeof(object)),
+                                instance)
+                            .Compile();
                 }
 
                 Action<TClass, object> setter = null;
-                var setMethod = property.GetSetMethod();
+                var setMethod = property.GetSetMethod(true);
                 if (setMethod != null)
                 {
                     var parameter = LinqExpression.Parameter(typeof(object));
                     setter =
-                    LinqExpression.Lambda<Action<TClass, object>>(
-                      LinqExpression.Call(
-                        LinqExpression.Convert(instance, eventLogCustomType),
-                        setMethod,
-                        LinqExpression.Convert(parameter, propertyType)),
-                      instance, parameter)
-                    .Compile();
+                        LinqExpression.Lambda<Action<TClass, object>>(
+                                LinqExpression.Call(
+                                    LinqExpression.Convert(instance, eventLogCustomType),
+                                    setMethod,
+                                    LinqExpression.Convert(parameter, propertyType)),
+                                instance, parameter)
+                            .Compile();
                 }
-                Cache.Add(property.Name, new Prop
+
+                _cache.TryAdd(keySelector(property, attribute), new Prop
                 {
                     Getter = getter,
                     Setter = setter,
+                    Property = property
                 });
             }
-
         }
 
-        public static Prop GetProperty(string propName)
+        public Prop GetProperty(string propName)
         {
-            return Cache[propName];
+            return _cache[propName];
         }
     }
 }

--- a/ACadSharp/PropertyReflection.cs
+++ b/ACadSharp/PropertyReflection.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using LinqExpression = System.Linq.Expressions.Expression;
+
+
+namespace ACadSharp
+{
+    internal static class PropertyExpression<TClass, TAttribute>
+        where TClass : class
+    {
+        public class Prop
+        {
+            public Func<TClass, object> Getter { get; set; }
+            public Action<TClass, object> Setter { get; set; }
+        }
+
+        private static readonly Dictionary<string, Prop> Cache = new Dictionary<string, Prop>();
+
+        static PropertyExpression()
+        {
+            var properties = typeof(TClass).GetProperties();
+            foreach(var property in properties)
+            {
+                Type eventLogCustomType = property.DeclaringType;
+                Type propertyType = property.PropertyType;
+
+                var instance = LinqExpression.Parameter(typeof(TClass));
+
+                Func<TClass, object> getter = null;
+                var getMethod = property.GetGetMethod();
+                if (getMethod != null)
+                {
+                    getter =
+                    LinqExpression.Lambda<Func<TClass, object>>(
+                      LinqExpression.Convert(
+                        LinqExpression.Call(
+                          LinqExpression.Convert(instance, eventLogCustomType),
+                          getMethod),
+                        typeof(object)),
+                      instance)
+                    .Compile();
+                }
+
+                Action<TClass, object> setter = null;
+                var setMethod = property.GetSetMethod();
+                if (setMethod != null)
+                {
+                    var parameter = LinqExpression.Parameter(typeof(object));
+                    setter =
+                    LinqExpression.Lambda<Action<TClass, object>>(
+                      LinqExpression.Call(
+                        LinqExpression.Convert(instance, eventLogCustomType),
+                        setMethod,
+                        LinqExpression.Convert(parameter, propertyType)),
+                      instance, parameter)
+                    .Compile();
+                }
+                Cache.Add(property.Name, new Prop
+                {
+                    Getter = getter,
+                    Setter = setter,
+                });
+            }
+
+        }
+
+        public static Prop GetProperty(string propName)
+        {
+            return Cache[propName];
+        }
+    }
+}


### PR DESCRIPTION
Upon my first review, I have found that reflection and list access are the immediate worst offenders at this point.  I ran a read & write operation as indicated below and found the following with a CAD DXF drawing that has roughly 22,000 items (Blocks & simple entities).  I would attach the DXF, but it is a private project file.

For this first pass, I tired to leave the base code alone as much as possible as my initial work on refactoring the Map classes to use static instances became wide reaching very fast.

With the current changes, we get a performance increase of roughly 5x on the first read and then 6.5x faster on subsequent reads over the baseline. The write performance is also now 4.7x faster.

Ran into a small reading issue with `DxfSectionReaderBase.readMapped` method where it was trying to read a `DxfReferenceType.Handle` for a FontStyle but the file actually contains a string value.  I'll address that in a separate PR.

#### Changes
- Reflection used for setting properties has now been changed out for using Expressions for generating cached setters & getters for properties via the `PropertyExpression` class.
- CadObjectCollection<T>.Entities is now a `HashMap<T>` due to `Contains()` lookups during addition of entities.
- `DxfMap` and `DxfClassMap` now both cache their results of the `Create<T>()` method.  Caches are cleared via the `ClearCache()` method on both types.  Caching these items reduces the reflection on the first read/write significantly and all future reads and writes have all the maps already cached and are thus faster.

``` csharp
var sw = Stopwatch.StartNew();
Console.WriteLine("Startup Read & Write");

var document = DxfReader.Read("X-Base.dxf", (o, e) => { });
Console.WriteLine($"[{sw.ElapsedMilliseconds:0,000}ms] Completed Read");
sw.Restart();
DxfWriter.Write("X-Base-output.dxf", document, false);
Console.WriteLine($"[{sw.ElapsedMilliseconds:0,000}ms] Completed Write");

Console.WriteLine($"Completed startup Read & Write.");
Console.WriteLine();

sw.Restart();
for (int i = 0; i < 1; i++)
{
    sw.Restart();
    Console.WriteLine($"Started Subsequent Read & Write number {i + 1}");
    document = DxfReader.Read("X-Base.dxf", (o, e) => { });
    Console.WriteLine($"[{sw.ElapsedMilliseconds:0,000}ms] Completed Read");

    sw.Restart();
    DxfWriter.Write("X-Base-output.dxf", document, false);
    Console.WriteLine($"[{sw.ElapsedMilliseconds:0,000}ms] Completed Write");

    Console.WriteLine($"Completed Subsequent Read & Write number {i + 1}");
    Console.WriteLine();
}
```

## Baseline Performance
``` 
Startup Read & Write
[5,693ms] Completed Read
[2,264ms] Completed Write
Completed startup Read & Write.

Started Subsequent Read & Write number 1
[5,534ms] Completed Read
[2,278ms] Completed Write
Completed Subsequent Read & Write number 1
```
#### Dot Trace Performance
![image](https://user-images.githubusercontent.com/224169/181372623-587f2123-c691-43bc-ac91-0acb548eec0f.png)


## After PR Modifications
```
Startup Read & Write
[1,114ms] Completed Read
[0,486ms] Completed Write
Completed startup Read & Write.

Started Subsequent Read & Write number 1
[0,872ms] Completed Read
[0,495ms] Completed Write
Completed Subsequent Read & Write number 1
```
#### Dot Trace Performance
![image](https://user-images.githubusercontent.com/224169/181374418-83af4e20-a4b1-4f48-9eb8-4ddb68c1d3f1.png)



