### PR TITLE
Issue 458 hatch clone fix

### DIFF
--- a/src/ACadSharp.Tests/IO/LocalSampleTests.cs
+++ b/src/ACadSharp.Tests/IO/LocalSampleTests.cs
@@ -34,6 +34,26 @@ namespace ACadSharp.Tests.IO
 				return;
 
 			CadDocument doc = DwgReader.Read(test.Path, this._dwgConfiguration, this.onNotification);
+
+			CadDocument newDoc = new CadDocument();
+
+			var h = doc.GetCadObject(7819);
+
+			foreach (var entity in doc.Entities)
+			{
+				doc.Entities.Remove(entity);
+				newDoc.Entities.Add(entity);
+			}
+
+		//	var h = doc.GetCadObject(7819);
+
+			var b1 = doc.BlockRecords["3D ORBIT"];
+			var b2 = doc.BlockRecords["3D ORBIT"];
+
+			using (DwgWriter wr = new DwgWriter(Path.Combine(TestVariables.DesktopFolder, "test.dwg"), newDoc))
+			{
+				wr.Write();
+			}
 		}
 
 		[Theory]

--- a/src/ACadSharp.Tests/IO/LocalSampleTests.cs
+++ b/src/ACadSharp.Tests/IO/LocalSampleTests.cs
@@ -37,22 +37,10 @@ namespace ACadSharp.Tests.IO
 
 			CadDocument newDoc = new CadDocument();
 
-			var h = doc.GetCadObject(7819);
-
 			foreach (var entity in doc.Entities)
 			{
 				doc.Entities.Remove(entity);
 				newDoc.Entities.Add(entity);
-			}
-
-		//	var h = doc.GetCadObject(7819);
-
-			var b1 = doc.BlockRecords["3D ORBIT"];
-			var b2 = doc.BlockRecords["3D ORBIT"];
-
-			using (DwgWriter wr = new DwgWriter(Path.Combine(TestVariables.DesktopFolder, "test.dwg"), newDoc))
-			{
-				wr.Write();
 			}
 		}
 

--- a/src/ACadSharp/Entities/Hatch.cs
+++ b/src/ACadSharp/Entities/Hatch.cs
@@ -146,7 +146,7 @@ namespace ACadSharp.Entities
 			clone.GradientColor = this.GradientColor?.Clone();
 			clone.Pattern = this.Pattern?.Clone();
 
-			clone.Paths.Clear();
+			clone.Paths = new List<BoundaryPath>();
 			foreach (BoundaryPath item in this.Paths)
 			{
 				clone.Paths.Add(item.Clone());

--- a/src/ACadSharp/Entities/HatchPattern.cs
+++ b/src/ACadSharp/Entities/HatchPattern.cs
@@ -57,7 +57,7 @@ namespace ACadSharp.Entities
 		{
 			HatchPattern clone = (HatchPattern)this.MemberwiseClone();
 
-			clone.Lines.Clear();
+			clone.Lines = new List<Line>();
 			foreach (var item in this.Lines)
 			{
 				clone.Lines.Add(item.Clone());


### PR DESCRIPTION
# Description

Fix for the method `Hatch.Clone()` and `HatchPattern.Clone()`.