### PR TITLE
Issue 605 cad document performance fix

### DIFF
--- a/src/ACadSharp.Tests/CadDocumentTests.cs
+++ b/src/ACadSharp.Tests/CadDocumentTests.cs
@@ -6,6 +6,7 @@ using ACadSharp.Entities;
 using Xunit.Abstractions;
 using ACadSharp.Blocks;
 using System.Linq;
+using System.Diagnostics;
 
 namespace ACadSharp.Tests
 {
@@ -13,7 +14,9 @@ namespace ACadSharp.Tests
 	{
 		public static readonly TheoryData<Type> EntityTypes;
 
-		protected readonly DocumentIntegrity _docIntegrity;
+		private readonly DocumentIntegrity _docIntegrity;
+
+		private readonly ITestOutputHelper _output;
 
 		static CadDocumentTests()
 		{
@@ -32,34 +35,37 @@ namespace ACadSharp.Tests
 
 		public CadDocumentTests(ITestOutputHelper output)
 		{
+			this._output = output;
 			this._docIntegrity = new DocumentIntegrity(output);
 		}
 
 		[Fact]
-		public void CadDocumentTest()
+		public void AddCadObjectStressTest()
 		{
 			CadDocument doc = new CadDocument();
 
-			this._docIntegrity.AssertTableHierarchy(doc);
+			Stopwatch stopwatch = new Stopwatch();
+			this._output.WriteLine("StopWatch start");
+			stopwatch.Start();
+
+			for (int i = 0; i < 10000; i++)
+			{
+				Polyline3D polyline = new Polyline3D();
+				for (int j = 0; j < 50; j++)
+				{
+					polyline.Vertices.Add(new Vertex3D() { Location = new CSMath.XYZ(i, j, 0) });
+				}
+
+				doc.Entities.Add(polyline);
+			}
+
+			stopwatch.Stop();
+			this._output.WriteLine(stopwatch.Elapsed.TotalSeconds.ToString());
+			Assert.True(stopwatch.Elapsed.TotalSeconds < 2);
 		}
 
 		[Fact]
-		public void CadDocumentDefaultTest()
-		{
-			CadDocument doc = new CadDocument();
-
-			this._docIntegrity.AssertDocumentDefaults(doc);
-			this._docIntegrity.AssertTableHierarchy(doc);
-			this._docIntegrity.AssertBlockRecords(doc);
-
-			Assert.Equal(2, doc.BlockRecords.Count);
-			Assert.Equal(1, doc.Layers.Count);
-			Assert.Equal(3, doc.LineTypes.Count);
-			Assert.Equal(2, doc.Layouts.Count());
-		}
-
-		[Fact]
-		public void AddCadObject()
+		public void AddCadObjectTest()
 		{
 			Line line = new Line();
 			CadDocument doc = new CadDocument();
@@ -94,6 +100,29 @@ namespace ACadSharp.Tests
 			Assert.False(0 == layer.Handle);
 			Assert.NotNull(doc.Layers[layer.Name]);
 			Assert.Equal(layer, doc.Layers[layer.Name]);
+		}
+
+		[Fact]
+		public void CadDocumentDefaultTest()
+		{
+			CadDocument doc = new CadDocument();
+
+			this._docIntegrity.AssertDocumentDefaults(doc);
+			this._docIntegrity.AssertTableHierarchy(doc);
+			this._docIntegrity.AssertBlockRecords(doc);
+
+			Assert.Equal(2, doc.BlockRecords.Count);
+			Assert.Equal(1, doc.Layers.Count);
+			Assert.Equal(3, doc.LineTypes.Count);
+			Assert.Equal(2, doc.Layouts.Count());
+		}
+
+		[Fact]
+		public void CadDocumentTest()
+		{
+			CadDocument doc = new CadDocument();
+
+			this._docIntegrity.AssertTableHierarchy(doc);
 		}
 
 		[Fact]
@@ -188,6 +217,27 @@ namespace ACadSharp.Tests
 		}
 
 		[Fact]
+		public void Get0HandleObject()
+		{
+			CadDocument doc = new CadDocument();
+
+			Assert.Null(doc.GetCadObject(0));
+			Assert.False(doc.TryGetCadObject(0, out CadObject cadObject));
+			Assert.Null(cadObject);
+		}
+
+		[Fact]
+		public void NotAllowDuplicate()
+		{
+			Line line = new Line();
+			CadDocument doc = new CadDocument();
+
+			doc.Entities.Add(line);
+
+			Assert.Throws<ArgumentException>(() => doc.Entities.Add(line));
+		}
+
+		[Fact]
 		public void RemoveCadObject()
 		{
 			Line line = new Line();
@@ -207,16 +257,6 @@ namespace ACadSharp.Tests
 			Assert.Null(l.Layer.Document);
 			Assert.True(0 == l.LineType.Handle);
 			Assert.Null(l.LineType.Document);
-		}
-
-		[Fact]
-		public void Get0HandleObject()
-		{
-			CadDocument doc = new CadDocument();
-
-			Assert.Null(doc.GetCadObject(0));
-			Assert.False(doc.TryGetCadObject(0, out CadObject cadObject));
-			Assert.Null(cadObject);
 		}
 
 		[Fact]
@@ -255,17 +295,6 @@ namespace ACadSharp.Tests
 			Assert.Null(ltype.Document);
 			Assert.True(ltype.Handle == 0);
 			Assert.Equal(doc.LineTypes[LineType.ByLayerName], line.LineType);
-		}
-
-		[Fact]
-		public void NotAllowDuplicate()
-		{
-			Line line = new Line();
-			CadDocument doc = new CadDocument();
-
-			doc.Entities.Add(line);
-
-			Assert.Throws<ArgumentException>(() => doc.Entities.Add(line));
 		}
 	}
 }

