### PR TITLE
ignore DwgColor

### DIFF
--- a/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -5450,7 +5450,7 @@ namespace ACadSharp.IO.DWG
 
 			dwgColor.Color = new Color(colorIndex);
 
-			return template;
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
# Description

ignore DwgColor to avoid a corrupted document.