### PR TITLE
Extends AutoCAD Testing Versions

### DIFF
--- a/ACadSharp.Tests/IO/IOTestsBase.cs
+++ b/ACadSharp.Tests/IO/IOTestsBase.cs
@@ -6,150 +6,187 @@ using System.Linq;
 using System.Text;
 using Xunit;
 using Xunit.Abstractions;
+using static System.Environment;
 
 namespace ACadSharp.Tests.IO
 {
-	public abstract class IOTestsBase
-	{
-		protected const string _samplesFolder = "../../../../samples/";
+    public abstract class IOTestsBase
+    {
+        protected const string _samplesFolder = "../../../../samples/";
 
-		protected const string _samplesOutFolder = "../../../../samples/out";
+        protected const string _samplesOutFolder = "../../../../samples/out";
 
-		public static TheoryData<string> DwgFilePaths { get; }
+        public static TheoryData<string> DwgFilePaths { get; }
 
-		public static TheoryData<string> DxfAsciiFiles { get; }
+        public static TheoryData<string> DxfAsciiFiles { get; }
 
-		public static TheoryData<string> DxfBinaryFiles { get; }
+        public static TheoryData<string> DxfBinaryFiles { get; }
 
-		public static TheoryData<ACadVersion> Versions { get; }
+        public static TheoryData<ACadVersion> Versions { get; }
+        public static string AcCoreConsolePath { get; }
 
-		protected readonly ITestOutputHelper _output;
+        protected readonly ITestOutputHelper _output;
 
-		protected readonly DocumentIntegrity _docIntegrity;
+        protected readonly DocumentIntegrity _docIntegrity;
 
-		static IOTestsBase()
-		{
-			DwgFilePaths = new TheoryData<string>();
-			foreach (string file in Directory.GetFiles(_samplesFolder, $"*.dwg"))
-			{
-				DwgFilePaths.Add(file);
-			}
+        static IOTestsBase()
+        {
+            DwgFilePaths = new TheoryData<string>();
+            foreach (string file in Directory.GetFiles(_samplesFolder, $"*.dwg"))
+            {
+                DwgFilePaths.Add(file);
+            }
 
-			DxfAsciiFiles = new TheoryData<string>();
-			foreach (string file in Directory.GetFiles(_samplesFolder, "*_ascii.dxf"))
-			{
-				DxfAsciiFiles.Add(file);
-			}
+            DxfAsciiFiles = new TheoryData<string>();
+            foreach (string file in Directory.GetFiles(_samplesFolder, "*_ascii.dxf"))
+            {
+                DxfAsciiFiles.Add(file);
+            }
 
-			DxfBinaryFiles = new TheoryData<string>();
-			foreach (string file in Directory.GetFiles(_samplesFolder, "*_binary.dxf"))
-			{
-				DxfBinaryFiles.Add(file);
-			}
+            DxfBinaryFiles = new TheoryData<string>();
+            foreach (string file in Directory.GetFiles(_samplesFolder, "*_binary.dxf"))
+            {
+                DxfBinaryFiles.Add(file);
+            }
 
-			Versions = new TheoryData<ACadVersion>();
-			Versions.Add(ACadVersion.AC1021);
-			Versions.Add(ACadVersion.AC1024);
-			Versions.Add(ACadVersion.AC1027);
-			Versions.Add(ACadVersion.AC1032);
+            Versions = new TheoryData<ACadVersion>();
+            Versions.Add(ACadVersion.AC1021);
+            Versions.Add(ACadVersion.AC1024);
+            Versions.Add(ACadVersion.AC1027);
+            Versions.Add(ACadVersion.AC1032);
 
-			//Create folder, necessary in workflow
-			if (!Directory.Exists(_samplesOutFolder))
-			{
-				Directory.CreateDirectory(_samplesOutFolder);
-			}
-		}
+            //Create folder, necessary in workflow
+            if (!Directory.Exists(_samplesOutFolder))
+            {
+                Directory.CreateDirectory(_samplesOutFolder);
+            }
 
-		public IOTestsBase(ITestOutputHelper output)
-		{
-			this._output = output;
-			this._docIntegrity = new DocumentIntegrity(output);
-		}
+            if (Environment.GetEnvironmentVariable("GITHUB_WORKFLOW") == null)
+            {
+                var acCoreConsolePath = @"D:\Programs\Autodesk\AutoCAD 2023\accoreconsole.exe";
 
-		protected void onNotification(object sender, NotificationEventArgs e)
-		{
-			_output.WriteLine(e.Message);
-		}
+                if (!File.Exists(acCoreConsolePath))
+                {
+                    var programFiles = Environment.GetFolderPath(SpecialFolder.ProgramFiles);
+                    var autoCadPath = Path.Combine(programFiles, "Autodesk");
+                    
+                    var baseAutoCadPaths = new string[]
+                    {
+                        "AutoCAD 2023",
+                        "AutoCAD LT 2023",
+                        "AutoCAD 2022",
+                        "AutoCAD LT 2022",
+                        "AutoCAD 2021",
+                        "AutoCAD LT 2021",
+                    };
 
-		protected void checkDocumentInAutocad(string path)
-		{
-			if (Environment.GetEnvironmentVariable("GITHUB_WORKFLOW") != null)
-				return;
+                    for (var i = 0; i < baseAutoCadPaths.Length; i++)
+                    {
+                        var consolePath = Path.Combine(autoCadPath, baseAutoCadPaths[i], "accoreconsole.exe");
+                        if (File.Exists(consolePath))
+                        {
+                            AcCoreConsolePath = consolePath;
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    AcCoreConsolePath = acCoreConsolePath;
+                }
+            }
+        }
 
-			System.Diagnostics.Process process = new System.Diagnostics.Process();
+        public IOTestsBase(ITestOutputHelper output)
+        {
+            this._output = output;
+            this._docIntegrity = new DocumentIntegrity(output);
+        }
 
-			try
-			{
-				process.StartInfo.WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden;
-				process.StartInfo.FileName = "\"D:\\Programs\\Autodesk\\AutoCAD 2023\\accoreconsole.exe\"";
-				process.StartInfo.Arguments = $"/i \"{Path.Combine(_samplesFolder, "sample_base/empty.dwg")}\" /l en - US";
-				process.StartInfo.UseShellExecute = false;
-				process.StartInfo.RedirectStandardOutput = true;
-				process.StartInfo.RedirectStandardInput = true;
-				process.StartInfo.StandardOutputEncoding = Encoding.ASCII;
+        protected void onNotification(object sender, NotificationEventArgs e)
+        {
+            _output.WriteLine(e.Message);
+        }
 
-				Assert.True(process.Start());
+        protected void checkDocumentInAutocad(string path)
+        {
+            if (Environment.GetEnvironmentVariable("GITHUB_WORKFLOW") != null)
+                return;
 
-				process.StandardInput.WriteLine($"_DXFIN");
-				process.StandardInput.WriteLine($"{path}");
+            System.Diagnostics.Process process = new System.Diagnostics.Process();
 
-				string l = process.StandardOutput.ReadLine();
-				bool testPassed = true;
-				while (!process.StandardOutput.EndOfStream)
-				{
-					string li = l.Replace("\0", "");
-					if (!string.IsNullOrEmpty(li))
-					{
-						if (li.Contains("Invalid or incomplete DXF input -- drawing discarded.")
-							|| li.Contains("error", StringComparison.OrdinalIgnoreCase))
-						{
-							testPassed = false;
-						}
+            try
+            {
+                process.StartInfo.WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden;
+                process.StartInfo.FileName = AcCoreConsolePath;
+                process.StartInfo.Arguments = $"/i \"{Path.Combine(_samplesFolder, "sample_base/empty.dwg")}\" /l en - US";
+                process.StartInfo.UseShellExecute = false;
+                process.StartInfo.RedirectStandardOutput = true;
+                process.StartInfo.RedirectStandardInput = true;
+                process.StartInfo.StandardOutputEncoding = Encoding.ASCII;
 
-						_output.WriteLine(li);
-					}
+                Assert.True(process.Start());
 
-					var t = process.StandardOutput.ReadLineAsync();
+                process.StandardInput.WriteLine($"_DXFIN");
+                process.StandardInput.WriteLine($"{path}");
 
-					//The last line gets into an infinite loop
-					if (t.Wait(1000))
-					{
-						l = t.Result;
-					}
-					else
-					{
-						break;
-					}
-				}
+                string l = process.StandardOutput.ReadLine();
+                bool testPassed = true;
+                while (!process.StandardOutput.EndOfStream)
+                {
+                    string li = l.Replace("\0", "");
+                    if (!string.IsNullOrEmpty(li))
+                    {
+                        if (li.Contains("Invalid or incomplete DXF input -- drawing discarded.")
+                            || li.Contains("error", StringComparison.OrdinalIgnoreCase))
+                        {
+                            testPassed = false;
+                        }
 
-				if (!testPassed)
-					throw new Exception("File loading with accoreconsole failed");
-			}
-			finally
-			{
-				process.Kill();
-			}
-		}
+                        _output.WriteLine(li);
+                    }
 
-		protected static void loadSamples(string folder, string ext, TheoryData<string> files)
-		{
-			string path = Path.Combine(_samplesFolder, "local", folder);
+                    var t = process.StandardOutput.ReadLineAsync();
 
-			if (!Directory.Exists(path))
-			{
-				files.Add(string.Empty);
-				return;
-			}
+                    //The last line gets into an infinite loop
+                    if (t.Wait(1000))
+                    {
+                        l = t.Result;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
 
-			foreach (string file in Directory.GetFiles(path, $"*.{ext}"))
-			{
-				files.Add(file);
-			}
+                if (!testPassed)
+                    throw new Exception("File loading with accoreconsole failed");
+            }
+            finally
+            {
+                process.Kill();
+            }
+        }
 
-			if (!files.Any())
-			{
-				files.Add(string.Empty);
-			}
-		}
-	}
+        protected static void loadSamples(string folder, string ext, TheoryData<string> files)
+        {
+            string path = Path.Combine(_samplesFolder, "local", folder);
+
+            if (!Directory.Exists(path))
+            {
+                files.Add(string.Empty);
+                return;
+            }
+
+            foreach (string file in Directory.GetFiles(path, $"*.{ext}"))
+            {
+                files.Add(file);
+            }
+
+            if (!files.Any())
+            {
+                files.Add(string.Empty);
+            }
+        }
+    }
 }

--- a/ACadSharp.Tests/IO/IOTestsBase.cs
+++ b/ACadSharp.Tests/IO/IOTestsBase.cs
@@ -10,183 +10,183 @@ using static System.Environment;
 
 namespace ACadSharp.Tests.IO
 {
-    public abstract class IOTestsBase
-    {
-        protected const string _samplesFolder = "../../../../samples/";
+	public abstract class IOTestsBase
+	{
+		protected const string _samplesFolder = "../../../../samples/";
 
-        protected const string _samplesOutFolder = "../../../../samples/out";
+		protected const string _samplesOutFolder = "../../../../samples/out";
 
-        public static TheoryData<string> DwgFilePaths { get; }
+		public static TheoryData<string> DwgFilePaths { get; }
 
-        public static TheoryData<string> DxfAsciiFiles { get; }
+		public static TheoryData<string> DxfAsciiFiles { get; }
 
-        public static TheoryData<string> DxfBinaryFiles { get; }
+		public static TheoryData<string> DxfBinaryFiles { get; }
 
-        public static TheoryData<ACadVersion> Versions { get; }
-        public static string AcCoreConsolePath { get; }
+		public static TheoryData<ACadVersion> Versions { get; }
+		public static string AcCoreConsolePath { get; }
 
-        protected readonly ITestOutputHelper _output;
+		protected readonly ITestOutputHelper _output;
 
-        protected readonly DocumentIntegrity _docIntegrity;
+		protected readonly DocumentIntegrity _docIntegrity;
 
-        static IOTestsBase()
-        {
-            DwgFilePaths = new TheoryData<string>();
-            foreach (string file in Directory.GetFiles(_samplesFolder, $"*.dwg"))
-            {
-                DwgFilePaths.Add(file);
-            }
+		static IOTestsBase()
+		{
+			DwgFilePaths = new TheoryData<string>();
+			foreach (string file in Directory.GetFiles(_samplesFolder, $"*.dwg"))
+			{
+				DwgFilePaths.Add(file);
+			}
 
-            DxfAsciiFiles = new TheoryData<string>();
-            foreach (string file in Directory.GetFiles(_samplesFolder, "*_ascii.dxf"))
-            {
-                DxfAsciiFiles.Add(file);
-            }
+			DxfAsciiFiles = new TheoryData<string>();
+			foreach (string file in Directory.GetFiles(_samplesFolder, "*_ascii.dxf"))
+			{
+				DxfAsciiFiles.Add(file);
+			}
 
-            DxfBinaryFiles = new TheoryData<string>();
-            foreach (string file in Directory.GetFiles(_samplesFolder, "*_binary.dxf"))
-            {
-                DxfBinaryFiles.Add(file);
-            }
+			DxfBinaryFiles = new TheoryData<string>();
+			foreach (string file in Directory.GetFiles(_samplesFolder, "*_binary.dxf"))
+			{
+				DxfBinaryFiles.Add(file);
+			}
 
-            Versions = new TheoryData<ACadVersion>();
-            Versions.Add(ACadVersion.AC1021);
-            Versions.Add(ACadVersion.AC1024);
-            Versions.Add(ACadVersion.AC1027);
-            Versions.Add(ACadVersion.AC1032);
+			Versions = new TheoryData<ACadVersion>();
+			Versions.Add(ACadVersion.AC1021);
+			Versions.Add(ACadVersion.AC1024);
+			Versions.Add(ACadVersion.AC1027);
+			Versions.Add(ACadVersion.AC1032);
 
-            //Create folder, necessary in workflow
-            if (!Directory.Exists(_samplesOutFolder))
-            {
-                Directory.CreateDirectory(_samplesOutFolder);
-            }
+			//Create folder, necessary in workflow
+			if (!Directory.Exists(_samplesOutFolder))
+			{
+				Directory.CreateDirectory(_samplesOutFolder);
+			}
 
-            if (Environment.GetEnvironmentVariable("GITHUB_WORKFLOW") == null)
-            {
-                var acCoreConsolePath = @"D:\Programs\Autodesk\AutoCAD 2023\accoreconsole.exe";
+			if (Environment.GetEnvironmentVariable("GITHUB_WORKFLOW") == null)
+			{
+				var acCoreConsolePath = @"D:\Programs\Autodesk\AutoCAD 2023\accoreconsole.exe";
 
-                if (!File.Exists(acCoreConsolePath))
-                {
-                    var programFiles = Environment.GetFolderPath(SpecialFolder.ProgramFiles);
-                    var autoCadPath = Path.Combine(programFiles, "Autodesk");
-                    
-                    var baseAutoCadPaths = new string[]
-                    {
-                        "AutoCAD 2023",
-                        "AutoCAD LT 2023",
-                        "AutoCAD 2022",
-                        "AutoCAD LT 2022",
-                        "AutoCAD 2021",
-                        "AutoCAD LT 2021",
-                    };
+				if (!File.Exists(acCoreConsolePath))
+				{
+					var programFiles = Environment.GetFolderPath(SpecialFolder.ProgramFiles);
+					var autoCadPath = Path.Combine(programFiles, "Autodesk");
+					
+					var baseAutoCadPaths = new string[]
+					{
+						"AutoCAD 2023",
+						"AutoCAD LT 2023",
+						"AutoCAD 2022",
+						"AutoCAD LT 2022",
+						"AutoCAD 2021",
+						"AutoCAD LT 2021",
+					};
 
-                    for (var i = 0; i < baseAutoCadPaths.Length; i++)
-                    {
-                        var consolePath = Path.Combine(autoCadPath, baseAutoCadPaths[i], "accoreconsole.exe");
-                        if (File.Exists(consolePath))
-                        {
-                            AcCoreConsolePath = consolePath;
-                            break;
-                        }
-                    }
-                }
-                else
-                {
-                    AcCoreConsolePath = acCoreConsolePath;
-                }
-            }
-        }
+					for (var i = 0; i < baseAutoCadPaths.Length; i++)
+					{
+						var consolePath = Path.Combine(autoCadPath, baseAutoCadPaths[i], "accoreconsole.exe");
+						if (File.Exists(consolePath))
+						{
+							AcCoreConsolePath = consolePath;
+							break;
+						}
+					}
+				}
+				else
+				{
+					AcCoreConsolePath = acCoreConsolePath;
+				}
+			}
+		}
 
-        public IOTestsBase(ITestOutputHelper output)
-        {
-            this._output = output;
-            this._docIntegrity = new DocumentIntegrity(output);
-        }
+		public IOTestsBase(ITestOutputHelper output)
+		{
+			this._output = output;
+			this._docIntegrity = new DocumentIntegrity(output);
+		}
 
-        protected void onNotification(object sender, NotificationEventArgs e)
-        {
-            _output.WriteLine(e.Message);
-        }
+		protected void onNotification(object sender, NotificationEventArgs e)
+		{
+			_output.WriteLine(e.Message);
+		}
 
-        protected void checkDocumentInAutocad(string path)
-        {
-            if (Environment.GetEnvironmentVariable("GITHUB_WORKFLOW") != null)
-                return;
+		protected void checkDocumentInAutocad(string path)
+		{
+			if (Environment.GetEnvironmentVariable("GITHUB_WORKFLOW") != null)
+				return;
 
-            System.Diagnostics.Process process = new System.Diagnostics.Process();
+			System.Diagnostics.Process process = new System.Diagnostics.Process();
 
-            try
-            {
-                process.StartInfo.WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden;
-                process.StartInfo.FileName = AcCoreConsolePath;
-                process.StartInfo.Arguments = $"/i \"{Path.Combine(_samplesFolder, "sample_base/empty.dwg")}\" /l en - US";
-                process.StartInfo.UseShellExecute = false;
-                process.StartInfo.RedirectStandardOutput = true;
-                process.StartInfo.RedirectStandardInput = true;
-                process.StartInfo.StandardOutputEncoding = Encoding.ASCII;
+			try
+			{
+				process.StartInfo.WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden;
+				process.StartInfo.FileName = AcCoreConsolePath;
+				process.StartInfo.Arguments = $"/i \"{Path.Combine(_samplesFolder, "sample_base/empty.dwg")}\" /l en - US";
+				process.StartInfo.UseShellExecute = false;
+				process.StartInfo.RedirectStandardOutput = true;
+				process.StartInfo.RedirectStandardInput = true;
+				process.StartInfo.StandardOutputEncoding = Encoding.ASCII;
 
-                Assert.True(process.Start());
+				Assert.True(process.Start());
 
-                process.StandardInput.WriteLine($"_DXFIN");
-                process.StandardInput.WriteLine($"{path}");
+				process.StandardInput.WriteLine($"_DXFIN");
+				process.StandardInput.WriteLine($"{path}");
 
-                string l = process.StandardOutput.ReadLine();
-                bool testPassed = true;
-                while (!process.StandardOutput.EndOfStream)
-                {
-                    string li = l.Replace("\0", "");
-                    if (!string.IsNullOrEmpty(li))
-                    {
-                        if (li.Contains("Invalid or incomplete DXF input -- drawing discarded.")
-                            || li.Contains("error", StringComparison.OrdinalIgnoreCase))
-                        {
-                            testPassed = false;
-                        }
+				string l = process.StandardOutput.ReadLine();
+				bool testPassed = true;
+				while (!process.StandardOutput.EndOfStream)
+				{
+					string li = l.Replace("\0", "");
+					if (!string.IsNullOrEmpty(li))
+					{
+						if (li.Contains("Invalid or incomplete DXF input -- drawing discarded.")
+							|| li.Contains("error", StringComparison.OrdinalIgnoreCase))
+						{
+							testPassed = false;
+						}
 
-                        _output.WriteLine(li);
-                    }
+						_output.WriteLine(li);
+					}
 
-                    var t = process.StandardOutput.ReadLineAsync();
+					var t = process.StandardOutput.ReadLineAsync();
 
-                    //The last line gets into an infinite loop
-                    if (t.Wait(1000))
-                    {
-                        l = t.Result;
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
+					//The last line gets into an infinite loop
+					if (t.Wait(1000))
+					{
+						l = t.Result;
+					}
+					else
+					{
+						break;
+					}
+				}
 
-                if (!testPassed)
-                    throw new Exception("File loading with accoreconsole failed");
-            }
-            finally
-            {
-                process.Kill();
-            }
-        }
+				if (!testPassed)
+					throw new Exception("File loading with accoreconsole failed");
+			}
+			finally
+			{
+				process.Kill();
+			}
+		}
 
-        protected static void loadSamples(string folder, string ext, TheoryData<string> files)
-        {
-            string path = Path.Combine(_samplesFolder, "local", folder);
+		protected static void loadSamples(string folder, string ext, TheoryData<string> files)
+		{
+			string path = Path.Combine(_samplesFolder, "local", folder);
 
-            if (!Directory.Exists(path))
-            {
-                files.Add(string.Empty);
-                return;
-            }
+			if (!Directory.Exists(path))
+			{
+				files.Add(string.Empty);
+				return;
+			}
 
-            foreach (string file in Directory.GetFiles(path, $"*.{ext}"))
-            {
-                files.Add(file);
-            }
+			foreach (string file in Directory.GetFiles(path, $"*.{ext}"))
+			{
+				files.Add(file);
+			}
 
-            if (!files.Any())
-            {
-                files.Add(string.Empty);
-            }
-        }
-    }
+			if (!files.Any())
+			{
+				files.Add(string.Empty);
+			}
+		}
+	}
 }


### PR DESCRIPTION
This PR adds a lookup for AutoCAD installations if it does not exist in the default location.  Allows testing on version of AutoCAD from 2023 to 2021 LT and full.