--- a/src/ACadSharp.Tests/CadDocumentTests.cs
+++ b/src/ACadSharp.Tests/CadDocumentTests.cs
@@ -61,7 +61,11 @@ namespace ACadSharp.Tests
 
 			stopwatch.Stop();
 			this._output.WriteLine(stopwatch.Elapsed.TotalSeconds.ToString());
-			Assert.True(stopwatch.Elapsed.TotalSeconds < 2);
+
+			if (TestVariables.LocalEnv)
+			{
+				Assert.True(stopwatch.Elapsed.TotalSeconds < 5);
+			}
 		}
 
 		[Fact]

--- a/src/ACadSharp.Tests/CadDocumentTests.cs
+++ b/src/ACadSharp.Tests/CadDocumentTests.cs
@@ -65,6 +65,29 @@ namespace ACadSharp.Tests
 		}
 
 		[Fact]
+		public void RestoreHandlesTest()
+		{
+			ulong bigHandle = 10000;
+			Line line = new Line();
+			line.Handle = bigHandle;
+
+			CadDocument doc = new CadDocument();
+
+			doc.Entities.Add(line);
+
+			doc.RestoreHandles();
+
+			CadObject l = doc.GetCadObject(line.Handle);
+
+			//Assert existing element
+			Assert.NotNull(l);
+			Assert.Equal(line, l);
+			Assert.False(0 == l.Handle);
+			Assert.Equal(line.Handle, l.Handle);
+			Assert.True(line.Handle < bigHandle);
+		}
+
+		[Fact]
 		public void AddCadObjectTest()
 		{
 			Line line = new Line();

--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>1.1.6</Version>
+		<Version>1.1.7</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 	</PropertyGroup>
 

--- a/src/ACadSharp/CadDocument.cs
+++ b/src/ACadSharp/CadDocument.cs
@@ -17,26 +17,6 @@ namespace ACadSharp
 	public class CadDocument : IHandledCadObject
 	{
 		/// <summary>
-		/// The document handle is always 0, this field makes sure that no object overrides this value.
-		/// </summary>
-		public ulong Handle { get { return 0; } }
-
-		/// <summary>
-		/// Contains all the header variables for this document.
-		/// </summary>
-		public CadHeader Header { get; internal set; }
-
-		/// <summary>
-		/// Accesses drawing properties such as the Title, Subject, Author, and Keywords properties.
-		/// </summary>
-		public CadSummaryInfo SummaryInfo { get; set; }
-
-		/// <summary>
-		/// Dxf classes defined in this document.
-		/// </summary>
-		public DxfClassCollection Classes { get; set; } = new DxfClassCollection();
-
-		/// <summary>
 		/// The collection of all registered applications in the drawing.
 		/// </summary>
 		public AppIdsTable AppIds { get; private set; }
@@ -47,9 +27,53 @@ namespace ACadSharp
 		public BlockRecordsTable BlockRecords { get; private set; }
 
 		/// <summary>
+		/// Dxf classes defined in this document.
+		/// </summary>
+		public DxfClassCollection Classes { get; set; } = new DxfClassCollection();
+
+		/// <summary>
+		/// The collection of all book colors in the drawing.
+		/// </summary>
+		/// <remarks>
+		/// The collection is null if the <see cref="CadDictionary.AcadColor"/> doesn't exist in the root dictionary.
+		/// </remarks>
+		public ColorCollection Colors { get; private set; }
+
+		/// <summary>
 		/// The collection of all dimension styles in the drawing.
 		/// </summary>
 		public DimensionStylesTable DimensionStyles { get; private set; }
+
+		/// <summary>
+		/// Collection with all the entities in the drawing
+		/// </summary>
+		public CadObjectCollection<Entity> Entities { get { return this.ModelSpace.Entities; } }
+
+		/// <summary>
+		/// The collection of all groups in the drawing.
+		/// </summary>
+		/// <remarks>
+		/// The collection is null if the <see cref="CadDictionary.AcadGroup"/> doesn't exist in the root dictionary.
+		/// </remarks>
+		public GroupCollection Groups { get; private set; }
+
+		/// <summary>
+		/// The document handle is always 0, this field makes sure that no object overrides this value.
+		/// </summary>
+		public ulong Handle { get { return 0; } }
+
+		/// <summary>
+		/// Contains all the header variables for this document.
+		/// </summary>
+		public CadHeader Header { get; internal set; }
+
+		/// <summary>
+		/// The collection of all images in the drawing.
+		/// </summary>
+		/// <remarks>
+		/// The collection is null if the <see cref="CadDictionary.AcadImageDict"/> doesn't exist in the root dictionary.
+		/// </remarks>
+		public ImageDefinitionCollection ImageDefinitions { get; private set; }
 
 		/// <summary>
 		/// The collection of all layers in the drawing.
@@ -57,9 +81,70 @@ namespace ACadSharp
 		public LayersTable Layers { get; private set; }
 
 		/// <summary>
-		/// The collection of all linetypes in the drawing.
+		/// The collection of all layouts in the drawing.
+		/// </summary>
+		/// <remarks>
+		/// The collection is null if the <see cref="CadDictionary.AcadLayout"/> doesn't exist in the root dictionary.
+		/// </remarks>
+		public LayoutCollection Layouts { get; private set; }
+
+		/// <summary>
+		/// The collection of all line types in the drawing.
 		/// </summary>
 		public LineTypesTable LineTypes { get; private set; }
+
+		/// <summary>
+		/// The collection of all Multi leader styles in the drawing.
+		/// </summary>
+		/// <remarks>
+		/// The collection is null if the <see cref="CadDictionary.AcadMLeaderStyle"/> doesn't exist in the root dictionary.
+		/// </remarks>
+		public MLeaderStyleCollection MLeaderStyles { get; private set; }
+
+		/// <summary>
+		/// The collection of all Multi line styles in the drawing.
+		/// </summary>
+		/// <remarks>
+		/// The collection is null if the <see cref="CadDictionary.AcadMLineStyle"/> doesn't exist in the root dictionary.
+		/// </remarks>
+		public MLineStyleCollection MLineStyles { get; private set; }
+
+		/// <summary>
+		/// Model space block record containing the drawing
+		/// </summary>
+		public BlockRecord ModelSpace { get { return this.BlockRecords[BlockRecord.ModelSpaceName]; } }
+
+		/// <summary>
+		/// Default paper space of the model
+		/// </summary>
+		public BlockRecord PaperSpace { get { return this.BlockRecords[BlockRecord.PaperSpaceName]; } }
+
+		/// <summary>
+		/// Root dictionary of the document.
+		/// </summary>
+		public CadDictionary RootDictionary
+		{
+			get { return this._rootDictionary; }
+			internal set
+			{
+				this._rootDictionary = value;
+				this._rootDictionary.Owner = this;
+				this.RegisterCollection(this._rootDictionary);
+			}
+		}
+
+		/// <summary>
+		/// The collection of all scales in the drawing.
+		/// </summary>
+		/// <remarks>
+		/// The collection is null if the <see cref="CadDictionary.AcadScaleList"/> doesn't exist in the root dictionary.
+		/// </remarks>
+		public ScaleCollection Scales { get; private set; }
+
+		/// <summary>
+		/// Accesses drawing properties such as the Title, Subject, Author, and Keywords properties.
+		/// </summary>
+		public CadSummaryInfo SummaryInfo { get; set; }
 
 		/// <summary>
 		/// The collection of all text styles in the drawing.
@@ -81,113 +166,18 @@ namespace ACadSharp
 		/// </summary>
 		public VPortsTable VPorts { get; private set; }
 
-		/// <summary>
-		/// The collection of all book colors in the drawing.
-		/// </summary>
-		/// <remarks>
-		/// The collection is null if the <see cref="CadDictionary.AcadColor"/> doesn't exist in the root dictionary.
-		/// </remarks>
-		public ColorCollection Colors { get; private set; }
-
-		/// <summary>
-		/// The collection of all layouts in the drawing.
-		/// </summary>
-		/// <remarks>
-		/// The collection is null if the <see cref="CadDictionary.AcadLayout"/> doesn't exist in the root dictionary.
-		/// </remarks>
-		public LayoutCollection Layouts { get; private set; }
-
-		/// <summary>
-		/// The collection of all groups in the drawing. 
-		/// </summary>
-		/// <remarks>
-		/// The collection is null if the <see cref="CadDictionary.AcadGroup"/> doesn't exist in the root dictionary.
-		/// </remarks>
-		public GroupCollection Groups { get; private set; }
-
-		/// <summary>
-		/// The collection of all scales in the drawing. 
-		/// </summary>
-		/// <remarks>
-		/// The collection is null if the <see cref="CadDictionary.AcadScaleList"/> doesn't exist in the root dictionary.
-		/// </remarks>
-		public ScaleCollection Scales { get; private set; }
-
-		/// <summary>
-		/// The collection of all Multi line styles in the drawing. 
-		/// </summary>
-		/// <remarks>
-		/// The collection is null if the <see cref="CadDictionary.AcadMLineStyle"/> doesn't exist in the root dictionary.
-		/// </remarks>
-		public MLineStyleCollection MLineStyles { get; private set; }
-
-		/// <summary>
-		/// The collection of all images in the drawing. 
-		/// </summary>
-		/// <remarks>
-		/// The collection is null if the <see cref="CadDictionary.AcadImageDict"/> doesn't exist in the root dictionary.
-		/// </remarks>
-		public ImageDefinitionCollection ImageDefinitions { get; private set; }
-
-		/// <summary>
-		/// The collection of all Multi leader styles in the drawing. 
-		/// </summary>
-		/// <remarks>
-		/// The collection is null if the <see cref="CadDictionary.AcadMLeaderStyle"/> doesn't exist in the root dictionary.
-		/// </remarks>
-		public MLeaderStyleCollection MLeaderStyles { get; private set; }
-
-		/// <summary>
-		/// Root dictionary of the document.
-		/// </summary>
-		public CadDictionary RootDictionary
-		{
-			get { return this._rootDictionary; }
-			internal set
-			{
-				this._rootDictionary = value;
-				this._rootDictionary.Owner = this;
-				this.RegisterCollection(this._rootDictionary);
-			}
-		}
-
-		/// <summary>
-		/// Collection with all the entities in the drawing
-		/// </summary>
-		public CadObjectCollection<Entity> Entities { get { return this.ModelSpace.Entities; } }
-
-		/// <summary>
-		/// Model space block record containing the drawing
-		/// </summary>
-		public BlockRecord ModelSpace { get { return this.BlockRecords[BlockRecord.ModelSpaceName]; } }
-
-		/// <summary>
-		/// Default paper space of the model
-		/// </summary>
-		public BlockRecord PaperSpace { get { return this.BlockRecords[BlockRecord.PaperSpaceName]; } }
-
-		private CadDictionary _rootDictionary = null;
-
 		//Contains all the objects in the document
 		private readonly Dictionary<ulong, IHandledCadObject> _cadObjects = new Dictionary<ulong, IHandledCadObject>();
 
-		internal CadDocument(bool createDefaults)
-		{
-			this._cadObjects.Add(this.Handle, this);
-
-			if (createDefaults)
-			{
-				this.CreateDefaults();
-			}
-		}
+		private CadDictionary _rootDictionary = null;
 
 		/// <summary>
 		/// Creates a document with the default objects
 		/// </summary>
 		/// <remarks>
-		/// Default version <see cref="ACadVersion.AC1018"/>
+		/// Default version <see cref="ACadVersion.AC1032"/>
 		/// </remarks>
-		public CadDocument() : this(ACadVersion.AC1018) { }
+		public CadDocument() : this(ACadVersion.AC1032) { }
 
 		/// <summary>
 		/// Creates a document with the default objects and a specific version
@@ -198,55 +188,14 @@ namespace ACadSharp
 			this.Header.Version = version;
 		}
 
-		/// <summary>
-		/// Gets an object in the document by it's handle
-		/// </summary>
-		/// <param name="handle"></param>
-		/// <returns>the cadObject or null if doesn't exists in the document</returns>
-		public CadObject GetCadObject(ulong handle)
+		internal CadDocument(bool createDefaults)
 		{
-			return this.GetCadObject<CadObject>(handle);
-		}
+			this._cadObjects.Add(this.Handle, this);
 
-		/// <summary>
-		/// Gets an object in the document by it's handle
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="handle"></param>
-		/// <returns>the cadObject or null if doesn't exists in the document</returns>
-		public T GetCadObject<T>(ulong handle)
-			where T : CadObject
-		{
-			if (this._cadObjects.TryGetValue(handle, out IHandledCadObject obj))
+			if (createDefaults)
 			{
-				return obj as T;
+				this.CreateDefaults();
 			}
-
-			return null;
-		}
-
-		/// <summary>
-		/// Gets an object in the document by it's handle
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="handle"></param>
-		/// <param name="cadObject"></param>
-		/// <returns></returns>
-		public bool TryGetCadObject<T>(ulong handle, out T cadObject)
-			where T : CadObject
-		{
-			cadObject = null;
-
-			if (handle == this.Handle)
-				return false;
-
-			if (this._cadObjects.TryGetValue(handle, out IHandledCadObject obj))
-			{
-				cadObject = obj as T;
-				return true;
-			}
-
-			return false;
 		}
 
 		/// <summary>
@@ -308,6 +257,81 @@ namespace ACadSharp
 		}
 
 		/// <summary>
