### PR TITLE
#226

### DIFF
--- a/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -3263,7 +3263,7 @@ namespace ACadSharp.IO.DWG
 				mLeaderStyle.TextAngle = (TextAngleType)_objectReader.ReadBitShort();
 
 			}   //	END IF IsNewFormat OR DXF file
-				//	BS	176	Text alignment type
+			//	BS	176	Text alignment type
 			mLeaderStyle.TextAlignment = (TextAlignmentType)_objectReader.ReadBitShort();
 			//	CMC	93	Text color
 			mLeaderStyle.TextColor = _mergedReaders.ReadCmColor();
@@ -3276,7 +3276,7 @@ namespace ACadSharp.IO.DWG
 			 //	B	297	Always align text left
 				mLeaderStyle.TextAlignAlwaysLeft = _objectReader.ReadBit();
 			}//	END IF IsNewFormat OR DXF file
-			 //	BD	46	Align space
+			//	BD	46	Align space
 			mLeaderStyle.AlignSpace = _objectReader.ReadBitDouble();
 			//	H	343	Block handle (hard pointer)
 			template.BlockContentHandle = this.handleReference();

--- a/ACadSharp/IO/Templates/CadDimensionStyleTemplate.cs
+++ b/ACadSharp/IO/Templates/CadDimensionStyleTemplate.cs
@@ -32,17 +32,17 @@ namespace ACadSharp.IO.Templates
 				this.CadObject.Style = style;
 			}
 
-			if (builder.TryGetCadObject(this.DIMLDRBLK, out Block leaderArrow))
+			if (builder.TryGetCadObject(this.DIMLDRBLK, out BlockRecord leaderArrow))
 			{
 				this.CadObject.LeaderArrow = leaderArrow;
 			}
 
-			if (builder.TryGetCadObject(this.DIMBLK1, out Block dimArrow1))
+			if (builder.TryGetCadObject(this.DIMBLK1, out BlockRecord dimArrow1))
 			{
 				this.CadObject.DimArrow1 = dimArrow1;
 			}
 
-			if (builder.TryGetCadObject(this.DIMBLK2, out Block dimArrow2))
+			if (builder.TryGetCadObject(this.DIMBLK2, out BlockRecord dimArrow2))
 			{
 				this.CadObject.DimArrow2 = dimArrow2;
 			}

--- a/ACadSharp/IO/Templates/CadDimensionStyleTemplate.cs
+++ b/ACadSharp/IO/Templates/CadDimensionStyleTemplate.cs
@@ -1,10 +1,10 @@
-﻿using ACadSharp.Blocks;
-using ACadSharp.Tables;
+﻿using ACadSharp.Tables;
 
 namespace ACadSharp.IO.Templates
 {
 	internal class CadDimensionStyleTemplate : CadTableEntryTemplate<DimensionStyle>
 	{
+		public string TextStyle_Name { get; internal set; }
 		public string DIMBL_Name { get; internal set; }
 		public string DIMBLK1_Name { get; internal set; }
 		public string DIMBLK2_Name { get; internal set; }
@@ -27,39 +27,24 @@ namespace ACadSharp.IO.Templates
 
 			//TODO: implement the dimension template for the names instead of handles
 
-			if (builder.TryGetCadObject(this.TextStyleHandle, out TextStyle style))
+			if (this.getTableReference(builder, this.TextStyleHandle, TextStyle_Name, out TextStyle style))
 			{
 				this.CadObject.Style = style;
 			}
 
-			if (builder.TryGetCadObject(this.DIMLDRBLK, out BlockRecord leaderArrow))
+			if (this.getTableReference(builder, this.DIMLDRBLK, this.DIMBL_Name, out BlockRecord leaderArrow))
 			{
 				this.CadObject.LeaderArrow = leaderArrow;
 			}
 
-			if (builder.TryGetCadObject(this.DIMBLK1, out BlockRecord dimArrow1))
+			if (this.getTableReference(builder, this.DIMBLK1, this.DIMBLK1_Name, out BlockRecord dimArrow1))
 			{
 				this.CadObject.DimArrow1 = dimArrow1;
 			}
 
-			if (builder.TryGetCadObject(this.DIMBLK2, out BlockRecord dimArrow2))
+			if (this.getTableReference(builder, this.DIMBLK2, this.DIMBLK2_Name, out BlockRecord dimArrow2))
 			{
 				this.CadObject.DimArrow2 = dimArrow2;
-			}
-
-			if (!string.IsNullOrWhiteSpace(DIMBL_Name))
-			{
-				builder.Notify($"DwgDimensionStyleTemplate does not implement the dimension block for : {DIMBL_Name}");
-			}
-
-			if (!string.IsNullOrWhiteSpace(DIMBLK1_Name))
-			{
-				builder.Notify($"DwgDimensionStyleTemplate does not implement the dimension block for : {DIMBLK1_Name}");
-			}
-
-			if (!string.IsNullOrWhiteSpace(DIMBLK2_Name))
-			{
-				builder.Notify($"DwgDimensionStyleTemplate does not implement the dimension block for : {DIMBLK2_Name}");
 			}
 		}
 	}

