### PR TITLE
DXF Angle Reading Conversion

### DIFF
--- a/ACadSharp/IO/DWG/DwgObjectSectionReader.cs
+++ b/ACadSharp/IO/DWG/DwgObjectSectionReader.cs
@@ -1588,7 +1588,7 @@ namespace ACadSharp.IO.DWG
 		private CadTemplate readArc()
 		{
 			Arc arc = new Arc();
-			CadEntityTemplate template = new CadEntityTemplate(arc);
+			CadEntityTemplate template = new CadArcTemplate(arc);
 
 			this.readCommonEntityData(template);
 

--- a/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
+++ b/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
@@ -130,7 +130,7 @@ namespace ACadSharp.IO.DXF
 					template = new CadTextEntityTemplate(new AttributeDefinition());
 					break;
 				case DxfFileToken.EntityArc:
-					template = new CadEntityTemplate(new Arc());
+					template = new CadArcTemplate(new Arc());
 					break;
 				case DxfFileToken.EntityCircle:
 					template = new CadEntityTemplate(new Circle());

--- a/ACadSharp/IO/Templates/CadArcTemplate.cs
+++ b/ACadSharp/IO/Templates/CadArcTemplate.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using ACadSharp.Entities;
+using ACadSharp.IO.DXF;
+using ACadSharp.Tables;
+
+namespace ACadSharp.IO.Templates
+{
+	internal class CadArcTemplate : CadEntityTemplate
+	{
+
+		public CadArcTemplate(Entity entity) : base(entity) { }
+
+
+        public override void Build(CadDocumentBuilder builder)
+		{
+			base.Build(builder);
+
+            if (builder is DxfDocumentBuilder && this.CadObject is Arc arc)
+            {
+                arc.StartAngle *= MathUtils.DegToRad;
+                arc.EndAngle *= MathUtils.DegToRad;
+            }
+		}
+	}
+}

--- a/ACadSharp/IO/Templates/CadInsertTemplate.cs
+++ b/ACadSharp/IO/Templates/CadInsertTemplate.cs
@@ -1,6 +1,7 @@
 ﻿using ACadSharp.Entities;
 using ACadSharp.Tables;
 using System.Collections.Generic;
+using ACadSharp.IO.DXF;
 
 namespace ACadSharp.IO.Templates
 {
@@ -47,7 +48,8 @@ namespace ACadSharp.IO.Templates
 		{
 			base.Build(builder);
 
-			Insert insert = this.CadObject as Insert;
+            if (!(this.CadObject is Insert insert))
+                return;
 
 			if (builder.TryGetCadObject(this.BlockHeaderHandle, out BlockRecord block))
 			{
@@ -72,6 +74,11 @@ namespace ACadSharp.IO.Templates
 			{
 				insert.Attributes.Seqend = seqend;
 			}
+
+            if (builder is DxfDocumentBuilder)
+            {
+                insert.Rotation *= MathUtils.DegToRad;
+            }
 		}
 	}
 }

--- a/ACadSharp/IO/Templates/CadTextEntityTemplate.cs
+++ b/ACadSharp/IO/Templates/CadTextEntityTemplate.cs
@@ -1,4 +1,6 @@
-﻿using ACadSharp.Entities;
+﻿using System;
+using ACadSharp.Entities;
+using ACadSharp.IO.DXF;
 using ACadSharp.Tables;
 
 namespace ACadSharp.IO.Templates
@@ -21,7 +23,7 @@ namespace ACadSharp.IO.Templates
 			}
 		}
 
-		public override void Build(CadDocumentBuilder builder)
+        public override void Build(CadDocumentBuilder builder)
 		{
 			base.Build(builder);
 
@@ -29,6 +31,12 @@ namespace ACadSharp.IO.Templates
 			{
 				case TextEntity text:
 					text.Style = builder.GetCadObject<TextStyle>(this.StyleHandle);
+
+                    // When the rotation is read in a DXF, the value is in decimal, but when the value
+                    // is read in a DWG, it is in radians.  Convert only on DXFs. Issue #80
+                    if (builder is DxfDocumentBuilder)
+                        text.Rotation *= MathUtils.DegToRad;
+
 					break;
 				case MText mtext:
 					mtext.Style = builder.GetCadObject<TextStyle>(this.StyleHandle);

--- a/ACadSharp/MathUtils.cs
+++ b/ACadSharp/MathUtils.cs
@@ -4,8 +4,18 @@ using System;
 namespace ACadSharp
 {
 	public static class MathUtils
-	{
-		public static XY GetCenter(XY start, XY end, double bulge)
+    {
+		/// <summary>
+		/// Factor for converting radians to degrees.
+		/// </summary>
+        public const double RadToDeg = (180 / Math.PI);
+
+		/// <summary>
+		/// Factor for converting degrees to radians.
+		/// </summary>
+        public const double DegToRad = (Math.PI / 180);
+
+        public static XY GetCenter(XY start, XY end, double bulge)
 		{
 			return GetCenter(start, end, bulge, out _);
 		}


### PR DESCRIPTION
It was discovered that angles read from `Arc`, `Insert` and `TextEntity` entities were in degrees while other DXF angles are in radians and all DWG angles are in radians.  This PR adds a new CadArcTemplate and modifies the  CadInsertTemplate and CadTextEntityTemplate to handle the conversion while reading DXF files.

I went ahead and added the new CadArcTemplate to DwgObjectSectionReader for consistency sake, even though it does not do anything at this time over the base CadEntityTemplate.