+		/// Gets an object in the document by it's handle
+		/// </summary>
+		/// <param name="handle"></param>
+		/// <returns>the cadObject or null if doesn't exists in the document</returns>
+		public CadObject GetCadObject(ulong handle)
+		{
+			return this.GetCadObject<CadObject>(handle);
+		}
+
+		/// <summary>
+		/// Gets an object in the document by it's handle
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="handle"></param>
+		/// <returns>the cadObject or null if doesn't exists in the document</returns>
+		public T GetCadObject<T>(ulong handle)
+			where T : CadObject
+		{
+			if (this._cadObjects.TryGetValue(handle, out IHandledCadObject obj))
+			{
+				return obj as T;
+			}
+
+			return null;
+		}
+
+		/// <summary>
+		/// Reassign all the handles in the document to avoid the variable <see cref="CadHeader.HandleSeed"/> to grow past its limit.
+		/// </summary>
+		public void RestoreHandles()
+		{
+			var source = new List<IHandledCadObject>(this._cadObjects.Values);
+			this._cadObjects.Clear();
+			this.Header.HandleSeed = 0;
+
+			this._cadObjects.Add(this.Header.HandleSeed, this);
+
+			var nextHandle = this.Header.HandleSeed + 1;
+
+			foreach (var item in source.Skip(1))
+			{
+				(item as CadObject).Handle = nextHandle;
+				nextHandle += 1;
+
+				this._cadObjects.Add(item.Handle, item);
+			}
+
+			this.Header.HandleSeed = nextHandle;
+		}
+
+		/// <summary>
+		/// Gets an object in the document by it's handle
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="handle"></param>
+		/// <param name="cadObject"></param>
+		/// <returns></returns>
+		public bool TryGetCadObject<T>(ulong handle, out T cadObject)
+			where T : CadObject
+		{
+			cadObject = null;
+
+			if (handle == this.Handle)
+				return false;
+
+			if (this._cadObjects.TryGetValue(handle, out IHandledCadObject obj))
+			{
+				cadObject = obj as T;
+				return true;
+			}
+
+			return false;
+		}
+
+		/// <summary>
 		/// Updates the collections in the document and link them to it's dictionary
 		/// </summary>
 		/// <param name="createDictionaries"></param>
