### PR TITLE
#215 Dimension: FlipArrow1 (group code 74) and FlipArrow2 (group code 75) not read

### DIFF
--- a/ACadSharp/Entities/Dimension.cs
+++ b/ACadSharp/Entities/Dimension.cs
@@ -107,17 +107,31 @@ namespace ACadSharp.Entities
 
 
 		/// <summary>
-		/// Gets or sets a value indicating whether the arrow at first point is
-		/// to be flipped.
+		/// Gets or sets a value indicating whether the first arrow
+		/// is to be flipped.
 		/// </summary>
+		/// <value>
+		/// <b>true</b> if the arrow is to be flipped; otherwise, <b>false</b>.
+		/// </value>
+		/// <remarks>
+		/// Arrows are by default drawn inside the extension lines if there is enaugh
+		/// space; otherwise, outside. This flag overrules the standard behaviour.
+		/// </remarks>
 		[DxfCodeValue(74)]
 		public bool FlipArrow1 { get; set; }
 
 
 		/// <summary>
-		/// Gets or sets a value indicating whether the arrow at second point is
+		/// Gets or sets a value indicating whether the second arrow
 		/// to be flipped.
 		/// </summary>
+		/// <value>
+		/// <b>true</b> if the arrow is to be flipped; otherwise, <b>false</b>.
+		/// </value>
+		/// <remarks>
+		/// Arrows are by default drawn inside the extension lines if there is enaugh
+		/// space; otherwise, outside. This flag overrules the standard behaviour.
+		/// </remarks>
 		[DxfCodeValue(75)]
 		public bool FlipArrow2 { get; set; }
 

--- a/ACadSharp/Entities/Dimension.cs
+++ b/ACadSharp/Entities/Dimension.cs
@@ -105,6 +105,23 @@ namespace ACadSharp.Entities
 		[DxfCodeValue(42)]
 		public double Measurement { get; internal set; }
 
+
+		/// <summary>
+		/// Gets or sets a value indicating whether the arrow at first point is
+		/// to be flipped.
+		/// </summary>
+		[DxfCodeValue(74)]
+		public bool FlipArrow1 { get; set; }
+
+
+		/// <summary>
+		/// Gets or sets a value indicating whether the arrow at second point is
+		/// to be flipped.
+		/// </summary>
+		[DxfCodeValue(75)]
+		public bool FlipArrow2 { get; set; }
+
+
 		/// <summary>
 		/// Dimension text explicitly entered by the user
 		/// </summary>

--- a/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -1931,9 +1931,9 @@ namespace ACadSharp.IO.DWG
 				//Unknown B 73
 				this._objectReader.ReadBit();
 				//Flip arrow1 B 74
-				this._objectReader.ReadBit();
+				dimension.FlipArrow1 = this._objectReader.ReadBit();
 				//Flip arrow2 B 75
-				this._objectReader.ReadBit();
+				dimension.FlipArrow2 = this._objectReader.ReadBit();
 			}
 
 			//Common:


### PR DESCRIPTION
- New properties `FlipArrow1`, `FlipArrow2` in class `Dimension`.
- `readCommonDimensionData`: read `FlipArrow1`, `FlipArrow2`.