### PR TITLE
Separate the dictionary key from the entry name

### DIFF
--- a/ACadSharp.Tests/IO/LocalSampleTests.cs
+++ b/ACadSharp.Tests/IO/LocalSampleTests.cs
@@ -33,15 +33,6 @@ namespace ACadSharp.Tests.IO
 				return;
 
 			CadDocument doc = DwgReader.Read(test, this._dwgConfiguration, this.onNotification);
-
-			return;
-
-			string outPath = Path.Combine(Path.GetDirectoryName(test), $"{Path.GetFileNameWithoutExtension(test)}.out.dxf");
-			using (DxfWriter writer = new DxfWriter(outPath, doc, false))
-			{
-				//writer.OnNotification += onNotification;
-				writer.Write();
-			}
 		}
 
 		[Theory]

--- a/ACadSharp/IO/Templates/CadDictionaryTemplate.cs
+++ b/ACadSharp/IO/Templates/CadDictionaryTemplate.cs
@@ -40,7 +40,14 @@ namespace ACadSharp.IO.Templates
 						entry.Name = item.Key;
 					}
 
-					this.CadObject.Add(entry);
+					try
+					{
+						this.CadObject.Add(item.Key, entry);
+					}
+					catch (System.Exception ex)
+					{
+						builder.Notify("", NotificationType.Error, ex);
+					}
 				}
 			}
 		}

--- a/ACadSharp/IO/Templates/CadDictionaryTemplate.cs
+++ b/ACadSharp/IO/Templates/CadDictionaryTemplate.cs
@@ -46,7 +46,7 @@ namespace ACadSharp.IO.Templates
 					}
 					catch (System.Exception ex)
 					{
-						builder.Notify("", NotificationType.Error, ex);
+						builder.Notify($"Error when trying to add the entry {entry.Name} to {this.CadObject.Name}|{this.CadObject.Handle}", NotificationType.Error, ex);
 					}
 				}
 			}

--- a/ACadSharp/Objects/CadDictionary.cs
+++ b/ACadSharp/Objects/CadDictionary.cs
@@ -215,19 +215,29 @@ namespace ACadSharp.Objects
 		/// <summary>
 		/// Add a <see cref="NonGraphicalObject"/> to the collection, this method triggers <see cref="OnAdd"/>
 		/// </summary>
+		/// <param name="key"></param>
 		/// <param name="value"></param>
-		/// <exception cref="ArgumentException"></exception>
-		public void Add(NonGraphicalObject value)
+		public void Add(string key, NonGraphicalObject value)
 		{
-			if (string.IsNullOrEmpty(value.Name))
+			if (string.IsNullOrEmpty(key))
 			{
 				throw new ArgumentNullException(nameof(value), $"NonGraphicalObject [{this.GetType().FullName}] must have a name");
 			}
 
-			this._entries.Add(value.Name, value);
+			this._entries.Add(key, value);
 			value.Owner = this;
 
 			OnAdd?.Invoke(this, new CollectionChangedEventArgs(value));
+		}
+
+		/// <summary>
+		/// Add a <see cref="NonGraphicalObject"/> to the collection, this method triggers <see cref="OnAdd"/>
+		/// </summary>
+		/// <param name="value"></param>
+		/// <exception cref="ArgumentException"></exception>
+		public void Add(NonGraphicalObject value)
+		{
+			this.Add(value.Name, value);
 		}
 
 		/// <summary>

--- a/ACadSharp/Objects/CadDictionary.cs
+++ b/ACadSharp/Objects/CadDictionary.cs
@@ -215,7 +215,7 @@ namespace ACadSharp.Objects
 		/// <summary>
 		/// Add a <see cref="NonGraphicalObject"/> to the collection, this method triggers <see cref="OnAdd"/>
 		/// </summary>
-		/// <param name="key"></param>
+		/// <param name="key">key for the entry in the dictionary</param>
 		/// <param name="value"></param>
 		public void Add(string key, NonGraphicalObject value)
 		{
@@ -233,7 +233,7 @@ namespace ACadSharp.Objects
 		/// <summary>
 		/// Add a <see cref="NonGraphicalObject"/> to the collection, this method triggers <see cref="OnAdd"/>
 		/// </summary>
-		/// <param name="value"></param>
+		/// <param name="value">the name of the NonGraphicalObject will be used as a key for the dictionary</param>
 		/// <exception cref="ArgumentException"></exception>
 		public void Add(NonGraphicalObject value)
 		{


### PR DESCRIPTION
# Description

Fix for `CadDictionary` entries that have a different key than their name.