### PR TITLE
Text rotation fix

### DIFF
--- a/ACadSharp/Entities/TextEntity.cs
+++ b/ACadSharp/Entities/TextEntity.cs
@@ -166,10 +166,6 @@ namespace ACadSharp.Entities
 
 		private double _height = 0.0;
 
-		private XYZ _alignmentPoint = XYZ.Zero;
-
-		private double _rotation = 0.0;
-
 		private TextStyle _style = TextStyle.Default;
 
 		public TextEntity() : base() { }

--- a/ACadSharp/Entities/TextEntity.cs
+++ b/ACadSharp/Entities/TextEntity.cs
@@ -84,15 +84,7 @@ namespace ACadSharp.Entities
 		/// The rotation angle in radians.
 		/// </value>
 		[DxfCodeValue(DxfReferenceType.IsAngle, 50)]
-		public double Rotation
-		{
-			get => _rotation;
-			set
-			{
-				_rotation = value;
-				this.AlignmentPoint = new XYZ(Math.Cos(_rotation), Math.Sin(_rotation), 0.0);
-			}
-		}
+		public double Rotation { get; set; }
 
 		/// <summary>
 		/// Relative X scale factor—widt
@@ -156,15 +148,7 @@ namespace ACadSharp.Entities
 		/// This value is meaningful only if the value of a 72 or 73 group is nonzero (if the justification is anything other than baseline/left)
 		/// </remarks>
 		[DxfCodeValue(DxfReferenceType.Optional, 11, 21, 31)]
-		public XYZ AlignmentPoint
-		{
-			get => _alignmentPoint;
-			set
-			{
-				_alignmentPoint = value;
-				this._rotation = new XY(this._alignmentPoint.X, this._alignmentPoint.Y).GetAngle();
-			}
-		}
+		public XYZ AlignmentPoint { get; set; }
 
 		/// <summary>
 		/// Specifies the three-dimensional normal unit vector for the object.


### PR DESCRIPTION
# Description

Removed internal linking of the `TextEntity.Rotation` and `TextEntity.AlignmentPoint` properties.

Fixes issues with rotation adjusting AlignmentPoint and AlignmentPoint adjusting the rotations.  After a bit of research, the AutoCad AlignmentPoint is the location where the text is to be inserted in conjunction with the VerticalAlignment and HorizontalAlignment.  Based upon certain configurations of the enumns, either the InsertPoint or the AlignmentPoint is used to determine where the text is to be inserted.  As far as I can tell, it does not have anything to do with the Rotation, at least as far as 2D goes.  I do not have time to experiment with 3d rotations. Ref #86.

For reference, the `InsertionPoint`s below are the bottom left grips while the `AlignmentPoint`s are the other grips on the text.
![image](https://github.com/DomCR/ACadSharp/assets/224169/ce905038-8b59-4a12-bd8f-413b4325e16f)

# Related Issues / Pull Requests
#81 
#82