@@ -355,86 +379,6 @@ namespace ACadSharp
 			if (this.updateCollection(CadDictionary.AcadColor, createDictionaries, out CadDictionary colors))
 			{
 				this.Colors = new ColorCollection(colors);
-			}
-		}
-
-		private bool updateCollection(string dictName, bool createDictionary, out CadDictionary dictionary)
-		{
-			if (this.RootDictionary.TryGetEntry(dictName, out dictionary))
-			{
-				return true;
-			}
-			else if (createDictionary)
-			{
-				dictionary = new CadDictionary(dictName);
-				this.RootDictionary.Add(dictionary);
-			}
-
-			return dictionary != null;
-		}
-
-		private void addCadObject(CadObject cadObject)
-		{
-			if (cadObject.Document != null)
-			{
-				throw new ArgumentException($"The item with handle {cadObject.Handle} is already assigned to a document");
-			}
-
-			if (cadObject.Handle == 0 || this._cadObjects.ContainsKey(cadObject.Handle))
-			{
-				var nextHandle = this.Header.HandleSeed + 1;
-
-				cadObject.Handle = nextHandle;
-				this.Header.HandleSeed = nextHandle;
-			}
-			else if (cadObject.Handle > this.Header.HandleSeed)
-			{
-				this.Header.HandleSeed = cadObject.Handle;
-			}
-
-			this._cadObjects.Add(cadObject.Handle, cadObject);
-
-			if (cadObject is BlockRecord record)
-			{
-				this.addCadObject(record.BlockEntity);
-				this.addCadObject(record.BlockEnd);
-			}
-
-			cadObject.AssignDocument(this);
-		}
-
-		private void removeCadObject(CadObject cadObject)
-		{
-			if (!this.TryGetCadObject(cadObject.Handle, out CadObject _)
-				|| !this._cadObjects.Remove(cadObject.Handle))
-			{
-				return;
-			}
-
-			cadObject.UnassignDocument();
-		}
-
-		private void onAdd(object sender, CollectionChangedEventArgs e)
-		{
-			if (e.Item is CadDictionary dictionary)
-			{
-				this.RegisterCollection(dictionary);
-			}
-			else
-			{
-				this.addCadObject(e.Item);
-			}
-		}
-
-		private void onRemove(object sender, CollectionChangedEventArgs e)
-		{
-			if (e.Item is CadDictionary dictionary)
-			{
-				this.UnregisterCollection(dictionary);
-			}
-			else
-			{
-				this.removeCadObject(e.Item);
 			}
 		}
 
