### PR TITLE
fix SummaryInfo being null

### DIFF
--- a/ACadSharp.Tests/IO/CadReaderTestsBase.cs
+++ b/ACadSharp.Tests/IO/CadReaderTestsBase.cs
@@ -38,6 +38,8 @@ namespace ACadSharp.Tests.IO
 		{
 			CadDocument doc = this.getDocument(test);
 
+			Assert.NotNull(doc.SummaryInfo);
+
 			if (doc.Header.Version < ACadVersion.AC1012)
 			{
 				//Older version do not keep the handles for tables and other objects like block_records

--- a/ACadSharp/IO/CadReaderBase.cs
+++ b/ACadSharp/IO/CadReaderBase.cs
@@ -22,9 +22,8 @@ namespace ACadSharp.IO
 			this.OnNotification += notification;
 		}
 
-		protected CadReaderBase(string filename, NotificationEventHandler notification = null) : this(notification)
+		protected CadReaderBase(string filename, NotificationEventHandler notification = null) : this(File.OpenRead(filename), notification)
 		{
-			this._fileStream = new StreamIO(filename, FileMode.Open, FileAccess.Read);
 		}
 
 		protected CadReaderBase(Stream stream, NotificationEventHandler notification = null) : this(notification)

--- a/ACadSharp/IO/DWG/DwgReader.cs
+++ b/ACadSharp/IO/DWG/DwgReader.cs
@@ -137,11 +137,11 @@ namespace ACadSharp.IO
 
 			//Older versions than 2004 don't have summaryinfo in it's file
 			if (this._fileHeader.AcadVersion < ACadVersion.AC1018)
-				return null;
+				return new CadSummaryInfo();
 
 			IDwgStreamReader reader = this.getSectionStream(DwgSectionDefinition.SummaryInfo);
 			if (reader == null)
-				return null;
+				return new CadSummaryInfo();
 
 			DwgSummaryInfoReader summaryReader = new DwgSummaryInfoReader(this._fileHeader.AcadVersion, reader);
 			return summaryReader.Read();

--- a/ACadSharp/IO/DXF/DxfReader.cs
+++ b/ACadSharp/IO/DXF/DxfReader.cs
@@ -108,20 +108,14 @@ namespace ACadSharp.IO
 		/// <returns></returns>
 		public static CadDocument Read(string filename, NotificationEventHandler notification = null)
 		{
-			CadDocument doc = null;
-
-			using (DxfReader reader = new DxfReader(filename, notification))
-			{
-				doc = reader.Read();
-			}
-
-			return doc;
+			return Read(File.OpenRead(filename));
 		}
 
 		/// <inheritdoc/>
 		public override CadDocument Read()
 		{
 			this._document = new CadDocument(false);
+			this._document.SummaryInfo = new CadSummaryInfo();
 
 			this._reader = this._reader ?? this.getReader();
 


### PR DESCRIPTION
# Description

Fix to setup the default value for `SummaryInfo` when reading a file.