### PR TITLE
Dwg DxfClasses reader fix

### DIFF
--- a/src/ACadSharp/Exceptions/CadNotSupportedException.cs
+++ b/src/ACadSharp/Exceptions/CadNotSupportedException.cs
@@ -5,7 +5,7 @@ namespace ACadSharp.Exceptions
 	[Serializable]
 	public class CadNotSupportedException : NotSupportedException
 	{
-		public CadNotSupportedException() : base($"File version not recognised") { }
+		public CadNotSupportedException() : base($"File version not recognized") { }
 
 		public CadNotSupportedException(ACadVersion version) : base($"File version not supported: {version}") { }
 	}

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgClassesReader.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgClassesReader.cs
@@ -65,7 +65,7 @@ namespace ACadSharp.IO.DWG
 
 			if (this._fileHeader.AcadVersion == ACadVersion.AC1018)
 			{
-				//BS : Maxiumum class number
+				//BS : Maximum class number
 				this._sreader.ReadBitShort();
 				//RC: 0x00
 				this._sreader.ReadRawChar();
@@ -113,20 +113,10 @@ namespace ACadSharp.IO.DWG
 					//BL : Number of objects created of this type in the current DB(DXF 91).
 					dxfClass.InstanceCount = this._sreader.ReadBitLong();
 
-					if (this._fileHeader.AcadVersion == ACadVersion.AC1018)
-					{
-						//BS : Dwg Version
-						dxfClass.DwgVersion = (ACadVersion)this._sreader.ReadBitShort();
-						//BS : Maintenance release version.
-						dxfClass.MaintenanceVersion = this._sreader.ReadBitShort();
-					}
-					else if (this._fileHeader.AcadVersion > ACadVersion.AC1018)
-					{
-						//BS : Dwg Version
-						dxfClass.DwgVersion = (ACadVersion)this._sreader.ReadBitLong();
-						//BS : Maintenance release version.
-						dxfClass.MaintenanceVersion = (short)this._sreader.ReadBitLong();
-					}
+					//BS : Dwg Version
+					dxfClass.DwgVersion = (ACadVersion)this._sreader.ReadBitLong();
+					//BS : Maintenance release version.
+					dxfClass.MaintenanceVersion = (short)this._sreader.ReadBitLong();
 
 					//BL : Unknown(normally 0L)
 					this._sreader.ReadBitLong();

--- a/src/CodeMaid.config
+++ b/src/CodeMaid.config
@@ -89,6 +89,10 @@
                 serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="Cleaning_InsertBlankLinePaddingBeforeCaseStatements"
+                serializeAs="String">
+                <value>False</value>
+            </setting>
         </SteveCadwallader.CodeMaid.Properties.Settings>
     </userSettings>
 </configuration>


### PR DESCRIPTION
# Description

Found invalid values for some cases of dwg files, the fix consist into change the type of some values to the newer versions of the file.