### PR TITLE
Fixed bug in reading bulges for Hatch.BoundaryPath.Polyline from DWG file

### DIFF
--- a/ACadSharp/Entities/Hatch.BoundaryPath.Polyline.cs
+++ b/ACadSharp/Entities/Hatch.BoundaryPath.Polyline.cs
@@ -1,6 +1,7 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ACadSharp.Entities
 {
@@ -17,7 +18,7 @@ namespace ACadSharp.Entities
 				/// Has bulge flag
 				/// </summary>
 				[DxfCodeValue(72)]
-				public bool HasBulge { get { return Bulge != 0; } }
+				public bool HasBulge => this.Bulges.Any();
 
 				/// <summary>
 				/// Is closed flag
@@ -29,10 +30,10 @@ namespace ACadSharp.Entities
 				/// Bulge
 				/// </summary>
 				/// <remarks>
-				/// optional, default = 0
+				/// optional, default empty
 				/// </remarks>
 				[DxfCodeValue(42)]
-				public double Bulge { get; set; } = 0.0;
+				public List<double> Bulges { get; set; } = new List<double>();
 
 				/// <remarks>
 				/// Position values are only X and Y

--- a/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -4968,9 +4968,11 @@ namespace ACadSharp.IO.DWG
 						//pt0 2RD 10 point on polyline
 						XY vertex = this._objectReader.Read2RawDouble();
 
-						if (bulgespresent)
+						if (bulgespresent) {
 							//bulge BD 42 bulge
-							pline.Bulge = this._objectReader.ReadBitDouble();
+							double bulge = this._objectReader.ReadBitDouble();
+							pline.Bulges.Add(bulge);
+						}
 
 						//Add the vertex
 						pline.Vertices.Add(new XY(vertex.X, vertex.Y));

--- a/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Entities.cs
+++ b/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Entities.cs
@@ -856,12 +856,15 @@ namespace ACadSharp.IO.DWG
 
 					//numpathsegs BL 91 number of path segments
 					this._writer.WriteBitLong(pline.Vertices.Count);
-					foreach (var vertex in pline.Vertices)
+					for (var i = 0; i < pline.Vertices.Count; ++i)
 					{
-						this._writer.Write2RawDouble(vertex);
+						var vertex = pline.Vertices[i];
+						var bulge  = pline.Bulges[i];
+
+						this._writer.Write2RawDouble(new XY(vertex.X, vertex.Y));
 						if (pline.HasBulge)
 						{
-							this._writer.WriteBitDouble(pline.Bulge);
+							this._writer.WriteBitDouble(bulge);
 						}
 					}
 				}


### PR DESCRIPTION
# Description

In the existing algorithm, when BoundaryPath of Polyline type had convexities, they were overwritten. This is incorrect according to the DWG format specification.

![image](https://github.com/DomCR/ACadSharp/assets/74456398/7ff8ff8d-63e7-4c82-8a68-580e6e6e7695)

Below I offer my solution to the problem.

# Related Issues / Pull Requests
 - Fixed #282

# Notes for reviewer
 - I've changed the way the bulges are stored. Now they are stored as a list.
 - I had to change the record loop from foreach to for.