### PR TITLE
Increase reading performance

### DIFF
--- a/ACadSharp.Examples/Common/NotificationHelper.cs
+++ b/ACadSharp.Examples/Common/NotificationHelper.cs
@@ -28,6 +28,7 @@ namespace ACadSharp.Examples.Common
 
 			//Write in the console all the messages
 			Console.WriteLine(e.Message);
+			Console.ResetColor();
 		}
 	}
 }

--- a/ACadSharp.Examples/Program.cs
+++ b/ACadSharp.Examples/Program.cs
@@ -2,7 +2,6 @@
 using ACadSharp.Tables;
 using ACadSharp.Tables.Collections;
 using System;
-using System.Diagnostics;
 using System.Linq;
 
 namespace ACadSharp.Examples
@@ -13,22 +12,7 @@ namespace ACadSharp.Examples
 
 		static void Main(string[] args)
 		{
-			Stopwatch stopwatch = new Stopwatch();
-			stopwatch.Start();
-
 			CadDocument doc;
-			using (DxfReader reader = new DxfReader("D:\\Albert DC\\Documents\\Visual Studio 2022\\Repos\\ACadSharp\\samples\\local\\stress\\stress_AC1032.dxf"))
-			{
-				reader.OnNotification += Common.NotificationHelper.LogConsoleNotification;
-				doc = reader.Read();
-			}
-
-			stopwatch.Stop();
-			var sec = stopwatch.ElapsedMilliseconds / 1000;
-			//9 seconds for 2.2.0
-			//12 seconds for 2.3.1
-			return;
-
 			using (DwgReader reader = new DwgReader(_file))
 			{
 				doc = reader.Read();

--- a/ACadSharp.Examples/Program.cs
+++ b/ACadSharp.Examples/Program.cs
@@ -2,6 +2,7 @@
 using ACadSharp.Tables;
 using ACadSharp.Tables.Collections;
 using System;
+using System.Diagnostics;
 using System.Linq;
 
 namespace ACadSharp.Examples
@@ -12,7 +13,22 @@ namespace ACadSharp.Examples
 
 		static void Main(string[] args)
 		{
+			Stopwatch stopwatch = new Stopwatch();
+			stopwatch.Start();
+
 			CadDocument doc;
+			using (DxfReader reader = new DxfReader("D:\\Albert DC\\Documents\\Visual Studio 2022\\Repos\\ACadSharp\\samples\\local\\stress\\stress_AC1032.dxf"))
+			{
+				reader.OnNotification += Common.NotificationHelper.LogConsoleNotification;
+				doc = reader.Read();
+			}
+
+			stopwatch.Stop();
+			var sec = stopwatch.ElapsedMilliseconds / 1000;
+			//9 seconds for 2.2.0
+			//12 seconds for 2.3.1
+			return;
+
 			using (DwgReader reader = new DwgReader(_file))
 			{
 				doc = reader.Read();

--- a/ACadSharp.Examples/Program.cs
+++ b/ACadSharp.Examples/Program.cs
@@ -13,22 +13,7 @@ namespace ACadSharp.Examples
 
 		static void Main(string[] args)
 		{
-			Stopwatch stopwatch = new Stopwatch();
-			stopwatch.Start();
-
 			CadDocument doc;
-			using (DwgReader reader = new DwgReader("D:\\Albert DC\\Documents\\Visual Studio 2022\\Repos\\ACadSharp\\samples\\local\\stress\\stress_AC1032.dwg"))
-			{
-				reader.OnNotification += Common.NotificationHelper.LogConsoleNotification;
-				doc = reader.Read();
-			}
-
-			stopwatch.Stop();
-			var sec = stopwatch.ElapsedMilliseconds / 1000;
-			//9 seconds for 2.2.0
-			//12 seconds for 2.3.1
-			return;
-
 			using (DwgReader reader = new DwgReader(_file))
 			{
 				doc = reader.Read();

--- a/ACadSharp.Examples/Program.cs
+++ b/ACadSharp.Examples/Program.cs
@@ -2,6 +2,7 @@
 using ACadSharp.Tables;
 using ACadSharp.Tables.Collections;
 using System;
+using System.Diagnostics;
 using System.Linq;
 
 namespace ACadSharp.Examples
@@ -12,7 +13,22 @@ namespace ACadSharp.Examples
 
 		static void Main(string[] args)
 		{
+			Stopwatch stopwatch = new Stopwatch();
+			stopwatch.Start();
+
 			CadDocument doc;
+			using (DwgReader reader = new DwgReader("D:\\Albert DC\\Documents\\Visual Studio 2022\\Repos\\ACadSharp\\samples\\local\\stress\\stress_AC1032.dwg"))
+			{
+				reader.OnNotification += Common.NotificationHelper.LogConsoleNotification;
+				doc = reader.Read();
+			}
+
+			stopwatch.Stop();
+			var sec = stopwatch.ElapsedMilliseconds / 1000;
+			//9 seconds for 2.2.0
+			//12 seconds for 2.3.1
+			return;
+
 			using (DwgReader reader = new DwgReader(_file))
 			{
 				doc = reader.Read();

--- a/ACadSharp.Examples/ReaderExamples.cs
+++ b/ACadSharp.Examples/ReaderExamples.cs
@@ -45,7 +45,7 @@ namespace ACadSharp.Examples
 			using (DxfReader reader = new DxfReader(file))
 			{
 				reader.OnNotification += NotificationHelper.LogConsoleNotification;
-				entities = reader.ReadEntities();
+				//entities = reader.ReadEntities();
 			}
 
 			doc.Entities.AddRange(entities);
@@ -60,7 +60,7 @@ namespace ACadSharp.Examples
 			using (DxfReader reader = new DxfReader(file))
 			{
 				reader.OnNotification += NotificationHelper.LogConsoleNotification;
-				CadDocument doc = reader.ReadTables();
+				//CadDocument doc = reader.ReadTables();
 			}
 		}
 	}

--- a/ACadSharp.Examples/ReaderExamples.cs
+++ b/ACadSharp.Examples/ReaderExamples.cs
@@ -45,7 +45,7 @@ namespace ACadSharp.Examples
 			using (DxfReader reader = new DxfReader(file))
 			{
 				reader.OnNotification += NotificationHelper.LogConsoleNotification;
-				//entities = reader.ReadEntities();
+				entities = reader.ReadEntities();
 			}
 
 			doc.Entities.AddRange(entities);
@@ -60,7 +60,7 @@ namespace ACadSharp.Examples
 			using (DxfReader reader = new DxfReader(file))
 			{
 				reader.OnNotification += NotificationHelper.LogConsoleNotification;
-				//CadDocument doc = reader.ReadTables();
+				CadDocument doc = reader.ReadTables();
 			}
 		}
 	}

--- a/ACadSharp.Tests/IO/LocalSampleTests.cs
+++ b/ACadSharp.Tests/IO/LocalSampleTests.cs
@@ -11,10 +11,13 @@ namespace ACadSharp.Tests.IO
 
 		public static TheoryData<string> UserDxfFiles { get; } = new TheoryData<string>();
 
+		public static TheoryData<string> StressFiles { get; } = new TheoryData<string>();
+
 		static LocalSampleTests()
 		{
 			loadSamples("user_files", "dwg", UserDwgFiles);
 			loadSamples("user_files", "dxf", UserDxfFiles);
+			loadSamples("stress", "*", StressFiles);
 		}
 
 		public LocalSampleTests(ITestOutputHelper output) : base(output)
@@ -48,6 +51,26 @@ namespace ACadSharp.Tests.IO
 				return;
 
 			CadDocument doc = DxfReader.Read(test, this.onNotification);
+		}
+
+
+		[Theory]
+		[MemberData(nameof(StressFiles))]
+		public void ReadStressFiles(string test)
+		{
+			if (string.IsNullOrEmpty(test))
+				return;
+
+			CadDocument doc = null;
+			string extension = Path.GetExtension(test);
+			if (extension == ".dxf")
+			{
+				doc = DxfReader.Read(test, this.onNotification);
+			}
+			else if (extension.Equals(".dwg", System.StringComparison.OrdinalIgnoreCase))
+			{
+				doc = DwgReader.Read(test, this.onNotification);
+			}
 		}
 	}
 }

--- a/ACadSharp.Tests/IO/LocalSampleTests.cs
+++ b/ACadSharp.Tests/IO/LocalSampleTests.cs
@@ -1,4 +1,5 @@
 ﻿using ACadSharp.IO;
+using System.Diagnostics;
 using System.IO;
 using Xunit;
 using Xunit.Abstractions;
@@ -63,6 +64,10 @@ namespace ACadSharp.Tests.IO
 
 			CadDocument doc = null;
 			string extension = Path.GetExtension(test);
+
+			Stopwatch stopwatch = new Stopwatch();
+			stopwatch.Start();
+
 			if (extension == ".dxf")
 			{
 				doc = DxfReader.Read(test, this.onNotification);
@@ -71,6 +76,13 @@ namespace ACadSharp.Tests.IO
 			{
 				doc = DwgReader.Read(test, this.onNotification);
 			}
+
+			stopwatch.Stop();
+			this._output.WriteLine(stopwatch.Elapsed.TotalSeconds.ToString());
+
+			//Files tested have a size of ~100MB
+			//Cannot exceed 10 seconds
+			Assert.True(stopwatch.Elapsed.TotalSeconds < 10);
 		}
 	}
 }

