### PR TITLE
issue 163 Alternative ModelSpace naming 

### DIFF
--- a/ACadSharp/IO/DXF/DxfStreamReader/DxfBlockSectionReader.cs
+++ b/ACadSharp/IO/DXF/DxfStreamReader/DxfBlockSectionReader.cs
@@ -66,6 +66,7 @@ namespace ACadSharp.IO.DXF
 				{
 					case 2:
 					case 3:
+						// TODO: check for alternative names "$MODEL_SPACE" or the add them to the default *ModelSpace
 						name = this._reader.ValueAsString;
 						if (record == null && this._builder.TryGetTableEntry(name, out record))
 						{


### PR DESCRIPTION
# Description

The `DxfReader` has to identify the different ModelSpace naming conventions.