@@ -560,6 +504,86 @@ namespace ACadSharp
 					this.removeCadObject(item);
 				}
 			}
+		}
+
+		private void addCadObject(CadObject cadObject)
+		{
+			if (cadObject.Document != null)
+			{
+				throw new ArgumentException($"The item with handle {cadObject.Handle} is already assigned to a document");
+			}
+
+			if (cadObject.Handle == 0 || this._cadObjects.ContainsKey(cadObject.Handle))
+			{
+				var nextHandle = this.Header.HandleSeed + 1;
+
+				cadObject.Handle = nextHandle;
+				this.Header.HandleSeed = nextHandle;
+			}
+			else if (cadObject.Handle > this.Header.HandleSeed)
+			{
+				this.Header.HandleSeed = cadObject.Handle;
+			}
+
+			this._cadObjects.Add(cadObject.Handle, cadObject);
+
+			if (cadObject is BlockRecord record)
+			{
+				this.addCadObject(record.BlockEntity);
+				this.addCadObject(record.BlockEnd);
+			}
+
+			cadObject.AssignDocument(this);
+		}
+
+		private void onAdd(object sender, CollectionChangedEventArgs e)
+		{
+			if (e.Item is CadDictionary dictionary)
+			{
+				this.RegisterCollection(dictionary);
+			}
+			else
+			{
+				this.addCadObject(e.Item);
+			}
+		}
+
+		private void onRemove(object sender, CollectionChangedEventArgs e)
+		{
+			if (e.Item is CadDictionary dictionary)
+			{
+				this.UnregisterCollection(dictionary);
+			}
+			else
+			{
+				this.removeCadObject(e.Item);
+			}
+		}
+
+		private void removeCadObject(CadObject cadObject)
+		{
+			if (!this.TryGetCadObject(cadObject.Handle, out CadObject _)
+				|| !this._cadObjects.Remove(cadObject.Handle))
+			{
+				return;
+			}
+
+			cadObject.UnassignDocument();
+		}
+
+		private bool updateCollection(string dictName, bool createDictionary, out CadDictionary dictionary)
+		{
+			if (this.RootDictionary.TryGetEntry(dictName, out dictionary))
+			{
+				return true;
+			}
+			else if (createDictionary)
+			{
+				dictionary = new CadDictionary(dictName);
+				this.RootDictionary.Add(dictionary);
+			}
+
+			return dictionary != null;
 		}
 	}
 }

--- a/src/ACadSharp/CadDocument.cs
+++ b/src/ACadSharp/CadDocument.cs
@@ -382,15 +382,14 @@ namespace ACadSharp
 
 			if (cadObject.Handle == 0 || this._cadObjects.ContainsKey(cadObject.Handle))
 			{
-				var nextHandle = this._cadObjects.Keys.Max() + 1;
-				if (nextHandle < this.Header.HandleSeed)
-				{
-					nextHandle = this.Header.HandleSeed;
-				}
+				var nextHandle = this.Header.HandleSeed + 1;
 
 				cadObject.Handle = nextHandle;
-
-				this.Header.HandleSeed = nextHandle + 1;
+				this.Header.HandleSeed = nextHandle;
+			}
+			else if (cadObject.Handle > this.Header.HandleSeed)
+			{
+				this.Header.HandleSeed = cadObject.Handle;
 			}
 
 			this._cadObjects.Add(cadObject.Handle, cadObject);


### PR DESCRIPTION
# Description

Performance fix for the `addCadObject` to the `CadDocument` to increase the speed and avoid unnecessary iterations.

# Tasks done in this PR
* [x] Performance fix.
* [x] Added the method to restore handles.