--- a/ACadSharp.Tests/Internal/DwgObjectWriterTests.cs
+++ b/ACadSharp.Tests/Internal/DwgObjectWriterTests.cs
@@ -68,7 +68,8 @@ namespace ACadSharp.Tests.Internal
 
 			foreach (Entity item in document.Entities)
 			{
-				var e = builder.GetCadObject(item.Handle);
+				builder.TryGetCadObject(item.Handle, out Entity e);
+
 				Assert.NotNull(e);
 
 				switch (item)

--- a/ACadSharp/IO/CadDocumentBuilder.cs
+++ b/ACadSharp/IO/CadDocumentBuilder.cs
@@ -124,7 +124,13 @@ namespace ACadSharp.IO
 		public bool TryGetTableEntry<T>(string name, out T entry)
 			where T : TableEntry
 		{
-			entry = cadObjects.Values.OfType<T>().FirstOrDefault(e => e.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase));
+			if (string.IsNullOrEmpty(name))
+			{
+				entry = null;
+				return false;
+			}
+
+			entry = this.cadObjects.Values.OfType<T>().FirstOrDefault(e => e.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase));
 			return entry != null;
 		}
 

--- a/ACadSharp/IO/CadDocumentBuilder.cs
+++ b/ACadSharp/IO/CadDocumentBuilder.cs
@@ -121,6 +121,16 @@ namespace ACadSharp.IO
 			return false;
 		}
 