--- a/ACadSharp/IO/Templates/CadDimensionStyleTemplate.cs
+++ b/ACadSharp/IO/Templates/CadDimensionStyleTemplate.cs
@@ -25,8 +25,6 @@ namespace ACadSharp.IO.Templates
 		{
 			base.Build(builder);
 
-			//TODO: implement the dimension template for the names instead of handles
-
 			if (this.getTableReference(builder, this.TextStyleHandle, TextStyle_Name, out TextStyle style))
 			{
 				this.CadObject.Style = style;

--- a/ACadSharp/Tables/DimensionStyle.cs
+++ b/ACadSharp/Tables/DimensionStyle.cs
@@ -37,7 +37,7 @@ namespace ACadSharp.Tables
 		/// (see DIMPOST System Variable).
 		/// </summary>
 		/// <remarks><para>
-		/// For example, to establish a suffix for millimeters, set <i>PostFix</i>> to mm;
+		/// For example, to establish a suffix for millimeters, set <i>PostFix</i> to mm;
 		/// a distance of 19.2 units would be displayed as 19.2 mm.
 		/// </para><para>
 		/// If tolerances are turned on, the suffix is applied to the tolerances

--- a/ACadSharp/Tables/DimensionStyle.cs
+++ b/ACadSharp/Tables/DimensionStyle.cs
@@ -1,16 +1,19 @@
 ﻿using ACadSharp.Attributes;
 using ACadSharp.Types.Units;
 using System;
-using ACadSharp.Blocks;
+
+//	TODO should the described coupling of properties be implemented in this class,
+//		 e.g., GenerateTolerances and LimitsGeneration?
 
 namespace ACadSharp.Tables
 {
 	/// <summary>
-	/// Represents a <see cref="DimensionStyle"/> entry
+	/// Represents a <see cref="DimensionStyle"/> table entry.
 	/// </summary>
 	/// <remarks>
 	/// Object name <see cref="DxfFileToken.TableDimstyle"/> <br/>
 	/// Dxf class name <see cref="DxfSubclassMarker.DimensionStyle"/>
+	/// see https://help.autodesk.com/view/ACDLT/2024/ENU/?guid=GUID-1B946C9E-0AB1-40E6-8675-80A51851BEA1.
 	/// </remarks>
 	[DxfName(DxfFileToken.TableDimstyle)]
 	[DxfSubClass(DxfSubclassMarker.DimensionStyle)]
@@ -30,157 +33,285 @@ namespace ACadSharp.Tables
 		public override string SubclassMarker => DxfSubclassMarker.DimensionStyle;
 
 		/// <summary>
-		/// DIMPOST
+		/// Specifies a text prefix or suffix (or both) to the dimension measurement
+		/// (see DIMPOST System Variable).
 		/// </summary>
+		/// <remarks><para>
+		/// For example, to establish a suffix for millimeters, set <i>PostFix</i>> to mm;
+		/// a distance of 19.2 units would be displayed as 19.2 mm.
+		/// </para><para>
+		/// If tolerances are turned on, the suffix is applied to the tolerances
+		/// as well as to the main dimension.
+		/// </para><para>
+		/// Use &lt;&gt; to indicate placement of the text in relation to the dimension value.
+		/// For example, enter &lt;&gt; mm to display a 5.0 millimeter radial dimension as "5.0mm".
+		/// If you entered mm &lt;&gt;, the dimension would be displayed as "mm 5.0". Use the &lt;&gt;
+		/// mechanism for angular dimensions.
+		/// </para>
+		/// </remarks>
 		[DxfCodeValue(3)]
 		public string PostFix { get; set; } = "<>";
 
 		/// <summary>
-		/// DIMAPOST
+		/// Specifies a text prefix or suffix (or both) to the alternate dimension
+		/// measurement for all types of dimensions except angular
+		/// (see DIMAPOST System Variable).
 		/// </summary>
+		/// <remarks><para>
+		/// For instance, if the current units are Architectural, <see cref="AlternateUnitDimensioning"/>
+		/// is on (true), <see cref="AlternateUnitScaleFactor"/> is 25.4 (the number of millimeters per inch),
+		/// <see cref="AlternateUnitDecimalPlaces"/> is 2, and <i>AlternateDimensioningSuffix</i> is set to "mm",
+		/// a distance of 10 units would be displayed as 10"[254.00mm].
+		/// </para><para>
+		/// To turn off an established prefix or suffix (or both), set it to a single period (.).
+		/// </para>
+		/// </remarks>
 		[DxfCodeValue(4)]
 		public string AlternateDimensioningSuffix { get; set; } = "[]";
 
 		/// <summary>
-		/// DIMTOL
+		/// Appends tolerances to dimension text
+		/// (see DIMTOL System Variable).
 		/// </summary>
+		/// <remarks>
+		/// Setting <i>GenerateTolerances</i> to on (true) turns <see cref="LimitsGeneration"/> off (false).
+		/// </remarks>
 		[DxfCodeValue(71)]
 		public bool GenerateTolerances { get; set; }
 
 		/// <summary>
-		/// DIMLIM
+		/// Generates dimension limits as the default text
+		/// (see DIMLIM System Variable).
 		/// </summary>
+		/// <remarks>
+		/// Setting <i>LimitsGeneration</i> to on (true) turns <see cref="GenerateTolerances"/> off (false).
+		/// </remarks>
 		[DxfCodeValue(72)]
 		public bool LimitsGeneration { get; set; }
 
 		/// <summary>
-		/// DIMTIH
+		/// Controls the position of dimension text inside the extension lines for all
+		/// dimension types except Ordinate.
+		/// (see DIMTIH System Variable).
 		/// </summary>
+		/// <value><b>true</b> if the text is to be drawn horizontally;
+		/// <b>false </b> if the text is to be aligned with the dimension line.</value>
 		[DxfCodeValue(73)]
 		public bool TextInsideHorizontal { get; set; }
 
 		/// <summary>
-		/// DIMTOH
+		/// Controls the position of dimension text outside the extension lines
+		/// (see DIMTOH System Variable).
 		/// </summary>
+		/// <value><b>true</b> if the text is to be drawn horizontally;
+		/// <b>false </b> if the text is to be aligned with the dimension line.</value>
 		[DxfCodeValue(74)]
 		public bool TextOutsideHorizontal { get; set; }
 
 		/// <summary>
-		/// DIMSE1
+		/// Suppresses display of the first extension line
+		/// (see DIMSE1 System Variable).
 		/// </summary>
+		/// <value><b>true</b> if the first extension line is to be suppressed; otherwise <b>false</b>.
+		/// </value>
 		[DxfCodeValue(75)]
 		public bool SuppressFirstExtensionLine { get; set; }
 
 		/// <summary>
-		/// DIMSE2
+		/// Suppresses display of the second extension line
+		/// (see DIMSE2 System Variable).
 		/// </summary>
+		/// <value><b>true</b> if the second extension line is to be suppressed; otherwise <b>false</b>.
+		/// </value>
 		[DxfCodeValue(76)]
 		public bool SuppressSecondExtensionLine { get; set; }
 
 		/// <summary>
-		/// DIMTAD
+		/// Controls the vertical position of text in relation to the dimension line
+		/// (see DIMTAD System Variable).
 		/// </summary>
 		[DxfCodeValue(77)]
 		public DimensionTextVerticalAlignment TextVerticalAlignment { get; set; }
 
 		/// <summary>
-		/// DIMZIN
+		/// Controls the suppression of zeros in the primary unit value
+		/// (see DIMZIN System Variable).
 		/// </summary>
 		[DxfCodeValue(78)]
 		public ZeroHandling ZeroHandling { get; set; }
 
-		/// <summary>
-		/// DIMALT
+		/// <summary>Controls the display of alternate units in dimensions
+		/// (see DIMALT System Variable).
 		/// </summary>
+		/// <value>
+		/// <b>true</b> enables alternate units; <b>false</b> disables alternate units.
+		/// </value>
 		[DxfCodeValue(170)]
 		public bool AlternateUnitDimensioning { get; set; }
 
 		/// <summary>
-		/// DIMALTD
+		/// Controls the number of decimal places in alternate units
+		/// (see DIMALTD System Variable).
 		/// </summary>
+		/// <remarks>
+		/// If <see cref="AlternateUnitDimensioning"/> is turned on (true), <i>AlternateUnitDecimalPlaces</i>
+		/// specifies the number of digits displayed to the right of the decimal point in the alternate
+		/// measurement.
+		/// </remarks>
 		[DxfCodeValue(171)]
 		public short AlternateUnitDecimalPlaces { get; set; }
 
 		/// <summary>
-		/// DIMTOFL
+		/// Controls whether a dimension line is drawn between the extension lines even when the text
+		/// is placed outside.
+		/// (see DIMTOFL System Variable).
 		/// </summary>
+		/// <remarks>
+		/// For radius and diameter dimensions, a dimension line is drawn inside the circle or arc when the text,
+		/// arrowheads, and leader are placed outside.
+		/// </remarks>
+		/// <value>
+		/// <para>
+		/// <b>true</b>: Draws dimension lines between the measured points even when arrowheads are placed
+		/// outside the measured points
+		/// </para><para>
+		/// <b>false</b>: Does not draw dimension lines between the measured points when arrowheads are placed
+		/// outside the measured points
+		/// </para>
+		/// </value>
 		[DxfCodeValue(172)]
 		public bool TextOutsideExtensions { get; set; }
 
 		/// <summary>
-		/// DIMSAH
+		/// Controls the display of dimension line arrowhead blocks
+		/// (see DIMSAH System Variable).
 		/// </summary>
+		/// <value>
+		/// <b>true</b> if arrowhead blocks set by <see cref="DimArrow1"/> and <see cref="DimArrow2"/>
+		/// shall be used;
+		/// <b>false</b> if arrowhead block set by <see cref="ArrowBlock"/> shall be used.
+		/// </value>
 		[DxfCodeValue(173)]
 		public bool SeparateArrowBlocks { get; set; }
 
 		/// <summary>
-		/// DIMTIX
+		/// Draws text between extension lines
+		/// (see DIMTIX System Variable).
 		/// </summary>
+		/// <value><para>
+		/// <b>false</b>: For linear and angular dimensions, dimension text is placed
+		/// inside the extension lines if there is sufficient room.
+		/// </para><para>
+		/// <b>true</b>: Draws dimension text between the extension lines even if it
+		/// would ordinarily be placed outside those lines.
+		/// For radius and diameter dimensions, TextInsideExtensions on (true) always forces
+		/// the dimension text outside the circle or arc.
+		/// </para>
+		/// </value>
 		[DxfCodeValue(174)]
 		public bool TextInsideExtensions { get; set; }
 
 		/// <summary>
-		/// DIMSOXD
+		/// Suppresses arrowheads if not enough space is available inside the extension lines
+		/// (see DIMSOXD System Variable).
 		/// </summary>
+		/// <value>
+		/// <b>true</b> if arrowheads are to be suppressed; otherwise, <b>false</b>.
+		/// </value>
 		[DxfCodeValue(175)]
 		public bool SuppressOutsideExtensions { get; set; }
 
 		/// <summary>
-		/// DIMADEC
+		/// Controls the number of precision places displayed in angular dimensions
+		/// (see DIMADEC System Variable).
 		/// </summary>
+		/// <value><para>
+		/// <b>-1</b>: Angular dimensions display the number of decimal places specified by
+		/// the <see cref="DecimalPlaces"/> property
+		/// </para><para>
+		/// <b>0-8</b>: Specifies the number of decimal places displayed in angular dimensions
+		/// (independent of the value of the <see cref="DecimalPlaces"/> property).
+		/// </para>
+		/// </value>
 		[DxfCodeValue(179)]
 		public short AngularDimensionDecimalPlaces { get; set; }
 
 		/// <summary>
-		/// DIMJUST
+		/// Controls the horizontal positioning of dimension text
+		/// (see DIMJUST System Variable).
 		/// </summary>
 		[DxfCodeValue(280)]
 		public DimensionTextHorizontalAlignment TextHorizontalAlignment { get; set; }
 
 		/// <summary>
-		/// DIMSD1
+		/// Controls suppression of the first dimension line and arrowhead
+		/// (see DIMSD1 System Variable).
 		/// </summary>
+		/// <value>
+		/// <b>true</b> if the first dimension line is to be suppressed; otherwise, <b>false</b>.
+		/// </value>
 		[DxfCodeValue(281)]
 		public bool SuppressFirstDimensionLine { get; set; }
 
 		/// <summary>
-		/// DIMSD2
+		/// Controls suppression of the second dimension line and arrowhead
+		/// (see DIMSD2 System Variable).
 		/// </summary>
+		/// <value>
+		/// <b>true</b> if the second dimension line is to be suppressed; otherwise, <b>false</b>.
+		/// </value>
 		[DxfCodeValue(282)]
 		public bool SuppressSecondDimensionLine { get; set; }
 
 		/// <summary>
-		/// DIMTOLJ
+		/// Gets or sets the vertical justification for tolerance values relative to the nominal dimension text.
+		/// (see DIMTOLJ System Variable).
 		/// </summary>
 		[DxfCodeValue(283)]
 		public ToleranceAlignment ToleranceAlignment { get; set; }
 
 		/// <summary>
-		/// DIMTZIN
+		/// Controls the suppression of zeros in tolerance values
+		/// (see DIMTZIN System Variable).
 		/// </summary>
+		/// <remarks>
+		/// Value 0-3 affect feet-and-inch dimensions only.
+		/// </remarks>
 		[DxfCodeValue(284)]
 		public ZeroHandling ToleranceZeroHandling { get; set; }
 
 		/// <summary>
-		/// DIMALTZ
+		/// Controls the suppression of zeros for alternate unit dimension values
+		/// (see DIMALTZ System Variable).
 		/// </summary>
 		[DxfCodeValue(285)]
 		public ZeroHandling AlternateUnitZeroHandling { get; set; }
 
 		/// <summary>
-		/// DIMFIT
+		/// Determines how dimension text and arrows are arranged when space is not sufficient to
+		/// place both within the extension lines.
+		/// (see DIMFIT System Variable).
 		/// </summary>
 		[DxfCodeValue(287)]
 		public char DimensionFit { get; set; }
 
 		/// <summary>
-		/// DIMUPT
+		/// Controls options for user-positioned text
+		/// (see DIMUPT System Variable).
 		/// </summary>
+		/// <value>
+		/// <para>
+		/// <b>false</b>: Cursor controls only the dimension line location.
+		/// </para><para>
+		/// <b>true</b>: Cursor controls both the text position and the dimension line location,
+		/// </para>
+		/// </value>
 		[DxfCodeValue(288)]
 		public bool CursorUpdate { get; set; }
 
 		/// <summary>
-		/// DIMALTTZ
+		/// Controls suppression of zeros in tolerance values
+		/// (see DIMALTTZ System Variable).
 		/// </summary>
 		[DxfCodeValue(286)]
 		public ZeroHandling AlternateUnitToleranceZeroHandling { get; set; }
@@ -192,43 +323,84 @@ namespace ACadSharp.Tables
 		public short DimensionUnit { get; set; }
 
 		/// <summary>
-		/// DIMAUNIT
+		/// Gets or sets the units format for angular dimensions
+		/// (see DIMAUNIT System Variable).
 		/// </summary>
 		[DxfCodeValue(275)]
 		public AngularUnitFormat AngularUnit { get; set; }
 
 		/// <summary>
-		/// DIMDEC
+		/// Gets or sets the number of decimal places displayed for the primary
+		/// units of a dimension
+		/// (see DIMDEC System Variable).
 		/// </summary>
 		[DxfCodeValue(271)]
 		public short DecimalPlaces { get; set; }
 
 		/// <summary>
-		/// DIMTDEC
+		/// Gets or sets the number of decimal places to display in tolerance values
+		/// for the primary units in a dimension
+		/// (see DIMTDEC System Variable).
 		/// </summary>
 		[DxfCodeValue(272)]
 		public short ToleranceDecimalPlaces { get; set; }
 
 		/// <summary>
-		/// DIMALTU
+		/// Gets or sets the units format for alternate units of all dimension substyles
+		/// except Angular
+		/// (see DIMALTU System Variable).
 		/// </summary>
 		[DxfCodeValue(273)]
 		public LinearUnitFormat AlternateUnitFormat { get; set; } = LinearUnitFormat.Decimal;
 
 		/// <summary>
-		/// DIMALTTD
+		/// Gets or sets the number of decimal places for the tolerance values in the alternate
+		/// units of a dimension
+		/// (see DIMALTTD System Variable).
 		/// </summary>
 		[DxfCodeValue(274)]
 		public short AlternateUnitToleranceDecimalPlaces { get; set; }
 
 		/// <summary>
-		/// DIMSCALE
+		/// Gets or sets the overall scale factor applied to dimensioning variables that specify
+		/// sizes, distances, or offsets
+		/// (see DIMSCALE System Variable).
 		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// This ScaleFactor does not affect measured lengths, coordinates, or angles.
+		/// </para><para>
+		/// Use <i>ScaleFactor</i> to control the overall scale of dimensions. However, if the current
+		/// dimension style is annotative, <i>ScaleFactor</i> is automatically set to zero and the
+		/// dimension scale is controlled by the CANNOSCALE system variable. <i>ScaleFactor</i> cannot
+		/// be set to a non-zero value when using annotative dimensions.
+		/// </para><para>
+		/// Also affects the leader objects with the LEADER command.
+		/// </para><para>
+		/// Use MLEADERSCALE to scale multileader objects created with the MLEADER command.
+		/// </para>
+		/// </remarks>
+		/// <value>
+		/// <para>
+		/// <b>0.0</b>
+		/// </para><para>
+		/// A reasonable default value is computed based on the scaling between the current
+		/// model space viewport and paper space. If you are in paper space or model space
+		/// and not using the paper space feature, the scale factor is 1.0.
+		/// </para><para>
+		/// <b>&gt;0</b>
+		/// </para><para>
+		/// A scale factor is computed that leads text sizes, arrowhead sizes, and other scaled
+		/// distances to plot at their face values.
+		/// </para>
+		/// </value>
 		[DxfCodeValue(40)]
 		public double ScaleFactor { get; set; }
 
 		/// <summary>
-		/// DIMASZ
+		/// Controls the size of dimension line and leader line arrowheads. Also controls the
+		/// size of hook lines
+		/// (see DIMASZ System Variable).
 		/// </summary>
 		[DxfCodeValue(41)]
 		public double ArrowSize
@@ -245,187 +417,357 @@ namespace ACadSharp.Tables
 		}
 
 		/// <summary>
-		/// DIMEXO
+		/// Specifies how far extension lines are offset from origin points
+		/// (see DIMEXO System Variable).
 		/// </summary>
+		/// <remarks>
+		/// With fixed-length extension lines, this value determines the minimum offset.
+		/// </remarks>
 		[DxfCodeValue(42)]
 		public double ExtensionLineOffset { get; set; }
 
 		/// <summary>
-		/// DIMDLI
+		/// Controls the spacing of the dimension lines in baseline dimensions
+		/// (see DIMDLI System Variable).
 		/// </summary>
+		/// <remarks>
+		/// Each dimension line is offset from the previous one by this amount, if necessary,
+		/// to avoid drawing over it. Changes made with <i>DimensionLineIncrement</i> are
+		/// not applied to existing dimensions.
+		/// </remarks>
 		[DxfCodeValue(43)]
 		public double DimensionLineIncrement { get; set; }
 
 		/// <summary>
-		/// DIMEXE
+		/// Specifies how far to extend the extension line beyond the dimension line
+		/// (see DIMEXE System Variable).
 		/// </summary>
 		[DxfCodeValue(44)]
 		public double ExtensionLineExtension { get; set; }
 
 		/// <summary>
-		/// DIMRND
+		/// Rounds all dimensioning distances to the specified value
+		/// (see DIMRND System Variable).
 		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// For instance, if <i>Rounding</i> is set to 0.25, all distances round
+		/// to the nearest 0.25 unit. If you set the value to 1.0, all distances round to the
+		/// nearest integer.
+		/// </para><para>
+		/// Note that the number of digits edited after the decimal point depends on the
+		/// precision set by <see cref="DecimalPlaces"/>.
+		/// </para><para>
+		/// This  does not apply to angular dimensions.
+		/// </para>
+		/// </remarks>
 		[DxfCodeValue(45)]
 		public double Rounding { get; set; }
 
 		/// <summary>
-		/// DIMDLE
+		/// Sets the distance the dimension line extends beyond the extension line when
+		/// oblique strokes are drawn instead of arrowheads.
+		/// (see DIMDLE System Variable).
 		/// </summary>
 		[DxfCodeValue(46)]
 		public double DimensionLineExtension { get; set; }
 
 		/// <summary>
-		/// DIMTP
+		/// Gets or sets the maximum (or upper) tolerance limit for dimension text when
+		/// <see cref="GenerateTolerances"/> or <see cref="LimitsGeneration"/> is on (true)
+		/// (see DIMTP System Variable).
 		/// </summary>
 		[DxfCodeValue(47)]
 		public double PlusTolerance { get; set; }
 
 		/// <summary>
-		/// DIMTM
+		/// Gets or sets the minimum (or lower) tolerance limit for dimension text when
+		/// <see cref="GenerateTolerances"/> or <see cref="LimitsGeneration"/> is on (true).
+		/// (see DIMTM System Variable).
 		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// <i>MinusTolerance</i> accepts signed values. If <see cref="GenerateTolerances"/> is on
+		/// and <see cref="PlusTolerance"/> and <i>MinusTolerance</i> are set to the same value,
+		/// a tolerance value is drawn.
+		/// </para><para>
+		/// If <i>MinusTolerance</i> and <see cref="PlusTolerance"/> values differ, the upper
+		/// tolerance is drawn above the lower, and a plus sign is added to the <see cref="PlusTolerance"/>
+		/// value if it is positive.
+		/// </para><para>
+		/// For <i>MinusTolerance</i>, the program uses the negative of the value you enter
+		/// (adding a minus sign if you specify a positive number and a plus sign if you specify a negative
+		/// number).
+		/// </para>
+		/// </remarks>
 		[DxfCodeValue(48)]
 		public double MinusTolerance { get; set; }
 
 		/// <summary>
-		/// DIMFXL
+		/// Sets the total length of the extension lines starting from the dimension line
+		/// toward the dimension origin
+		/// (see DIMFXL System Variable).
 		/// </summary>
 		[DxfCodeValue(49)]
 		public double FixedExtensionLineLength { get; set; }
 
 		/// <summary>
-		/// DIMJOGANG
+		/// (see DIMJOGANG System Variable).
 		/// </summary>
 		[DxfCodeValue(DxfReferenceType.IsAngle, 50)]
 		public double JoggedRadiusDimensionTransverseSegmentAngle { get; set; }
 
 		/// <summary>
-		/// DIMTFILL
+		/// Controls the background of dimension text
+		/// (see DIMTFILL System Variable).
 		/// </summary>
 		[DxfCodeValue(69)]
 		public DimensionTextBackgroundFillMode TextBackgroundFillMode { get; set; }
 
 		/// <summary>
-		/// DIMTFILLCLR
+		/// Determines the angle of the transverse segment of the dimension line
+		/// in a jogged radius dimension.
+		/// (see DIMTFILLCLR System Variable).
 		/// </summary>
-		//[DxfCodeValue(70)]	//No present in the dxf documentation
+		//[DxfCodeValue(70)]	//Not present in the dxf documentation
 		public Color TextBackgroundColor { get; set; }
 
 		/// <summary>
-		/// DIMAZIN
+		/// Suppresses zeros for angular dimensions
+		/// (see DIMAZIN System Variable).
 		/// </summary>
 		[DxfCodeValue(79)]
 		public ZeroHandling AngularZeroHandling { get; set; }
 
 		/// <summary>
-		/// DIMARCSYM
+		/// Controls display of the arc symbol in an arc length dimension
+		/// (see DIMARCSYM System Variable).
 		/// </summary>
 		[DxfCodeValue(90)]
 		public ArcLengthSymbolPosition ArcLengthSymbolPosition { get; set; }
 
 		/// <summary>
-		/// DIMTXT
+		/// Specifies the height of dimension text, unless the current text style has a fixed height
+		/// (see DIMTXT System Variable).
 		/// </summary>
 		[DxfCodeValue(140)]
 		public double TextHeight { get; set; } = 0.18;
 
 		/// <summary>
-		/// DIMCEN
+		/// Controls drawing of circle or arc center marks and centerlines by the
+		/// DIMCENTER, DIMDIAMETER, and DIMRADIUS commands
+		/// (see DIMCEN System Variable).
 		/// </summary>
+		/// <remarks>
+		/// For DIMDIAMETER and DIMRADIUS, the center mark is drawn only if you place
+		/// the dimension line outside the circle or arc.
+		/// </remarks>
+		/// <value>
+		/// <para>
+		/// <b>0</b>
+		/// </para><para>
+		/// No center marks or lines are drawn
+		/// </para><para>
+		/// <b>&lt;0</b>
+		/// </para><para>
+		/// Centerlines are drawn
+		/// </para><para>
+		/// <b>&gt;0</b>
+		/// </para><para>
+		/// Center marks are drawn
+		/// </para>
+		/// </value>
 		[DxfCodeValue(141)]
 		public double CenterMarkSize { get; set; }
 
 		/// <summary>
-		/// DIMTSZ
+		/// Specifies the size of oblique strokes drawn instead of arrowheads for linear, radius,
+		/// and diameter dimensioning
+		/// (see DIMTSZ System Variable).
 		/// </summary>
+		/// <value>
+		/// <para>
+		/// <b>0</b>
+		/// </para><para>
+		/// Draws arrowheads.
+		/// </para><para>
+		/// <b>&gt;0</b>
+		/// </para><para>
+		/// Draws oblique strokes instead of arrowheads.
+		/// The size of the oblique strokes is determined by this value multiplied by the value
+		/// of <see cref="ScaleFactor"/>.
+		/// </para>
+		/// </value>
 		[DxfCodeValue(142)]
 		public double TickSize { get; set; }
 
 		/// <summary>
-		/// DIMALTF
+		/// Controls the multiplier for alternate units
+		/// (see DIMALTF System Variable).
 		/// </summary>
+		/// <remarks>
+		/// If <see cref="AlternateUnitDimensioning"/> is turned on (true), the value of this
+		/// property (AlternateUnitScaleFactor) multiplies linear dimensions by a factor to produce
+		/// a value in an alternate system of measurement. The initial value represents the number
+		/// of millimeters in an inch.
+		/// </remarks>
 		[DxfCodeValue(143)]
 		public double AlternateUnitScaleFactor { get; set; } = 25.4;
 
 		/// <summary>
-		/// DIMLFAC
+		/// Sets a scale factor for linear dimension measurements
+		/// (see DIMLFAC System Variable).
 		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// All linear dimension distances, including radii, diameters, and coordinates, are multiplied
+		/// by this <i>LinearScaleFactor</i> before being converted to dimension text.
+		/// Positive values of <i>LinearScaleFactor</i> are applied to dimensions in both model space and
+		/// paper space; negative values are applied to paper space only.
+		/// </para><para>
+		/// <i>LinearScaleFactor</i> applies primarily to nonassociative dimensions (DIMASSOC set 0 or 1).
+		/// For nonassociative dimensions in paper space, <i>LinearScaleFactor</i> must be set individually
+		/// for each layout viewport to accommodate viewport scaling.
+		/// </para><para>
+		/// <i>LinearScaleFactor</i> has no effect on angular dimensions, and is not applied to the values held in
+		/// <see cref="Rounding"/>, <see cref="MinusTolerance"/>, or <see cref="PlusTolerance"/>.
+		/// </para>
+		/// </remarks>
 		[DxfCodeValue(144)]
 		public double LinearScaleFactor { get; set; } = 1.0;
 
 		/// <summary>
-		/// DIMTVP
+		/// Controls the vertical position of dimension text above or below the dimension line
+		/// (see DIMTVP System Variable).
 		/// </summary>
+		/// <remarks>
+		/// The <i>TextVerticalPosition</i> value is used when <see cref="TextVerticalAlignment"/>
+		/// is off. The magnitude of the vertical offset of text is the product of the text height
+		/// and <i>TextVerticalPosition</i>. Setting <i>TextVerticalPosition</i> to 1.0 is equivalent
+		/// to setting <see cref="TextVerticalAlignment"/> to on. The dimension line splits to
+		/// accommodate the text only if the absolute value of <i>TextVerticalPosition</i> is less than 0.7.
+		/// </remarks>
 		[DxfCodeValue(145)]
 		public double TextVerticalPosition { get; set; }
 
 		/// <summary>
-		/// DIMTFAC
+		/// Specifies a scale factor for the text height of fractions and tolerance values relative
+		/// to the dimension text height, as set by <see cref="TextHeight"/>
+		/// (see DIMTFAC System Variable).
 		/// </summary>
+		/// <remarks>
+		/// For example, if <i>ToleranceScaleFactor</i> is set to 1.0, the text height of fractions and
+		/// tolerances is the same height as the dimension text. If <i>ToleranceScaleFactor</i> is set
+		/// to 0.7500, the text height of fractions and tolerances is three-quarters the size of
+		/// dimension text.
+		/// </remarks>
 		[DxfCodeValue(146)]
 		public double ToleranceScaleFactor { get; set; } = 1.0;
 
 		/// <summary>
-		/// DIMGAP
+		/// Gets or sets the distance around the dimension text when the dimension line breaks to
+		/// accommodate dimension text
+		/// (see DIMGAP System Variable).
 		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// Also sets the gap between annotation and a hook line created with the LEADER command.
+		/// If you enter a negative value, <i>DimensionLineGap</i> places a box around the dimension text.
+		/// </para><para>
+		/// The value of <i>DimensionLineGap</i> is also used as the minimum length of each segment
+		/// of the dimension line. To locate the components of a linear dimension within the extension
+		/// lines, enough space must be available for both arrowheads (2 x <see cref="ArrowSize"/>),
+		/// both dimension line segments (2 x <i>DimensionLineGap</i>), a gap on either side of the
+		/// dimension text (another 2 x <i>DimensionLineGap</i>), and the length of the dimension text,
+		/// which depends on its size and number of decimal places displayed.
+		/// </para>
+		/// </remarks>
 		[DxfCodeValue(147)]
 		public double DimensionLineGap { get; set; }
 
 		/// <summary>
-		/// DIMALTRND
+		/// Rounds off the alternate dimension units
+		/// (see DIMALTRND System Variable).
 		/// </summary>
 		[DxfCodeValue(148)]
 		public double AlternateUnitRounding { get; set; }
 
 		/// <summary>
-		/// DIMCLRD
+		/// Gets or sets colors to dimension lines, arrowheads, and dimension leader lines
+		/// (see DIMCLRD System Variable).
 		/// </summary>
+		/// <remarks>
+		/// Also controls the color of leader lines created with the LEADER command.
+		/// </remarks>
 		[DxfCodeValue(176)]
 		public Color DimensionLineColor { get; set; }
 
 		/// <summary>
-		/// DIMCLRE
+		/// Gets or sets colors to extension lines, center marks, and centerlines
+		/// (see DIMCLRE System Variable).
 		/// </summary>
 		[DxfCodeValue(177)]
 		public Color ExtensionLineColor { get; set; }
 
 		/// <summary>
-		/// DIMCLRT
+		/// Assigns colors to dimension text
+		/// (see DIMCLRT System Variable).
 		/// </summary>
+		/// <remarks>
+		/// The color can be any valid color number.
+		/// </remarks>
 		[DxfCodeValue(178)]
 		public Color TextColor { get; set; }
 
 		/// <summary>
-		/// DIMFRAC
+		/// Gets or sets the fraction format when <see cref="LinearUnitFormat"/> is set to 4 (Architectural) or 5 (Fractional).
+		/// (see DIMFRAC System Variable).
 		/// </summary>
 		[DxfCodeValue(276)]
 		public FractionFormat FractionFormat { get; set; }
 
 		/// <summary>
-		/// DIMLUNIT
+		/// Gets or sets units for all dimension types except Angular
+		/// (see DIMLUNIT System Variable).
 		/// </summary>
 		[DxfCodeValue(277)]
 		public LinearUnitFormat LinearUnitFormat { get; set; } = LinearUnitFormat.Decimal;
 
 		/// <summary>
-		/// DIMDSEP
+		/// Specifies a single-character decimal separator to use when creating dimensions whose unit
+		/// format is decimal
+		/// (see DIMDSEP System Variable).
 		/// </summary>
+		/// <remarks>
+		/// When prompted, enter a single character at the Command prompt. If dimension units is set
+		/// to Decimal, the <i>DecimalSeparator</i> character is used instead of the default decimal point. 
+		/// If <i>DecimalSeparator</i> is set to NULL (default value), the decimal point is used as
+		/// the dimension separator.
+		/// </remarks>
 		[DxfCodeValue(278)]
 		public char DecimalSeparator { get; set; } = '.';
 
 		/// <summary>
-		/// DIMTMOVE
+		/// Sets dimension text movement rules
+		/// (see DIMTMOVE System Variable).
 		/// </summary>
 		[DxfCodeValue(279)]
 		public TextMovement TextMovement { get; set; }
 
 		/// <summary>
-		/// DIMFXLON
+		/// Controls whether extension lines are set to a fixed length
+		/// (see DIMFXLON System Variable).
 		/// </summary>
+		/// <value>
+		/// <b>true</b> when extension lines are set to the length specified by
+		/// <see cref="FixedExtensionLineLength"/>; otherwise, <b>false</b>.
+		/// </value>
 		[DxfCodeValue(290)]
 		public bool IsExtensionLineLengthFixed { get; set; }
 
 		/// <summary>
-		/// DIMTXTDIRECTION
+		/// Specifies the reading direction of the dimension text
+		/// (see DIMTXTDIRECTION System Variable).
 		/// </summary>
 		[DxfCodeValue(295)]
 		public TextDirection TextDirection { get; set; }
@@ -435,14 +777,24 @@ namespace ACadSharp.Tables
 		public double Mzf { get; set; }
 
 		/// <summary>
-		/// DIMLWD
+		/// Assigns lineweight to dimension lines
+		/// (see DIMLWD System Variable).
 		/// </summary>
+		/// <value>
+		/// Positive values represent line weight in hundredths of millimeters.
+		/// (Multiply a value by 2540 to convert values from inches to hundredths of millimeters.)
+		/// </value>
 		[DxfCodeValue(371)]
 		public LineweightType DimensionLineWeight { get; set; }
 
 		/// <summary>
-		/// DIMLWE
+		/// Assigns lineweight to extension lines
+		/// (see DIMLWE System Variable).
 		/// </summary>
+		/// <value>
+		/// Positive values represent line weight in hundredths of millimeters.
+		/// (Multiply a value by 2540 to convert values from inches to hundredths of millimeters.)
+		/// </value>
 		[DxfCodeValue(372)]
 		public LineweightType ExtensionLineWeight { get; set; }
 
@@ -450,13 +802,20 @@ namespace ACadSharp.Tables
 		public string Mzs { get; set; }
 
 		/// <summary>
-		/// DIMATFIT
+		/// Determines how dimension text and arrows are arranged when space is not sufficient
+		/// to place both within the extension lines.
+		/// (see DIMATFIT System Variable).
 		/// </summary>
+		/// <remarks>
+		/// A leader is added to moved dimension text when <see cref="TextMovement"/> is set to
+		/// <see cref="TextMovement.AddLeaderWhenTextMoved"/>.
+		/// </remarks>
 		[DxfCodeValue(289)]
 		public short DimensionTextArrowFit { get; set; }
 
 		/// <summary>
-		/// DIMTXSTY
+		/// Specifies the text style of the dimension
+		/// (see DIMTXSTY System Variable).
 		/// </summary>
 		[DxfCodeValue(DxfReferenceType.Handle, 340)]
 		public TextStyle Style
@@ -481,22 +840,34 @@ namespace ACadSharp.Tables
 		}
 
 		/// <summary>
-		/// Arrowhead block for leaders
+		/// Specifies the arrow type for leaders
+		/// (see DIMLDRBLK System Variable).
 		/// </summary>
+		/// <value>
+		/// A <see cref="BlockRecord"/> that makes up an arrowhead or null if the default,
+		/// closed-filled arrowhead is to be displayed.
+		/// </value>
 		/// <remarks>
-		/// DIMLDRBLK
+		/// Note: Annotative blocks cannot be used as custom arrowheads for dimensions or leaders.
 		/// </remarks>
 		[DxfCodeValue(341)]
-		public Block LeaderArrow { get; set; }
+		public BlockRecord LeaderArrow { get; set; }
 
 		/// <summary>
-		/// Arrow block for this style
+		/// Gets or sets the arrowhead block displayed at the ends of dimension lines
+		/// (see DIMBLK System Variable).
 		/// </summary>
+		/// <value>
+		/// A <see cref="BlockRecord"/> that makes up an arrowhead or null if the default,
+		/// closed-filled arrowhead is to be displayed.
+		/// </value>
 		/// <remarks>
-		/// DIMBLK
+		/// <para>
+		/// Note: Annotative blocks cannot be used as custom arrowheads for dimensions or leaders.
+		/// </para>
 		/// </remarks>
 		[DxfCodeValue(342)]
-		public Block ArrowBlock { get; set; }
+		public BlockRecord ArrowBlock { get; set; }
 
 		//5	DIMBLK(obsolete, now object ID)
 
@@ -505,22 +876,38 @@ namespace ACadSharp.Tables
 		//7	DIMBLK2(obsolete, now object ID)
 
 		/// <summary>
-		/// Arrowhead block for the first end of the dimension line
+		/// Gets or sets the arrowhead for the first end of the dimension line when
+		/// <see cref="SeparateArrowBlocks"/> is on (true)
+		/// (see DIMBLK1 System Variable).
 		/// </summary>
+		/// <value>
+		/// A <see cref="BlockRecord"/> that makes up an arrowhead or null if the default,
+		/// closed-filled arrowhead is to be displayed.
+		/// </value>
 		/// <remarks>
-		/// DIMBLK1
+		/// <para>
+		/// Note: Annotative blocks cannot be used as custom arrowheads for dimensions or leaders.
+		/// </para>
 		/// </remarks>
 		[DxfCodeValue(343)]
-		public Block DimArrow1 { get; set; }
+		public BlockRecord DimArrow1 { get; set; }
 
 		/// <summary>
-		/// Arrowhead block for the second end of the dimension line
+		/// Gets or sets the arrowhead for the first end of the dimension line when
+		/// <see cref="SeparateArrowBlocks"/> is on (true)
+		/// (see DIMBLK2 System Variable).
 		/// </summary>
+		/// <value>
+		/// A <see cref="BlockRecord"/> that makes up an arrowhead or null if the default,
+		/// closed-filled arrowhead is to be displayed.
+		/// </value>
 		/// <remarks>
-		/// DIMBLK2
+		/// <para>
+		/// Note: Annotative blocks cannot be used as custom arrowheads for dimensions or leaders.
+		/// </para>
 		/// </remarks>
 		[DxfCodeValue(344)]
-		public Block DimArrow2 { get; set; }
+		public BlockRecord DimArrow2 { get; set; }
 
 		private double _arrowSize = 0.18;
 
@@ -535,10 +922,10 @@ namespace ACadSharp.Tables
 		{
 			DimensionStyle clone = new DimensionStyle(this.Name);
 			clone.Style = (TextStyle)this.Style?.Clone();
-			clone.LeaderArrow = (Block)this.LeaderArrow?.Clone();
-			clone.ArrowBlock = (Block)this.ArrowBlock?.Clone();
-			clone.DimArrow1 = (Block)this.DimArrow1?.Clone();
-			clone.DimArrow2 = (Block)this.DimArrow2?.Clone();
+			clone.LeaderArrow = (BlockRecord)this.LeaderArrow?.Clone();
+			clone.ArrowBlock = (BlockRecord)this.ArrowBlock?.Clone();
+			clone.DimArrow1 = (BlockRecord)this.DimArrow1?.Clone();
+			clone.DimArrow2 = (BlockRecord)this.DimArrow2?.Clone();
 			return clone;
 		}
 

--- a/ACadSharp/Tables/DimensionTextVerticalAlignment.cs
+++ b/ACadSharp/Tables/DimensionTextVerticalAlignment.cs
@@ -13,18 +13,21 @@
 		/// <summary>
 		/// Places the dimension text above the dimension line except when the dimension
 		/// line is not horizontal and text inside the extension lines is forced horizontal
-		/// (DIMTIH = 1). The distance from the dimension line to the baseline of the lowest
-		/// line of text is the current DIMGAP value.
+		/// (<see cref="DimensionStyle.TextInsideHorizontal"/> = true). The distance from
+		/// the dimension line to the baseline of the lowest line of text is the current
+		/// <see cref="DimensionStyle.DimensionLineGap" /> value.
 		/// </summary>
 		Above = 1,
 
 		/// <summary>
-		/// Places the dimension text on the side of the dimension line farthest away from the first defining point.
+		/// Places the dimension text on the side of the dimension line farthest away from
+		/// the first defining point.
 		/// </summary>
 		Outside = 2,
 
 		/// <summary>
-		/// Places the dimension text to conform to a Japanese Industrial Standards (JIS) representation.
+		/// Places the dimension text to conform to a Japanese Industrial Standards (JIS)
+		/// representation.
 		/// </summary>
 		JIS = 3,
 

--- a/ACadSharp/Tables/DimensionTextVerticalAlignment.cs
+++ b/ACadSharp/Tables/DimensionTextVerticalAlignment.cs
@@ -11,7 +11,10 @@
 		Centered = 0,
 
 		/// <summary>
-		/// Places the dimension text above the dimension line.
+		/// Places the dimension text above the dimension line except when the dimension
+		/// line is not horizontal and text inside the extension lines is forced horizontal
+		/// (DIMTIH = 1). The distance from the dimension line to the baseline of the lowest
+		/// line of text is the current DIMGAP value.
 		/// </summary>
 		Above = 1,
 


### PR DESCRIPTION
-  LeaderArrow, ArrowBlock, DimArrow1, DimArrow2: type changed to BlockRecord
-  Comments added from https://help.autodesk.com/view/ACDLT/2024/