### PR TITLE
Revert Text/MText Linking of Rotation and AlignmentPoint

### DIFF
--- a/ACadSharp.Tests/Entities/MTextTests.cs
+++ b/ACadSharp.Tests/Entities/MTextTests.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using ACadSharp.Entities;
+using CSMath;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace ACadSharp.Tests.Entities
+{
+    public class MTextTests
+    {
+
+        [Fact]
+        public void RotationDoesNotOverrideAlignmentPoint()
+        {
+            var text = new MText
+            {
+                Rotation = Math.PI
+            };
+
+            Assert.Equal(text.AlignmentPoint, XYZ.Zero);
+        }
+    }
+}

--- a/ACadSharp.Tests/Entities/TextEntityTests.cs
+++ b/ACadSharp.Tests/Entities/TextEntityTests.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using ACadSharp.Entities;
+using CSMath;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace ACadSharp.Tests.Entities
+{
+    public class TextEntityTests
+    {
+
+        [Fact]
+        public void RotationDoesNotOverrideAlignmentPoint()
+        {
+            var text = new TextEntity
+            {
+                Rotation = Math.PI
+            };
+            Assert.Equal(text.AlignmentPoint, XYZ.Zero);
+        }
+    }
+}

--- a/ACadSharp/Entities/MText.cs
+++ b/ACadSharp/Entities/MText.cs
@@ -110,7 +110,7 @@ namespace ACadSharp.Entities
 			set
 			{
 				_alignmentPoint = value;
-				this._rotation = new XY(this._alignmentPoint.X, this._alignmentPoint.Y).GetAngle();
+				//this._rotation = new XY(this._alignmentPoint.X, this._alignmentPoint.Y).GetAngle();
 			}
 		}
 
@@ -147,7 +147,7 @@ namespace ACadSharp.Entities
 			set
 			{
 				_rotation = value;
-				this.AlignmentPoint = new XYZ(Math.Cos(_rotation), Math.Sin(_rotation), 0.0);
+				//this._alignmentPoint = new XYZ(Math.Cos(_rotation), Math.Sin(_rotation), 0.0);
 			}
 		}
 

--- a/ACadSharp/Entities/TextEntity.cs
+++ b/ACadSharp/Entities/TextEntity.cs
@@ -87,7 +87,7 @@ namespace ACadSharp.Entities
 			set
 			{
 				_rotation = value;
-				this.AlignmentPoint = new XYZ(Math.Cos(_rotation), Math.Sin(_rotation), 0.0);
+                //this._alignmentPoint = new XYZ(Math.Cos(_rotation), Math.Sin(_rotation), 0.0);
 			}
 		}
 
@@ -140,7 +140,7 @@ namespace ACadSharp.Entities
 			set
 			{
 				_alignmentPoint = value;
-				this._rotation = new XY(this._alignmentPoint.X, this._alignmentPoint.Y).GetAngle();
+				//this._rotation = new XY(this._alignmentPoint.X, this._alignmentPoint.Y).GetAngle();
 			}
 		}
 


### PR DESCRIPTION
While testing these changes in production, it was found that since the MText.Rotation set the AlignmentPoint and vice versa, the former would break the correct alignment points which are required for correct text placement.

We need to review how to handle this properly.  Right now, I think the best course of action would be to unlink the two and allow for the library consumer to determine how to properly handle the values.  I am not even sure that it is actually possible to convert from a `Rotation` radian to a 3D `AlignmentPoint`.