+		public T GetObjectTemplate<T>(ulong handle) where T : CadTemplate
+		{
+			if (this.templates.TryGetValue(handle, out CadTemplate template))
+			{
+				return (T)template;
+			}
+
+			return null;
+		}
+
 		public bool TryGetTableEntry<T>(string name, out T entry)
 			where T : TableEntry
 		{
@@ -134,19 +144,9 @@ namespace ACadSharp.IO
 			return entry != null;
 		}
 
-		public T GetObjectTemplate<T>(ulong handle) where T : CadTemplate
-		{
-			if (this.templates.TryGetValue(handle, out CadTemplate builder))
-			{
-				return (T)builder;
-			}
-
-			return null;
-		}
-
 		public bool TryGetObjectTemplate<T>(ulong? handle, out T value) where T : CadTemplate
 		{
-			if (!handle.HasValue)
+			if (!handle.HasValue || handle == 0)
 			{
 				value = null;
 				return false;

--- a/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -269,9 +269,8 @@ namespace ACadSharp.IO.DWG
 			//Read the handle
 			ulong value = this._handlesReader.HandleReference(handle);
 
-			if (!this._builder.TryGetObjectTemplate(value, out CadTemplate _) &&
-				!this._handles.Contains(value) &&
-				value != 0 &&
+			if (value != 0 &&
+				!this._builder.TryGetObjectTemplate(value, out CadTemplate _) &&
 				!this._readedObjects.ContainsKey(value))
 			{
 				//Add the value to the handles queue to be processed

--- a/ACadSharp/IO/DXF/DxfDocumentBuilder.cs
+++ b/ACadSharp/IO/DXF/DxfDocumentBuilder.cs
@@ -31,7 +31,7 @@ namespace ACadSharp.IO.DXF
 			this.BuildTables();
 
 			//Assign the owners for the different objects
-			foreach (CadTemplate template in this.templates.Values)
+			foreach (CadTemplate template in this.cadObjectsTemplates.Values)
 			{
 				this.assignOwner(template);
 			}
@@ -48,7 +48,7 @@ namespace ACadSharp.IO.DXF
 		{
 			var entities = new List<Entity>();
 
-			foreach (CadEntityTemplate item in this.templates.Values.OfType<CadEntityTemplate>())
+			foreach (CadEntityTemplate item in this.cadObjectsTemplates.Values.OfType<CadEntityTemplate>())
 			{
 				item.Build(this);
 

--- a/ACadSharp/IO/DXF/DxfStreamReader/DxfObjectsSectionReader.cs
+++ b/ACadSharp/IO/DXF/DxfStreamReader/DxfObjectsSectionReader.cs
@@ -66,8 +66,8 @@ namespace ACadSharp.IO.DXF
 					return this.readObjectCodes<Layout>(new CadLayoutTemplate(), this.readLayout);
 				case DxfFileToken.ObjectDictionaryVar:
 					return this.readObjectCodes<DictionaryVariable>(new CadTemplate<DictionaryVariable>(new DictionaryVariable()), this.readObjectSubclassMap);
-				//case DxfFileToken.ObjectSortEntsTable:
-				//return this.readSortentsTable();
+				case DxfFileToken.ObjectSortEntsTable:
+					return this.readSortentsTable();
 				case DxfFileToken.ObjectScale:
 					return this.readObjectCodes<Scale>(new CadTemplate<Scale>(new Scale()), this.readScale);
 				case DxfFileToken.ObjectVisualStyle:

--- a/ACadSharp/IO/DXF/DxfStreamReader/DxfObjectsSectionReader.cs
+++ b/ACadSharp/IO/DXF/DxfStreamReader/DxfObjectsSectionReader.cs
@@ -59,21 +59,21 @@ namespace ACadSharp.IO.DXF
 			switch (this._reader.ValueAsString)
 			{
 				case DxfFileToken.ObjectDictionary:
-					return this.readObjectCodes<CadDictionary>(new CadDictionaryTemplate(), readDictionary);
+					return this.readObjectCodes<CadDictionary>(new CadDictionaryTemplate(), this.readDictionary);
 				case DxfFileToken.ObjectDictionaryWithDefault:
 					return this.readObjectCodes<CadDictionaryWithDefault>(new CadDictionaryWithDefaultTemplate(), this.readDictionaryWithDefault);
 				case DxfFileToken.ObjectLayout:
-					return this.readObjectCodes<Layout>(new CadLayoutTemplate(), readLayout);
+					return this.readObjectCodes<Layout>(new CadLayoutTemplate(), this.readLayout);
 				case DxfFileToken.ObjectDictionaryVar:
 					return this.readObjectCodes<DictionaryVariable>(new CadTemplate<DictionaryVariable>(new DictionaryVariable()), this.readObjectSubclassMap);
 				//case DxfFileToken.ObjectSortEntsTable:
 				//return this.readSortentsTable();
 				case DxfFileToken.ObjectScale:
-					return this.readObjectCodes<Scale>(new CadTemplate<Scale>(new Scale()), this.readObjectSubclassMap);
+					return this.readObjectCodes<Scale>(new CadTemplate<Scale>(new Scale()), this.readScale);
 				case DxfFileToken.ObjectVisualStyle:
 					return this.readObjectCodes<VisualStyle>(new CadTemplate<VisualStyle>(new VisualStyle()), this.readVisualStyle);
 				case DxfFileToken.ObjectXRecord:
-					return this.readObjectCodes<XRecord>(new CadXRecordTemplate(), readXRecord);
+					return this.readObjectCodes<XRecord>(new CadXRecordTemplate(), this.readXRecord);
 				default:
 					this._builder.Notify($"Object not implemented: {this._reader.ValueAsString}", NotificationType.NotImplemented);
 					do
@@ -144,6 +144,19 @@ namespace ACadSharp.IO.DXF
 						return this.readPlotSettings(template, map);
 					}
 					return true;
+			}
+		}
+
+		private bool readScale(CadTemplate template, DxfMap map)
+		{
+			switch (this._reader.Code)
+			{
+				// Undocumented codes
+				case 70:
+					//Always 0
+					return true;
+				default:
+					return this.tryAssignCurrentValue(template.CadObject, map.SubClasses[DxfSubclassMarker.Scale]);
 			}
 		}
 
@@ -226,7 +239,7 @@ namespace ACadSharp.IO.DXF
 				default:
 					if (!this.tryAssignCurrentValue(template.CadObject, map.SubClasses[DxfSubclassMarker.DictionaryWithDefault]))
 					{
-						return readDictionary(template, map);
+						return this.readDictionary(template, map);
 					}
 					return true;
 			}

--- a/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
+++ b/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
@@ -71,7 +71,7 @@ namespace ACadSharp.IO.DXF
 			}
 		}
 
-		[Obsolete]
+		[Obsolete("Only needed for SortEntitiesTable but it should be removed")]
 		protected void readCommonObjectData(CadTemplate template)
 		{
 			while (this._reader.DxfCode != DxfCode.Subclass)

--- a/ACadSharp/IO/Templates/CadHatchTemplate.CadBoundaryPathTemplate.cs
+++ b/ACadSharp/IO/Templates/CadHatchTemplate.CadBoundaryPathTemplate.cs
@@ -5,7 +5,7 @@ namespace ACadSharp.IO.Templates
 {
 	internal partial class CadHatchTemplate
 	{
-		public class CadBoundaryPathTemplate : ICadObjectTemplate
+		public class CadBoundaryPathTemplate
 		{
 			public Hatch.BoundaryPath Path { get; set; } = new Hatch.BoundaryPath();
 

--- a/ACadSharp/IO/Templates/CadLineTypeTemplate.cs
+++ b/ACadSharp/IO/Templates/CadLineTypeTemplate.cs
@@ -5,7 +5,7 @@ namespace ACadSharp.IO.Templates
 {
 	internal class CadLineTypeTemplate : CadTableEntryTemplate<LineType>
 	{
-		public class SegmentTemplate : ICadObjectTemplate
+		public class SegmentTemplate
 		{
 			public ulong? StyleHandle { get; set; }
 

--- a/ACadSharp/IO/Templates/CadMLineStyleTemplate.cs
+++ b/ACadSharp/IO/Templates/CadMLineStyleTemplate.cs
@@ -7,7 +7,7 @@ namespace ACadSharp.IO.Templates
 {
 	internal class CadMLineStyleTemplate : CadTemplate<MLineStyle>
 	{
-		public class ElementTemplate : ICadObjectTemplate
+		public class ElementTemplate
 		{
 			public ulong? LinetypeHandle { get; set; }
 			public int? LinetypeIndex { get; set; }

--- a/ACadSharp/IO/Templates/DwgGroupTemplate.cs
+++ b/ACadSharp/IO/Templates/DwgGroupTemplate.cs
@@ -22,15 +22,7 @@ namespace ACadSharp.IO.Templates
 				}
 				else
 				{
-					CadObject cad = builder.GetCadObject(handle);
-					if (cad != null)
-					{
-						builder.Notify($"CadObject with handle {cad.GetType().FullName}:{handle} is not an entity and could not be added in group {this.CadObject.Handle}", NotificationType.Warning);
-					}
-					else
-					{
-						builder.Notify($"Entity with handle {handle} not found for group {this.CadObject.Handle}", NotificationType.Warning);
-					}
+					builder.Notify($"Entity with handle {handle} not found for group {this.CadObject.Handle}", NotificationType.Warning);
 				}
 			}
 		}

--- a/ACadSharp/IO/Templates/ICadObjectTemplate.cs
+++ b/ACadSharp/IO/Templates/ICadObjectTemplate.cs
@@ -1,9 +1,9 @@
-﻿using ACadSharp.IO.DWG;
-
-namespace ACadSharp.IO.Templates
+﻿namespace ACadSharp.IO.Templates
 {
 	internal interface ICadObjectTemplate
 	{
+		CadObject CadObject { get; }
+
 		void Build(CadDocumentBuilder builder);
 	}
 }


### PR DESCRIPTION
# Description

Modify the Builder to improve the reading performance.

The stress files have a size of 115MB for dxf and 24MB for dwg.