### PR TITLE
handleMap not initialized exception

### DIFF
--- a/ACadSharp/IO/DWG/DwgStreamWriters/DwgHandleWriter.cs
+++ b/ACadSharp/IO/DWG/DwgStreamWriters/DwgHandleWriter.cs
@@ -23,6 +23,8 @@ namespace ACadSharp.IO.DWG
 			this._stream = stream;
 
 #if NET48_OR_GREATER
+			this._handleMap = new Dictionary<ulong, long>();
+
 			foreach (var item in map.OrderBy(o => o.Key))
 			{
 				this._handleMap.Add(item.Key, item.Value);


### PR DESCRIPTION
# Description

When using the DwgWriter, a not initialized exception occures in net48 version.

# Tasks done in this PR
* [x] An evil bug have been defeted.

# Notes for reviewer
Null exception when using Net48