### PR TITLE
Escape special characters when writing strings to svg

### DIFF
--- a/src/ACadSharp/IO/SVG/SvgXmlWriter.cs
+++ b/src/ACadSharp/IO/SVG/SvgXmlWriter.cs
@@ -394,7 +394,7 @@ namespace ACadSharp.IO.SVG
 						this.WriteStartElement("tspan");
 						this.WriteAttributeString("x", 0);
 						this.WriteAttributeString("dy", "1em");
-						this.WriteRaw(item);
+						this.WriteString(item);
 						this.WriteEndElement();
 					}
 					break;
@@ -414,7 +414,7 @@ namespace ACadSharp.IO.SVG
 							break;
 					}
 
-					this.WriteRaw(text.Value);
+					this.WriteString(text.Value);
 					break;
 			}
 


### PR DESCRIPTION
Use writestring to allow escaping special symbols.

# Description

When a string/text contains & or other special symbols it should be escaped, not written raw to svg.

# Tasks done in this PR
* [ ] Something awesome.
* [x] An evil bug have been defeated.
* [ ] Code cleanup and maintenance has been done.
