### PR TITLE
issue-649 XRecord

### DIFF
--- a/src/ACadSharp.Tests/IO/WriterSingleObjectTests.cs
+++ b/src/ACadSharp.Tests/IO/WriterSingleObjectTests.cs
@@ -71,6 +71,7 @@ namespace ACadSharp.Tests.IO
 			Data.Add(new(nameof(SingleCaseGenerator.LineTypeInBlock)));
 			Data.Add(new(nameof(SingleCaseGenerator.XData)));
 			Data.Add(new(nameof(SingleCaseGenerator.SPlineCreation)));
+			Data.Add(new(nameof(SingleCaseGenerator.CreateXRecords)));
 		}
 
 		public WriterSingleObjectTests(ITestOutputHelper output) : base(output)
@@ -408,6 +409,23 @@ namespace ACadSharp.Tests.IO
 				Layout layout = new Layout("my_layout");
 
 				this.Document.Layouts.Add(layout);
+			}
+
+			public void CreateXRecords()
+			{
+				Layer lay = new Layer("my_layer");
+
+				//Extracted form a real case
+				var dict = lay.CreateExtendedDictionary();
+				var layerstates = new CadDictionary("ACAD_LAYERSTATES");
+				dict.Add(layerstates);
+
+				XRecord record = new XRecord("test");
+				record.CreateEntry(90, 1);
+				record.CreateEntry(330, Document.Layers);
+				layerstates.Add(record);
+
+				this.Document.Layers.Add(lay);
 			}
 
 			public void CurrentEntityByBlock()

--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>1.1.20</Version>
+		<Version>1.1.21</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 	</PropertyGroup>
 

--- a/src/ACadSharp/IO/CadWriterConfiguration.cs
+++ b/src/ACadSharp/IO/CadWriterConfiguration.cs
@@ -16,10 +16,10 @@ namespace ACadSharp.IO
 		public bool CloseStream { get; set; } = true;
 
 		/// <summary>
-		/// Will not ignore the <see cref="ACadSharp.Objects.XRecord"/> objects in the document.
+		/// The writer will not ignore the <see cref="ACadSharp.Objects.XRecord"/> objects in the document.
 		/// </summary>
 		/// <remarks>
-		/// Due the complexity of XRecords, if this flag is set to true, it may cause a corruption of the file if the records have been modified manually.
+		/// Due the complexity of XRecords, if this flag is set to true, it may cause a corruption of the file.
 		/// </remarks>
 		/// <value>
 		/// default: false
@@ -27,7 +27,7 @@ namespace ACadSharp.IO
 		public bool WriteXRecords { get; set; } = false;
 
 		/// <summary>
-		/// Will not ignore the <see cref="ACadSharp.XData.ExtendedData"/> collection in the <see cref="CadObject"/>.
+		/// The writer will not ignore the <see cref="ACadSharp.XData.ExtendedData"/> collection in the <see cref="CadObject"/>.
 		/// </summary>
 		/// <value>
 		/// default: true
@@ -40,6 +40,9 @@ namespace ACadSharp.IO
 		/// <remarks>
 		/// Sometimes the files are corrupted by badly formed dxf classes, is recommended to keep this flag set.
 		/// </remarks>
+		/// <value>
+		/// default: true
+		/// </value>
 		public bool ResetDxfClasses { get; set; } = true;
 	}
 }

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
@@ -774,7 +774,7 @@ namespace ACadSharp.IO.DWG
 			ms.EndianConverter = new LittleEndianConverter();
 
 			foreach (XRecord.Entry entry in xrecord.Entries)
-			{
+			{				
 				if (entry.Value == null)
 				{
 					continue;

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
@@ -3,6 +3,7 @@ using ACadSharp.Objects.Evaluations;
 using CSMath;
 using CSUtilities.Converters;
 using CSUtilities.IO;
+using CSUtilities.Text;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -835,12 +836,12 @@ namespace ACadSharp.IO.DWG
 						else if (string.IsNullOrEmpty(text))
 						{
 							ms.Write<short, LittleEndianConverter>(0);
-							ms.Write((byte)this._writer.Encoding.CodePage);
+							ms.Write((byte)CadUtils.GetCodeIndex((CodePage)this._writer.Encoding.CodePage));
 						}
 						else
 						{
 							ms.Write<short, LittleEndianConverter>((short)text.Length);
-							ms.Write((byte)this._writer.Encoding.CodePage);
+							ms.Write((byte)CadUtils.GetCodeIndex((CodePage)this._writer.Encoding.CodePage));
 							ms.Write(text, this._writer.Encoding);
 						}
 						break;


### PR DESCRIPTION
# Description

Fix the writing for older versions XRecord.

# Notes

There is an issue with some XRecords pointing to handles or objects that `ACadSharp` doesn't support, for example adding this guard to the method writeXRecords for a dwg file fixes some of the recovery issues:

```C#
if(entry.Value.ToString() == "MATERIAL")
{
	continue;
}
```

It seems that the `XRecord` is expecting or indicating a material (not specified there is only the name) but Autocad is not able to read it so is discarded.