### PR TITLE
Support ACDB_MLEADEROBJECTCONTEXTDATA_CLASS

### DIFF
--- a/src/ACadSharp/Classes/DxfClassCollection.cs
+++ b/src/ACadSharp/Classes/DxfClassCollection.cs
@@ -426,6 +426,18 @@ namespace ACadSharp.Classes
 				ProxyFlags = ProxyFlags.EraseAllowed | ProxyFlags.DisablesProxyWarningDialog,
 				WasZombie = false,
 			});
+
+			//AcDbMLeaderObjectContextData
+			doc.Classes.AddOrUpdate(new DxfClass {
+				CppClassName = DxfSubclassMarker.MultiLeaderObjectContextData,
+				ClassNumber = (short)(500 + doc.Classes.Count),
+				DwgVersion = ACadVersion.MC0_0,
+				DxfName = DxfFileToken.ObjectMLeaderContextData,
+				ItemClassId = 499,
+				MaintenanceVersion = 0,
+				ProxyFlags = ProxyFlags.EraseAllowed | ProxyFlags.DisablesProxyWarningDialog,
+				WasZombie = false,
+			});
 		}
 
 		/// <summary>

--- a/src/ACadSharp/DxfFileToken.cs
+++ b/src/ACadSharp/DxfFileToken.cs
@@ -125,7 +125,7 @@
 		public const string ObjectScale = "SCALE";
 		public const string ObjectSortEntsTable = "SORTENTSTABLE";
 		public const string ObjectXRecord = "XRECORD";
-		public const string ObjectMLeaderContextData = "CONTEXT_DATA";
+		public const string ObjectMLeaderContextData = "ACDB_MLEADEROBJECTCONTEXTDATA_CLASS";
 		public const string ObjectEvalGraph = "ACAD_EVALUATION_GRAPH";
 		public const string ObjectBlockLinearParameter = "BLOCKLINEARPARAMETER";
 		public const string ObjectBlockVisibilityParameter = "BLOCKVISIBILITYPARAMETER";

--- a/src/ACadSharp/DxfSubclassMarker.cs
+++ b/src/ACadSharp/DxfSubclassMarker.cs
@@ -47,7 +47,7 @@
 		public const string Material = "AcDbMaterial";
 		public const string MultiLeader = "AcDbMLeader";
 		public const string MLeaderStyle = "AcDbMLeaderStyle";
-		public const string MultiLeaderAnnotContext = "AcDbMultiLeaderAnnotContext";
+		public const string MultiLeaderObjectContextData = "AcDbMLeaderObjectContextData";
 		public const string LwPolyline = "AcDbPolyline";
 		public const string PolylineVertex = "AcDb2dVertex";
 		public const string Polyline3d = "AcDb3dPolyline";
@@ -85,6 +85,8 @@
 		public const string DictionaryVariables = "DictionaryVariables";
 		public const string Scale = "AcDbScale";
 		public const string GeoData = "AcDbGeoData";
+		public const string ObjectContextData = "AcDbObjectContextData";
+		public const string AnnotScaleObjectContextData = "AcDbAnnotScaleObjectContextData";
 
 		//Dynamic block constants
 		public const string EvalGraph = "AcDbEvalGraph";

--- a/src/ACadSharp/Entities/MultiLeader.cs
+++ b/src/ACadSharp/Entities/MultiLeader.cs
@@ -34,9 +34,9 @@ namespace ACadSharp.Entities
 		/// </summary>
 		/// <remarks>
 		/// The value for all leader lines can be overridden for each individual leader line by the
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.Arrowhead"/> property when the
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.Arrowhead"/> property when the
 		/// <see cref="LeaderLinePropertOverrideFlags.Arrowhead"/> flag is set in the
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.OverrideFlags"/> property.
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.OverrideFlags"/> property.
 		/// </remarks>
 		[DxfCodeValue(DxfReferenceType.Handle, 342)]
 		public BlockRecord Arrowhead
@@ -57,12 +57,12 @@ namespace ACadSharp.Entities
 		/// <remarks>
 		/// <para>
 		/// The value for all leader lines can be overridden for each individual leader line by the
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.ArrowheadSize"/> property when the
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.ArrowheadSize"/> property when the
 		/// <see cref="LeaderLinePropertOverrideFlags.ArrowheadSize"/> flag is set in the
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.OverrideFlags"/> property.
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.OverrideFlags"/> property.
 		/// </para><para>
-		/// This property is also exposed by the <see cref="MultiLeaderAnnotContext"/> class. Values
-		/// should be equal, the value <see cref="MultiLeaderAnnotContext.ArrowheadSize"/> is
+		/// This property is also exposed by the <see cref="MultiLeaderObjectContextData"/> class. Values
+		/// should be equal, the value <see cref="MultiLeaderObjectContextData.ArrowheadSize"/> is
 		/// assumed to be used.
 		/// </para>
 		/// </remarks>
@@ -86,7 +86,7 @@ namespace ACadSharp.Entities
 		/// <summary>
 		/// Contains the multileader content (block/text) and the leaders.
 		/// </summary>
-		public MultiLeaderAnnotContext ContextData { get; private set; } = new MultiLeaderAnnotContext();
+		public MultiLeaderObjectContextData ContextData { get; private set; } = new MultiLeaderObjectContextData();
 
 		/// <summary>
 		/// Enable Annotation Scale
@@ -126,7 +126,7 @@ namespace ACadSharp.Entities
 		/// </summary>
 		/// <remarks><para>
 		/// There is only one field for the landing distance in the multileader property grid.
-		/// The value entered arrives in this property and the <see cref="Objects.MultiLeaderAnnotContext.LeaderRoot.LandingDistance"/>
+		/// The value entered arrives in this property and the <see cref="Objects.MultiLeaderObjectContextData.LeaderRoot.LandingDistance"/>
 		/// property. If two leader roots exist both receive the same value. I seems
 		/// <see cref="MultiLeaderPropertyOverrideFlags.LandingDistance"/> flag is never set.
 		/// </para>
@@ -144,9 +144,9 @@ namespace ACadSharp.Entities
 		/// </summary>
 		/// <remarks>
 		/// The setting for all leader lines can be overridden for each individual leader line by the
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.LineType"/> property when the
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.LineType"/> property when the
 		/// <see cref="LeaderLinePropertOverrideFlags.LineType"/> flag is set in the
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.OverrideFlags"/> property.
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.OverrideFlags"/> property.
 		/// </remarks>
 		[DxfCodeValue(DxfReferenceType.Handle, 341)]
 		public LineType LeaderLineType
@@ -180,9 +180,9 @@ namespace ACadSharp.Entities
 		/// </summary>
 		/// <remarks>
 		/// The value for all leader lines can be overridden for each individual leader line by the
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.LineWeight"/> property when the
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.LineWeight"/> property when the
 		/// <see cref="LeaderLinePropertOverrideFlags.LineWeight"/> flag is set in the
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.OverrideFlags"/> property.
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.OverrideFlags"/> property.
 		/// </remarks>
 		[DxfCodeValue(171)]
 		public LineweightType LeaderLineWeight { get; set; }
@@ -196,9 +196,9 @@ namespace ACadSharp.Entities
 		/// </summary>
 		/// <remarks>
 		/// The value for all leader lines can be overridden for each individual leader line by the
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.LineColor"/> property when the
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.LineColor"/> property when the
 		/// <see cref="LeaderLinePropertOverrideFlags.LineColor"/> flag is set in the
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.OverrideFlags"/> property.
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.OverrideFlags"/> property.
 		/// </remarks>
 		[DxfCodeValue(91)]
 		public Color LineColor { get; set; }
@@ -223,7 +223,7 @@ namespace ACadSharp.Entities
 		/// Gets or sets a value containing a list of flags indicating which multileader
 		/// properties specified by the associated <see cref="MultiLeaderStyle"/>
 		/// are to be overridden by properties specified by this <see cref="MultiLeader"/>
-		/// or the attached <see cref="MultiLeaderAnnotContext"/>.
+		/// or the attached <see cref="MultiLeaderObjectContextData"/>.
 		/// </summary>
 		[DxfCodeValue(90)]
 		public MultiLeaderPropertyOverrideFlags PropertyOverrideFlags { get; set; }
@@ -236,8 +236,8 @@ namespace ACadSharp.Entities
 		/// The scale factor is applied by AutoCAD.
 		/// </summary>
 		/// <remarks>
-		/// This property is also exposed by the <see cref="MultiLeaderAnnotContext"/> class. Values
-		/// should be equal, the value <see cref="MultiLeaderAnnotContext.ScaleFactor"/> is
+		/// This property is also exposed by the <see cref="MultiLeaderObjectContextData"/> class. Values
+		/// should be equal, the value <see cref="MultiLeaderObjectContextData.ScaleFactor"/> is
 		/// assumed to be relevant.
 		/// </remarks>
 		[DxfCodeValue(45)]
@@ -282,8 +282,8 @@ namespace ACadSharp.Entities
 		/// DXF reference as <i>Text Aligment Type</i>.
 		/// Available DWG and DXF sample documents saved by AutoCAD return always 0=Left.
 		/// </para><para>
-		/// This property is also exposed by the <see cref="MultiLeaderAnnotContext"/> class. Values
-		/// should be equal, the value <see cref="MultiLeaderAnnotContext.TextAlignment"/> is
+		/// This property is also exposed by the <see cref="MultiLeaderObjectContextData"/> class. Values
+		/// should be equal, the value <see cref="MultiLeaderObjectContextData.TextAlignment"/> is
 		/// assumed to be used.
 		/// </para>
 		/// </remarks>
@@ -307,8 +307,8 @@ namespace ACadSharp.Entities
 		/// <see cref="PropertyOverrideFlags"/> property).
 		/// </summary>
 		/// <remarks>
-		/// This property is also exposed by the <see cref="MultiLeaderAnnotContext"/> class. Values
-		/// should be equal, the value <see cref="MultiLeaderAnnotContext.TextColor"/> is
+		/// This property is also exposed by the <see cref="MultiLeaderObjectContextData"/> class. Values
+		/// should be equal, the value <see cref="MultiLeaderObjectContextData.TextColor"/> is
 		/// assumed to be used.
 		/// </remarks>
 		[DxfCodeValue(92)]
@@ -330,8 +330,8 @@ namespace ACadSharp.Entities
 		/// <see cref="PropertyOverrideFlags"/> property).
 		/// </summary>
 		/// <remarks>
-		/// This property is also exposed by the <see cref="MultiLeaderAnnotContext"/> class. Values
-		/// should be equal, the value <see cref="MultiLeaderAnnotContext.TextLeftAttachment"/> is
+		/// This property is also exposed by the <see cref="MultiLeaderObjectContextData"/> class. Values
+		/// should be equal, the value <see cref="MultiLeaderObjectContextData.TextLeftAttachment"/> is
 		/// assumed to be used.
 		/// </remarks>
 		/// <value>
@@ -348,8 +348,8 @@ namespace ACadSharp.Entities
 		/// <see cref="PropertyOverrideFlags"/> property).
 		/// </summary>
 		/// <remarks>
-		/// This property is also exposed by the <see cref="MultiLeaderAnnotContext"/> class. Values
-		/// should be equal, the value <see cref="MultiLeaderAnnotContext.TextRightAttachment"/> is
+		/// This property is also exposed by the <see cref="MultiLeaderObjectContextData"/> class. Values
+		/// should be equal, the value <see cref="MultiLeaderObjectContextData.TextRightAttachment"/> is
 		/// assumed to be used.
 		/// </remarks>
 		/// <value>
@@ -367,9 +367,9 @@ namespace ACadSharp.Entities
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </summary>
 		/// <remarks>
-		/// This property is also exposed by the <see cref="MultiLeaderAnnotContext"/> class
-		/// (<see cref="MultiLeaderAnnotContext.TextStyle"/>).
-		/// Values should be equal, the <see cref="MultiLeaderAnnotContext.TextStyle"/>
+		/// This property is also exposed by the <see cref="MultiLeaderObjectContextData"/> class
+		/// (<see cref="MultiLeaderObjectContextData.TextStyle"/>).
+		/// Values should be equal, the <see cref="MultiLeaderObjectContextData.TextStyle"/>
 		/// is assumed to be used.
 		/// </remarks>
 		[DxfCodeValue(DxfReferenceType.Handle, 343)]
@@ -406,8 +406,8 @@ namespace ACadSharp.Entities
 		/// <see cref="PropertyOverrideFlags"/> property).
 		/// </summary>
 		/// <remarks>
-		/// This property is also exposed by the <see cref="MultiLeaderAnnotContext"/> class. Values
-		/// should be equal, the value <see cref="MultiLeaderAnnotContext.BlockContent"/> is
+		/// This property is also exposed by the <see cref="MultiLeaderObjectContextData"/> class. Values
+		/// should be equal, the value <see cref="MultiLeaderObjectContextData.BlockContent"/> is
 		/// assumed to be used.
 		/// </remarks>
 		[DxfCodeValue(DxfReferenceType.Handle, 344)]
@@ -428,8 +428,8 @@ namespace ACadSharp.Entities
 		/// <see cref="PropertyOverrideFlags"/> property).
 		/// </summary>
 		/// <remarks>
-		/// This property is also exposed by the <see cref="MultiLeaderAnnotContext"/> class. Values
-		/// should be equal, the value <see cref="MultiLeaderAnnotContext.BlockContentColor"/> is
+		/// This property is also exposed by the <see cref="MultiLeaderObjectContextData"/> class. Values
+		/// should be equal, the value <see cref="MultiLeaderObjectContextData.BlockContentColor"/> is
 		/// assumed to be used.
 		/// </remarks>
 		[DxfCodeValue(93)]
@@ -442,8 +442,8 @@ namespace ACadSharp.Entities
 		/// <see cref="PropertyOverrideFlags"/> property.
 		/// </summary>
 		/// <remarks>
-		/// This property is also exposed by the <see cref="MultiLeaderAnnotContext"/> class. Values
-		/// should be equal, the value <see cref="MultiLeaderAnnotContext.BlockContentConnection"/> is
+		/// This property is also exposed by the <see cref="MultiLeaderObjectContextData"/> class. Values
+		/// should be equal, the value <see cref="MultiLeaderObjectContextData.BlockContentConnection"/> is
 		/// assumed to be used.
 		/// </remarks>
 		[DxfCodeValue(176)]
@@ -453,8 +453,8 @@ namespace ACadSharp.Entities
 		/// Gets or sets the rotation of the block content of the multileader.
 		/// </summary>
 		/// <remarks>
-		/// This property is also exposed by the <see cref="MultiLeaderAnnotContext"/> class. Values
-		/// should be equal, the value <see cref="MultiLeaderAnnotContext.BlockContentRotation"/> is
+		/// This property is also exposed by the <see cref="MultiLeaderObjectContextData"/> class. Values
+		/// should be equal, the value <see cref="MultiLeaderObjectContextData.BlockContentRotation"/> is
 		/// assumed to be used.
 		/// </remarks>
 		[DxfCodeValue(DxfReferenceType.IsAngle, 43)]
@@ -467,8 +467,8 @@ namespace ACadSharp.Entities
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property).
 		/// </summary>
 		/// <remarks>
-		/// This property is also exposed by the <see cref="MultiLeaderAnnotContext"/> class. Values
-		/// should be equal, the value <see cref="MultiLeaderAnnotContext.BlockContentScale"/> is
+		/// This property is also exposed by the <see cref="MultiLeaderObjectContextData"/> class. Values
+		/// should be equal, the value <see cref="MultiLeaderObjectContextData.BlockContentScale"/> is
 		/// assumed to be used.
 		/// </remarks>
 		[DxfCodeValue(10, 20, 30)]
@@ -508,9 +508,9 @@ namespace ACadSharp.Entities
 		/// or attach to the top/bottom.
 		/// </para><para>
 		/// The value for all leader lines can be overridden for each individual leader line by the
-		/// <see cref="Objects.MultiLeaderAnnotContext.LeaderRoot.TextAttachmentDirection"/> property when the
+		/// <see cref="Objects.MultiLeaderObjectContextData.LeaderRoot.TextAttachmentDirection"/> property when the
 		/// <see cref="MultiLeaderPropertyOverrideFlags.TextAttachmentDirection"/> flag is set in the
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.OverrideFlags"/> property.
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.OverrideFlags"/> property.
 		/// </para>
 		/// </remarks>
 		/// <value>
@@ -528,9 +528,9 @@ namespace ACadSharp.Entities
 		/// </para><para>
 		/// This property is also exposed by the <see cref="MultiLeader"/> class
 		/// (<see cref="MultiLeader.TextAttachmentPoint"/>).
-		/// The <see cref="MultiLeaderAnnotContext.TextAttachmentPoint"/> property always has the same value
-		/// and seems to have the respective value as <see cref="MultiLeaderAnnotContext.TextAlignment"/>.
-		/// The <see cref="MultiLeaderAnnotContext.TextAttachmentPoint"/> property is to be used.
+		/// The <see cref="MultiLeaderObjectContextData.TextAttachmentPoint"/> property always has the same value
+		/// and seems to have the respective value as <see cref="MultiLeaderObjectContextData.TextAlignment"/>.
+		/// The <see cref="MultiLeaderObjectContextData.TextAttachmentPoint"/> property is to be used.
 		/// </para>
 		/// </remarks>
 		[DxfCodeValue(179)]
@@ -543,8 +543,8 @@ namespace ACadSharp.Entities
 		/// <see cref="PropertyOverrideFlags"/> property).
 		/// </summary>
 		/// <remarks>
-		/// This property is also exposed by the <see cref="MultiLeaderAnnotContext"/> class. Values
-		/// should be equal, the value <see cref="MultiLeaderAnnotContext.TextBottomAttachment"/> is
+		/// This property is also exposed by the <see cref="MultiLeaderObjectContextData"/> class. Values
+		/// should be equal, the value <see cref="MultiLeaderObjectContextData.TextBottomAttachment"/> is
 		/// assumed to be used.
 		/// </remarks>
 		/// <value>
@@ -570,8 +570,8 @@ namespace ACadSharp.Entities
 		/// <see cref="PropertyOverrideFlags"/> property).
 		/// </summary>
 		/// <remarks>
-		/// This property is also exposed by the <see cref="MultiLeaderAnnotContext"/> class. Values
-		/// should be equal, the value <see cref="MultiLeaderAnnotContext.TextTopAttachment"/> is
+		/// This property is also exposed by the <see cref="MultiLeaderObjectContextData"/> class. Values
+		/// should be equal, the value <see cref="MultiLeaderObjectContextData.TextTopAttachment"/> is
 		/// assumed to be used.
 		/// </remarks>
 		/// <value>
@@ -593,7 +593,7 @@ namespace ACadSharp.Entities
 		{
 			MultiLeader clone = (MultiLeader)base.Clone();
 
-			clone.ContextData = (MultiLeaderAnnotContext)this.ContextData.Clone();
+			clone.ContextData = (MultiLeaderObjectContextData)this.ContextData?.Clone();
 
 			clone.BlockAttributes = new List<BlockAttribute>();
 			foreach (var att in this.BlockAttributes)
@@ -607,7 +607,31 @@ namespace ACadSharp.Entities
 			clone._arrowhead = (BlockRecord)this._arrowhead?.Clone();
 			clone._blockContent = (BlockRecord)this._blockContent?.Clone();
 
+			if (tryGetContextdata(out MultiLeaderObjectContextData contextData)) {
+				MultiLeaderObjectContextData contextDataClone = (MultiLeaderObjectContextData)contextData.Clone();
+
+				CadDictionary annotScales = new CadDictionary("ACDB_ANNOTATIONSCALES");
+				annotScales.Add("*A1", contextDataClone);
+				CadDictionary contextDataManager = new CadDictionary("AcDbContextDataManager");
+				contextDataManager.Add("ACDB_ANNOTATIONSCALES", annotScales);
+				clone.XDictionary = new CadDictionary("");
+				clone.XDictionary.Add("AcDbContextDataManager", contextDataManager);
+			}
+
 			return clone;
+		}
+
+		private bool tryGetContextdata(out MultiLeaderObjectContextData contextData)
+		{
+			if (this.XDictionary.TryGetEntry("AcDbContextDataManager", out CadDictionary contextDataManager) &&
+				contextDataManager.TryGetEntry("ACDB_ANNOTATIONSCALES", out CadDictionary annotScales) &&
+				annotScales.TryGetEntry("*A1", out MultiLeaderObjectContextData a1))
+			{
+				contextData = a1;
+				return true;
+			}
+			contextData = null;
+			return false;
 		}
 
 		internal override void AssignDocument(CadDocument doc)

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Entities.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Entities.cs
@@ -1143,7 +1143,7 @@ namespace ACadSharp.IO.DWG
 			this._writer.WriteBitLong((int)multiLeader.PropertyOverrideFlags);
 			//	170 LeaderLineType (short)
 			this._writer.WriteBitShort((short)multiLeader.PathType);
-			//	91  Leader LineColor (Color)
+			//	91  Leade LineColor (Color)
 			this._writer.WriteCmColor(multiLeader.LineColor);
 			//	341 LeaderLineTypeID (handle/LineType)
 			this._writer.HandleReference(DwgReferenceType.HardPointer, multiLeader.LeaderLineType);
@@ -1235,12 +1235,25 @@ namespace ACadSharp.IO.DWG
 			}
 		}
 
-		private void writeMultiLeaderAnnotContext(MultiLeaderAnnotContext annotContext)
-		{
 
-			//	BL	-	Number of leader roots
+		private void writeMultiLeaderAnnotContextSubObject(bool writeLeaderRootsCount, MultiLeaderObjectContextData annotContext)
+		{
 			int leaderRootCount = annotContext.LeaderRoots.Count;
-			this._writer.WriteBitLong(leaderRootCount);
+			if (writeLeaderRootsCount) {
+				//	BL	-	Number of leader roots
+				this._writer.WriteBitLong(leaderRootCount);
+			}
+			else {
+				this._writer.WriteBitLong(0);
+				this._writer.WriteBit(false);    // b0
+				this._writer.WriteBit(false);    // b1
+				this._writer.WriteBit(false);    // b2
+				this._writer.WriteBit(false);    // b3
+				this._writer.WriteBit(false);    // b4
+				this._writer.WriteBit(leaderRootCount == 2);	// b5
+				this._writer.WriteBit(leaderRootCount == 1);	// b6
+			}
+
 			for (int i = 0; i < leaderRootCount; i++)
 			{
 				writeLeaderRoot(annotContext.LeaderRoots[i]);
@@ -1397,7 +1410,7 @@ namespace ACadSharp.IO.DWG
 			}
 		}
 
-		private void writeLeaderRoot(MultiLeaderAnnotContext.LeaderRoot leaderRoot)
+		private void writeLeaderRoot(MultiLeaderObjectContextData.LeaderRoot leaderRoot)
 		{
 			//	B		290		Is content valid(ODA writes true)/DXF: Has Set Last Leader Line Point
 			this._writer.WriteBit(leaderRoot.ContentValid);
@@ -1413,7 +1426,7 @@ namespace ACadSharp.IO.DWG
 			//	3BD		12		Break start point
 			//	3BD		13		Break end point
 			this._writer.WriteBitLong(leaderRoot.BreakStartEndPointsPairs.Count);
-			foreach (MultiLeaderAnnotContext.StartEndPointPair startEndPointPair in leaderRoot.BreakStartEndPointsPairs)
+			foreach (MultiLeaderObjectContextData.StartEndPointPair startEndPointPair in leaderRoot.BreakStartEndPointsPairs)
 			{
 				this._writer.Write3BitDouble(startEndPointPair.StartPoint);
 				this._writer.Write3BitDouble(startEndPointPair.EndPoint);
@@ -1427,7 +1440,7 @@ namespace ACadSharp.IO.DWG
 			//	Leader lines
 			//	BL		Number of leader lines
 			this._writer.WriteBitLong(leaderRoot.Lines.Count);
-			foreach (MultiLeaderAnnotContext.LeaderLine leaderLine in leaderRoot.Lines)
+			foreach (MultiLeaderObjectContextData.LeaderLine leaderLine in leaderRoot.Lines)
 			{
 				writeLeaderLine(leaderLine);
 			}
@@ -1439,7 +1452,7 @@ namespace ACadSharp.IO.DWG
 			}
 		}
 
-		private void writeLeaderLine(MultiLeaderAnnotContext.LeaderLine leaderLine)
+		private void writeLeaderLine(MultiLeaderObjectContextData.LeaderLine leaderLine)
 		{
 			//	Points
 			//	BL	-	Number of points
@@ -1462,7 +1475,7 @@ namespace ACadSharp.IO.DWG
 				//	Start/end point pairs
 				//	3BD	12	End point
 				this._writer.WriteBitLong(leaderLine.StartEndPoints.Count);
-				foreach (MultiLeaderAnnotContext.StartEndPointPair sep in leaderLine.StartEndPoints)
+				foreach (MultiLeaderObjectContextData.StartEndPointPair sep in leaderLine.StartEndPoints)
 				{
 					//	3BD	11	Start Point
 					this._writer.Write3BitDouble(sep.StartPoint);

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
@@ -28,6 +28,8 @@ namespace ACadSharp.IO.DWG
 			{
 				case EvaluationGraph:
 				case Material:
+				//	case MultiLeaderObjectContextData:
+				case MultiLeaderStyle when !this.R2010Plus:
 				case SortEntitiesTable:
 				case UnknownNonGraphicalObject:
 				case VisualStyle:
@@ -79,6 +81,11 @@ namespace ACadSharp.IO.DWG
 					break;
 				case MultiLeaderStyle multiLeaderStyle:
 					this.writeMultiLeaderStyle(multiLeaderStyle);
+					break;
+				case MultiLeaderObjectContextData multiLeaderObjectContextData:
+					this.writeObjectContextData(multiLeaderObjectContextData);
+					this.writeAnnotScaleObjectContextData(multiLeaderObjectContextData);
+					this.writeMultiLeaderAnnotContext(multiLeaderObjectContextData);
 					break;
 				case PlotSettings plotsettings:
 					this.writePlotSettings(plotsettings);
@@ -530,11 +537,13 @@ namespace ACadSharp.IO.DWG
 
 		private void writeMultiLeaderStyle(MultiLeaderStyle mLeaderStyle)
 		{
-			if (this.R2010Plus)
+			if (!R2010Plus)
 			{
-				//	BS	179	Version expected: 2
-				this._writer.WriteBitShort(2);
+				return;
 			}
+
+			//	BS	179	Version expected: 2
+			this._writer.WriteBitShort(2);
 
 			//	BS	170	Content type (see paragraph on LEADER for more details).
 			this._writer.WriteBitShort((short)mLeaderStyle.ContentType);
@@ -543,7 +552,7 @@ namespace ACadSharp.IO.DWG
 			//	BS	172	Draw leader order (0 = draw leader head first, 1 = draw leader tail first)
 			this._writer.WriteBitShort((short)mLeaderStyle.LeaderDrawOrder);
 			//	BL	90	Maximum number of points for leader
-			this._writer.WriteBitLong((short)mLeaderStyle.MaxLeaderSegmentsPoints);
+			this._writer.WriteBitShort((short)mLeaderStyle.MaxLeaderSegmentsPoints);
 			//	BD	40	First segment angle (radians)
 			this._writer.WriteBitDouble(mLeaderStyle.FirstSegmentAngleConstraint);
 			//	BD	41	Second segment angle (radians)
@@ -552,10 +561,8 @@ namespace ACadSharp.IO.DWG
 			this._writer.WriteBitShort((short)mLeaderStyle.PathType);
 			//	CMC	91	Leader line color
 			this._writer.WriteCmColor(mLeaderStyle.LineColor);
-
 			//	H	340	Leader line type handle (hard pointer)
 			this._writer.HandleReference(DwgReferenceType.HardPointer, mLeaderStyle.LeaderLineType);
-
 			//	BL	92	Leader line weight
 			this._writer.WriteBitLong((short)mLeaderStyle.LeaderLineWeight);
 			//	B	290	Is landing enabled?
@@ -568,24 +575,25 @@ namespace ACadSharp.IO.DWG
 			this._writer.WriteBitDouble(mLeaderStyle.LandingDistance);
 			//	TV	3	Style description
 			this._writer.WriteVariableText(mLeaderStyle.Description);
-
 			//	H	341	Arrow head block handle (hard pointer)
 			this._writer.HandleReference(DwgReferenceType.HardPointer, mLeaderStyle.Arrowhead);
-
 			//	BD	44	Arrow head size
 			this._writer.WriteBitDouble(mLeaderStyle.ArrowheadSize);
 			//	TV	300	Text default
 			this._writer.WriteVariableText(mLeaderStyle.DefaultTextContents);
-
 			//	H	342	Text style handle (hard pointer)
 			this._writer.HandleReference(DwgReferenceType.HardPointer, mLeaderStyle.TextStyle);
-
 			//	BS	174	Left attachment (see paragraph on LEADER for more details).
 			this._writer.WriteBitShort((short)mLeaderStyle.TextLeftAttachment);
 			//	BS	178	Right attachment (see paragraph on LEADER for more details).
 			this._writer.WriteBitShort((short)mLeaderStyle.TextRightAttachment);
-			//	BS	175	Text angle type (see paragraph on LEADER for more details).
-			this._writer.WriteBitShort((short)mLeaderStyle.TextAngle);
+			if (R2010Plus)
+			{
+				//	IF IsNewFormat OR DXF file
+				//	BS	175	Text angle type (see paragraph on LEADER for more details).
+				this._writer.WriteBitShort((short)mLeaderStyle.TextAngle);
+				//	END IF IsNewFormat OR DXF file
+			}
 			//	BS	176	Text alignment type
 			this._writer.WriteBitShort((short)mLeaderStyle.TextAlignment);
 			//	CMC	93	Text color
@@ -594,14 +602,17 @@ namespace ACadSharp.IO.DWG
 			this._writer.WriteBitDouble(mLeaderStyle.TextHeight);
 			//	B	292	Text frame enabled
 			this._writer.WriteBit(mLeaderStyle.TextFrame);
-			//	B	297	Always align text left
-			this._writer.WriteBit(mLeaderStyle.TextAlignAlwaysLeft);
+			if (R2010Plus)
+			{
+				//	IF IsNewFormat OR DXF file
+				//	B	297	Always align text left
+				this._writer.WriteBit(mLeaderStyle.TextAlignAlwaysLeft);
+				//	END IF IsNewFormat OR DXF file
+			}
 			//	BD	46	Align space
 			this._writer.WriteBitDouble(mLeaderStyle.AlignSpace);
-
 			//	H	343	Block handle (hard pointer)
 			this._writer.HandleReference(DwgReferenceType.HardPointer, mLeaderStyle.BlockContent);
-
 			//	CMC	94	Block color
 			this._writer.WriteCmColor(mLeaderStyle.BlockContentColor);
 			//	3BD	47,49,140	Block scale vector
@@ -626,21 +637,33 @@ namespace ACadSharp.IO.DWG
 			//	BD	143	Break size
 			this._writer.WriteBitDouble(mLeaderStyle.BreakGapSize);
 
-			if (this.R2010Plus)
-			{
-				//	BS	271	Attachment direction (see paragraph on LEADER for more details).
-				this._writer.WriteBitShort((short)mLeaderStyle.TextAttachmentDirection);
-				//	BS	273	Top attachment (see paragraph on LEADER for more details).
-				this._writer.WriteBitShort((short)mLeaderStyle.TextBottomAttachment);
-				//	BS	272	Bottom attachment (see paragraph on LEADER for more details).
-				this._writer.WriteBitShort((short)mLeaderStyle.TextTopAttachment);
-			}
+			//	BS	271	Attachment direction (see paragraph on LEADER for more details).
+			this._writer.WriteBitShort((short)mLeaderStyle.TextAttachmentDirection);
+			//	BS	273	Top attachment (see paragraph on LEADER for more details).
+			this._writer.WriteBitShort((short)mLeaderStyle.TextBottomAttachment);
+			//	BS	272	Bottom attachment (see paragraph on LEADER for more details).
+			this._writer.WriteBitShort((short)mLeaderStyle.TextTopAttachment);
 
-			if (this.R2013Plus)
-			{
-				//	B	298 Undocumented, found in DXF
-				this._writer.WriteBit(mLeaderStyle.UnknownFlag298);
-			}
+			//	B	298 Undocumented, found in DXF
+			this._writer.WriteBit(mLeaderStyle.UnknownFlag298);
+		}
+
+
+		private void writeObjectContextData(ObjectContextData objectContextData) {
+			//BS	70	Version.
+			this._writer.WriteBitShort(objectContextData.Version);
+			//B	-	Has file to extension dictionary.
+			this._writer.WriteBit(objectContextData.HasFileToExtensionDictionary);
+			//B	290	Default flag.
+			this._writer.WriteBit(objectContextData.Default);
+		}
+
+		private void writeAnnotScaleObjectContextData(AnnotScaleObjectContextData annotScaleObjectContextData) {
+			this._writer.HandleReference(DwgReferenceType.HardPointer, annotScaleObjectContextData.Scale);
+		}
+
+		private void writeMultiLeaderAnnotContext(MultiLeaderObjectContextData multiLeaderAnnotContext) {
+			writeMultiLeaderAnnotContextSubObject(false, multiLeaderAnnotContext);
 		}
 
 		private void writePlotSettings(PlotSettings plot)

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
@@ -35,7 +35,7 @@ namespace ACadSharp.IO.DXF
 				case AcdbPlaceHolder:
 				case EvaluationGraph:
 				case Material:
-				case MultiLeaderAnnotContext:
+				case MultiLeaderObjectContextData:
 				case VisualStyle:
 				case ImageDefinitionReactor:
 				case UnknownNonGraphicalObject:

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
@@ -703,7 +703,7 @@ namespace ACadSharp.IO.DXF
 
 		private void writeMultiLeader(MultiLeader multiLeader)
 		{
-			MultiLeaderAnnotContext contextData = multiLeader.ContextData;
+			MultiLeaderObjectContextData contextData = multiLeader.ContextData;
 
 			this._writer.Write(100, "AcDbMLeader");
 
@@ -754,7 +754,7 @@ namespace ACadSharp.IO.DXF
 			this._writer.Write(295, 0);
 		}
 
-		private void writeMultiLeaderAnnotContext(MultiLeaderAnnotContext contextData)
+		private void writeMultiLeaderAnnotContext(MultiLeaderObjectContextData contextData)
 		{
 			this._writer.Write(300, "CONTEXT_DATA{");
 			this._writer.Write(40, contextData.ScaleFactor);
@@ -811,7 +811,7 @@ namespace ACadSharp.IO.DXF
 
 			this._writer.Write(297, contextData.NormalReversed);
 
-			foreach (MultiLeaderAnnotContext.LeaderRoot leaderRoot in contextData.LeaderRoots)
+			foreach (MultiLeaderObjectContextData.LeaderRoot leaderRoot in contextData.LeaderRoots)
 			{
 				writeLeaderRoot(leaderRoot);
 			}
@@ -821,7 +821,7 @@ namespace ACadSharp.IO.DXF
 			this._writer.Write(301, "}");       //	CONTEXT_DATA
 		}
 
-		private void writeLeaderRoot(MultiLeaderAnnotContext.LeaderRoot leaderRoot)
+		private void writeLeaderRoot(MultiLeaderObjectContextData.LeaderRoot leaderRoot)
 		{
 			this._writer.Write(302, "LEADER{");
 
@@ -836,7 +836,7 @@ namespace ACadSharp.IO.DXF
 			this._writer.Write(90, leaderRoot.LeaderIndex);
 			this._writer.Write(40, leaderRoot.LandingDistance);
 
-			foreach (MultiLeaderAnnotContext.LeaderLine leaderLine in leaderRoot.Lines)
+			foreach (MultiLeaderObjectContextData.LeaderLine leaderLine in leaderRoot.Lines)
 			{
 				writeLeaderLine(leaderLine);
 			}
@@ -845,7 +845,7 @@ namespace ACadSharp.IO.DXF
 			this._writer.Write(303, "}");   //	LEADER
 		}
 
-		private void writeLeaderLine(MultiLeaderAnnotContext.LeaderLine leaderLine)
+		private void writeLeaderLine(MultiLeaderObjectContextData.LeaderLine leaderLine)
 		{
 			this._writer.Write(304, "LEADER_LINE{");
 

--- a/src/ACadSharp/IO/Templates/CadAnnotScaleObjectContextDataTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadAnnotScaleObjectContextDataTemplate.cs
@@ -1,0 +1,24 @@
+﻿using ACadSharp.Objects;
+
+namespace ACadSharp.IO.Templates {
+	internal class CadAnnotScaleObjectContextDataTemplate : CadNonGraphicalObjectTemplate
+	{
+		public CadAnnotScaleObjectContextDataTemplate(AnnotScaleObjectContextData cadObject)
+			: base(cadObject)
+		{
+		}
+
+		public ulong ScaleHandle { get; internal set; }
+
+		public override void Build(CadDocumentBuilder builder)
+		{
+			base.Build(builder);
+
+			AnnotScaleObjectContextData contextData = (AnnotScaleObjectContextData)this.CadObject;
+			if (builder.TryGetCadObject(this.ScaleHandle, out Scale scale))
+			{
+				contextData.Scale = scale;
+			}
+		}
+	}
+}

--- a/src/ACadSharp/IO/Templates/CadMLeaderAnnotContextTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadMLeaderAnnotContextTemplate.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+
+using ACadSharp.Objects;
+using ACadSharp.Tables;
+
+
+namespace ACadSharp.IO.Templates {
+	internal class CadMLeaderAnnotContextTemplate : CadAnnotScaleObjectContextDataTemplate {
+		public CadMLeaderAnnotContextTemplate(MultiLeaderObjectContextData cadObject)
+			: base(cadObject)
+		{
+		}
+
+		public ulong TextStyleHandle { get; internal set; }
+
+		public ulong BlockRecordHandle { get; internal set; }
+
+		public IList<LeaderLineSubTemplate> LeaderLineSubTemplates { get; } = new List<LeaderLineSubTemplate>();
+
+
+		public class LeaderLineSubTemplate
+		{
+			public MultiLeaderObjectContextData.LeaderLine LeaderLine { get; }
+
+			public LeaderLineSubTemplate(MultiLeaderObjectContextData.LeaderLine leaderLine) {
+				this.LeaderLine = leaderLine;
+			}
+
+			public ulong LineTypeHandle { get; internal set; }
+
+			public ulong ArrowSymbolHandle { get; internal set; }
+		}
+
+
+		public override void Build(CadDocumentBuilder builder)
+		{
+			base.Build(builder);
+			MultiLeaderObjectContextData annotContext = (MultiLeaderObjectContextData)this.CadObject;
+
+			if (builder.TryGetCadObject(this.TextStyleHandle, out TextStyle annotContextTextStyle)) {
+				annotContext.TextStyle = annotContextTextStyle;
+			}
+			if (builder.TryGetCadObject(this.BlockRecordHandle, out BlockRecord annotContextBlockRecord)) {
+				annotContext.BlockContent = annotContextBlockRecord;
+			}
+
+			foreach (LeaderLineSubTemplate leaderLineSubTemplate in this.LeaderLineSubTemplates) {
+				MultiLeaderObjectContextData.LeaderLine leaderLine = leaderLineSubTemplate.LeaderLine;
+				if (builder.TryGetCadObject(leaderLineSubTemplate.LineTypeHandle, out LineType leaderLinelineType)) {
+					leaderLine.LineType = leaderLinelineType;
+				}
+				if (builder.TryGetCadObject(leaderLineSubTemplate.ArrowSymbolHandle, out BlockRecord arrowhead)) {
+					leaderLine.Arrowhead = arrowhead;
+				}
+			}
+		}
+	}
+}

--- a/src/ACadSharp/IO/Templates/CadMLeaderTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadMLeaderTemplate.cs
@@ -25,43 +25,15 @@ namespace ACadSharp.IO.Templates
 
 		public IDictionary<MultiLeader.BlockAttribute, ulong> BlockAttributeHandles { get; } = new Dictionary<MultiLeader.BlockAttribute, ulong>();
 
-		//	Context-Data Handles
-		public ulong AnnotContextTextStyleHandle { get; internal set; }
 
-		public ulong AnnotContextBlockRecordHandle { get; internal set; }
-
-		public IList<LeaderLineSubTemplate> LeaderLineSubTemplates { get; } = new List<LeaderLineSubTemplate>();
-		
-		public class LeaderLineSubTemplate
-		{
-			public MultiLeaderAnnotContext.LeaderLine LeaderLine { get; }
-
-			public LeaderLineSubTemplate(MultiLeaderAnnotContext.LeaderLine leaderLine)
-			{ 
-				this.LeaderLine = leaderLine;
-			}
-
-			public ulong LineTypeHandle { get; internal set; }
-
-			public ulong ArrowSymbolHandle { get; internal set; }
-		}
-
+		public CadMLeaderAnnotContextTemplate CadMLeaderAnnotContextTemplate { get; set; }
 
 		public override void Build(CadDocumentBuilder builder)
 		{
 			base.Build(builder);
+			this.CadMLeaderAnnotContextTemplate.Build(builder);
 
 			MultiLeader multiLeader = (MultiLeader)this.CadObject;
-			MultiLeaderAnnotContext annotContext = multiLeader.ContextData;
-
-			if (builder.TryGetCadObject(this.AnnotContextTextStyleHandle, out TextStyle annotContextTextStyle))
-			{
-				annotContext.TextStyle = annotContextTextStyle;
-			}
-			if (builder.TryGetCadObject(this.AnnotContextBlockRecordHandle, out BlockRecord annotContextBlockRecord))
-			{
-				annotContext.BlockContent = annotContextBlockRecord;
-			}
 
 			if (builder.TryGetCadObject(this.LeaderStyleHandle, out MultiLeaderStyle leaderStyle))
 			{
@@ -94,19 +66,6 @@ namespace ACadSharp.IO.Templates
 				if (builder.TryGetCadObject(attributeHandle, out AttributeDefinition attributeDefinition))
 				{
 					blockAttribute.AttributeDefinition = attributeDefinition;
-				}
-			}
-
-			foreach (LeaderLineSubTemplate leaderLineSubTemplate in this.LeaderLineSubTemplates)
-			{
-				MultiLeaderAnnotContext.LeaderLine leaderLine = leaderLineSubTemplate.LeaderLine;
-				if (builder.TryGetCadObject(leaderLineSubTemplate.LineTypeHandle, out LineType leaderLinelineType))
-				{
-					leaderLine.LineType = leaderLinelineType;
-				}
-				if (builder.TryGetCadObject(leaderLineSubTemplate.ArrowSymbolHandle, out BlockRecord arrowhead))
-				{
-					leaderLine.Arrowhead = arrowhead;
 				}
 			}
 		}

--- a/src/ACadSharp/Objects/AnnotScaleObjectContextData.cs
+++ b/src/ACadSharp/Objects/AnnotScaleObjectContextData.cs
@@ -1,0 +1,72 @@
+﻿using System;
+
+using ACadSharp.Attributes;
+
+namespace ACadSharp.Objects
+{
+	[DxfSubClass(DxfSubclassMarker.AnnotScaleObjectContextData)]
+	public abstract class AnnotScaleObjectContextData : ObjectContextData
+	{
+		private Scale _scale = Scale.Default;
+
+		/// <inheritdoc/>
+		public override string SubclassMarker => DxfSubclassMarker.AnnotScaleObjectContextData;
+
+		//H	340	Handle to scale(AcDbScale) object (hard pointer).
+		[DxfCodeValue(DxfReferenceType.Handle, 340)]
+		public Scale Scale
+		{
+			get { return _scale; } 
+			set
+			{
+				if (value == null) {
+					throw new ArgumentNullException(nameof(value));
+				}
+
+				if (this.Document != null)
+				{
+					this._scale = this.updateCollection(value, this.Document.Scales);
+				}
+				else
+				{
+					this._scale = value;
+				}
+			}
+		}
+
+		public override CadObject Clone()
+		{
+			AnnotScaleObjectContextData clone =  (AnnotScaleObjectContextData)base.Clone();
+
+			clone._scale = (Scale)this._scale?.Clone();
+
+			return clone;
+		}
+
+		internal override void AssignDocument(CadDocument doc)
+		{
+			base.AssignDocument(doc);
+
+			this._scale = this.updateCollection(this._scale, this.Document?.Scales);
+
+			this.Document.Scales.OnRemove += tableOnRemove;
+		}
+
+		internal override void UnassignDocument()
+		{
+			this.Document.Scales.OnRemove -= tableOnRemove;
+
+			base.UnassignDocument();
+
+			this._scale = (Scale)this._scale.Clone();
+		}
+
+		private void tableOnRemove(object sender, CollectionChangedEventArgs e)
+		{
+			if (e.Item.Equals(this._scale))
+			{
+				this._scale = this.Document.Scales[Scale.Default.Name];
+			}
+		}
+	}
+}

--- a/src/ACadSharp/Objects/LeaderDrawOrderType.cs
+++ b/src/ACadSharp/Objects/LeaderDrawOrderType.cs
@@ -2,7 +2,7 @@
 {
 
 	/// <summary>
-	/// Specifies the draw order of a <see cref="MultiLeaderAnnotContext.LeaderRoot"/>
+	/// Specifies the draw order of a <see cref="MultiLeaderObjectContextData.LeaderRoot"/>
 	/// in a <see cref="Entities.MultiLeader"/> entity.
 	/// </summary>
 	public enum LeaderDrawOrderType

--- a/src/ACadSharp/Objects/LeaderLinePropertOverrideFlags.cs
+++ b/src/ACadSharp/Objects/LeaderLinePropertOverrideFlags.cs
@@ -17,37 +17,37 @@ namespace ACadSharp.Objects
 		None = 0,
 
 		/// <summary>
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.PathType" /> property 
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.PathType" /> property 
 		/// overrides settings from <see cref="MultiLeader"/> and <see cref="MultiLeaderStyle"/>.
 		/// </summary>
 		PathType = 1,
 
 		/// <summary>
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.LineColor" /> property
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.LineColor" /> property
 		/// overrides settings from <see cref="MultiLeader"/> and <see cref="MultiLeaderStyle"/>.
 		/// </summary>
 		LineColor = 2,
 
 		/// <summary>
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.LineType"/> property
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.LineType"/> property
 		/// overrides settings from <see cref="MultiLeader"/> and <see cref="MultiLeaderStyle"/>.
 		/// </summary>
 		LineType = 4,
 
 		/// <summary>
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.LineWeight" /> property
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.LineWeight" /> property
 		/// overrides settings from <see cref="MultiLeader"/> and <see cref="MultiLeaderStyle"/>.
 		/// </summary>
 		LineWeight = 8,
 
 		/// <summary>
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.ArrowheadSize" /> property
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.ArrowheadSize" /> property
 		/// overrides settings from <see cref="MultiLeader"/> and <see cref="MultiLeaderStyle"/>.
 		/// </summary>
 		ArrowheadSize = 16,
 
 		/// <summary>
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.Arrowhead" /> property
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.Arrowhead" /> property
 		/// overrides settings from <see cref="MultiLeader"/> and <see cref="MultiLeaderStyle"/>.
 		/// </summary>
 		Arrowhead = 32,

--- a/src/ACadSharp/Objects/MultiLeaderObjectContextData.cs
+++ b/src/ACadSharp/Objects/MultiLeaderObjectContextData.cs
@@ -14,7 +14,7 @@ namespace ACadSharp.Objects {
 	/// This class represents a subset ob the properties of the MLeaderAnnotContext
 	/// object, that are embedded into the MultiLeader entity.
 	/// </summary>
-	public partial class MultiLeaderAnnotContext : NonGraphicalObject
+	public partial class MultiLeaderObjectContextData : AnnotScaleObjectContextData
 	{
 		private TextStyle _textStyle = TextStyle.Default;
 		private BlockRecord _blockContent;
@@ -22,7 +22,7 @@ namespace ACadSharp.Objects {
 		public override ObjectType ObjectType => ObjectType.UNLISTED;
 
 		/// <inheritdoc />
-		public override string SubclassMarker => DxfSubclassMarker.MultiLeaderAnnotContext;
+		public override string SubclassMarker => DxfSubclassMarker.MultiLeaderObjectContextData;
 
 		/// <inheritdoc />
 		public override string ObjectName => DxfFileToken.ObjectMLeaderContextData;
@@ -572,12 +572,12 @@ namespace ACadSharp.Objects {
 		public TextAttachmentType TextBottomAttachment { get; set; }
 
 		/// <summary>
-		/// Initializes a new instance of a <see cref="MultiLeaderAnnotContext"/>.
+		/// Initializes a new instance of a <see cref="MultiLeaderObjectContextData"/>.
 		/// </summary>
-		public MultiLeaderAnnotContext() : base() { }
+		public MultiLeaderObjectContextData() : base() { }
 
 		public override CadObject Clone() {
-			MultiLeaderAnnotContext clone = (MultiLeaderAnnotContext)base.Clone();
+			MultiLeaderObjectContextData clone = (MultiLeaderObjectContextData)base.Clone();
 
 			clone._textStyle = (TextStyle)this._textStyle.Clone();
 			clone._blockContent = (BlockRecord)this._blockContent?.Clone();

--- a/src/ACadSharp/Objects/MultiLeaderObjectContextDataClasses.cs
+++ b/src/ACadSharp/Objects/MultiLeaderObjectContextDataClasses.cs
@@ -13,7 +13,7 @@ namespace ACadSharp.Objects
 	/// <summary>
 	/// Nested classes in MultiLeaderAnnotContext
 	/// </summary>
-	public partial class MultiLeaderAnnotContext : NonGraphicalObject
+	public partial class MultiLeaderObjectContextData : AnnotScaleObjectContextData
 	{
 		/// <summary>
 		/// Represents a leader root

--- a/src/ACadSharp/Objects/MultiLeaderStyle.cs
+++ b/src/ACadSharp/Objects/MultiLeaderStyle.cs
@@ -119,9 +119,9 @@ namespace ACadSharp.Objects
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para><para>
 		/// The value for all leader lines can be overridden for each individual leader line by the
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.PathType"/> property when the
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.PathType"/> property when the
 		/// <see cref="LeaderLinePropertOverrideFlags.PathType"/> flag is set in the 
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.OverrideFlags"/> property.
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.OverrideFlags"/> property.
 		/// </para>
 		/// </remarks>
 		[DxfCodeValue(173)]
@@ -137,9 +137,9 @@ namespace ACadSharp.Objects
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para><para>
 		/// The value for all leader lines can be overridden for each individual leader line by the
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.LineColor"/> property when the
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.LineColor"/> property when the
 		/// <see cref="LeaderLinePropertOverrideFlags.LineColor"/> flag is set in the 
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.OverrideFlags"/> property.
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.OverrideFlags"/> property.
 		/// </para>
 		/// </remarks>
 		[DxfCodeValue(91)]
@@ -156,9 +156,9 @@ namespace ACadSharp.Objects
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para><para>
 		/// The setting for all leader lines can be overridden for each individual leader line by the
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.LineType"/> property when the
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.LineType"/> property when the
 		/// <see cref="LeaderLinePropertOverrideFlags.LineType"/> flag is set in the 
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.OverrideFlags"/> property.
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.OverrideFlags"/> property.
 		/// </para>
 		/// </remarks>
 		[DxfCodeValue(DxfReferenceType.Handle, 340)]
@@ -193,9 +193,9 @@ namespace ACadSharp.Objects
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para><para>
 		/// The value for all leader lines can be overridden for each individual leader line by the
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.LineWeight"/> property when the
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.LineWeight"/> property when the
 		/// <see cref="LeaderLinePropertOverrideFlags.LineWeight"/> flag is set in the 
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.OverrideFlags"/> property.
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.OverrideFlags"/> property.
 		/// </para>
 		/// </remarks>
 		[DxfCodeValue(92)]
@@ -224,7 +224,7 @@ namespace ACadSharp.Objects
 		/// </summary>
 		/// <remarks>
 		/// <para>
-		/// This value can be overridden by the <see cref="MultiLeaderAnnotContext.LandingGap"/> property
+		/// This value can be overridden by the <see cref="MultiLeaderObjectContextData.LandingGap"/> property
 		/// when the <see cref="MultiLeaderPropertyOverrideFlags.LandingGap"/> flag is set in the
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para>
@@ -278,9 +278,9 @@ namespace ACadSharp.Objects
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para><para>
 		/// The value for all leader lines can be overridden for each individual leader line by the
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.Arrowhead"/> property when the
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.Arrowhead"/> property when the
 		/// <see cref="LeaderLinePropertOverrideFlags.Arrowhead"/> flag is set in the 
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.OverrideFlags"/> property.
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.OverrideFlags"/> property.
 		/// </para>
 		/// </remarks>
 		[DxfCodeValue(DxfReferenceType.Handle, 341)]
@@ -298,14 +298,14 @@ namespace ACadSharp.Objects
 		/// </summary>
 		/// <remarks>
 		/// <para>
-		/// This value can be overridden by the <see cref="MultiLeaderAnnotContext.ArrowheadSize"/> property
+		/// This value can be overridden by the <see cref="MultiLeaderObjectContextData.ArrowheadSize"/> property
 		/// when the <see cref="MultiLeaderPropertyOverrideFlags.ArrowheadSize"/> flag is set in the
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para><para>
 		/// The value for all leader lines can be overridden for each individual leader line by the
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.ArrowheadSize"/> property when the
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.ArrowheadSize"/> property when the
 		/// <see cref="LeaderLinePropertOverrideFlags.ArrowheadSize"/> flag is set in the 
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.OverrideFlags"/> property.
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.OverrideFlags"/> property.
 		/// </para>
 		/// </remarks>
 		[DxfCodeValue(44)]
@@ -324,7 +324,7 @@ namespace ACadSharp.Objects
 		/// </summary>
 		/// <remarks>
 		/// <para>
-		/// This value can be overridden by the <see cref="MultiLeaderAnnotContext.TextStyle"/> property
+		/// This value can be overridden by the <see cref="MultiLeaderObjectContextData.TextStyle"/> property
 		/// when the <see cref="MultiLeaderPropertyOverrideFlags.TextStyle"/> flag is set in the
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para>
@@ -358,7 +358,7 @@ namespace ACadSharp.Objects
 		/// </summary>
 		/// <remarks>
 		/// <para>
-		/// This value can be overridden by the <see cref="MultiLeaderAnnotContext.TextLeftAttachment"/> property
+		/// This value can be overridden by the <see cref="MultiLeaderObjectContextData.TextLeftAttachment"/> property
 		/// when the <see cref="MultiLeaderPropertyOverrideFlags.TextLeftAttachment"/> flag is set in the
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para><para>
@@ -390,11 +390,11 @@ namespace ACadSharp.Objects
 
 		/// <summary>
 		/// Gets or sets the text alignment, i.e. the alignment of text lines if the a multiline
-		/// text label, relative to the <see cref="MultiLeaderAnnotContext.TextLocation"/>.
+		/// text label, relative to the <see cref="MultiLeaderObjectContextData.TextLocation"/>.
 		/// </summary>
 		/// <remarks>
 		/// <para>
-		/// This value can be overridden by the <see cref="MultiLeaderAnnotContext.TextAlignment"/> property
+		/// This value can be overridden by the <see cref="MultiLeaderObjectContextData.TextAlignment"/> property
 		/// when the <see cref="MultiLeaderPropertyOverrideFlags.TextAlignment"/> flag is set in the
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para>
@@ -409,7 +409,7 @@ namespace ACadSharp.Objects
 		/// </summary>
 		/// <remarks>
 		/// <para>
-		/// This value can be overridden by the <see cref="MultiLeaderAnnotContext.TextRightAttachment"/> property
+		/// This value can be overridden by the <see cref="MultiLeaderObjectContextData.TextRightAttachment"/> property
 		/// when the <see cref="MultiLeaderPropertyOverrideFlags.TextRightAttachment"/> flag is set in the
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para><para>
@@ -430,7 +430,7 @@ namespace ACadSharp.Objects
 		/// </summary>
 		/// <remarks>
 		/// <para>
-		/// This value can be overridden by the <see cref="MultiLeaderAnnotContext.TextColor"/> property
+		/// This value can be overridden by the <see cref="MultiLeaderObjectContextData.TextColor"/> property
 		/// when the <see cref="MultiLeaderPropertyOverrideFlags.TextColor"/> flag is set in the
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para>
@@ -443,7 +443,7 @@ namespace ACadSharp.Objects
 		/// </summary>
 		/// <remarks>
 		/// <para>
-		/// This value can be overridden by the <see cref="MultiLeaderAnnotContext.TextHeight"/> property
+		/// This value can be overridden by the <see cref="MultiLeaderObjectContextData.TextHeight"/> property
 		/// when the <see cref="MultiLeaderPropertyOverrideFlags.TextHeight"/> flag is set in the
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para>
@@ -484,7 +484,7 @@ namespace ACadSharp.Objects
 		/// </summary>
 		/// <remarks>
 		/// <para>
-		/// Thw standard content block can be overridden by the <see cref="MultiLeaderAnnotContext.BlockContent"/>
+		/// Thw standard content block can be overridden by the <see cref="MultiLeaderObjectContextData.BlockContent"/>
 		/// property when the <see cref="MultiLeaderPropertyOverrideFlags.BlockContent"/> flag is set in the
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para>
@@ -503,7 +503,7 @@ namespace ACadSharp.Objects
 		/// </summary>
 		/// <remarks>
 		/// <para>
-		/// This value can be overridden by the <see cref="MultiLeaderAnnotContext.BlockContentColor"/> property
+		/// This value can be overridden by the <see cref="MultiLeaderObjectContextData.BlockContentColor"/> property
 		/// when the <see cref="MultiLeaderPropertyOverrideFlags.BlockContentColor"/> flag is set in the
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para>
@@ -516,7 +516,7 @@ namespace ACadSharp.Objects
 		/// </summary>
 		/// <remarks>
 		/// <para>
-		/// This value can be overridden by the <see cref="MultiLeaderAnnotContext.BlockContentScale"/> property
+		/// This value can be overridden by the <see cref="MultiLeaderObjectContextData.BlockContentScale"/> property
 		/// when the <see cref="MultiLeaderPropertyOverrideFlags.BlockContentScale"/> flag is set in the
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para>
@@ -536,7 +536,7 @@ namespace ACadSharp.Objects
 		/// </summary>
 		/// <remarks>
 		/// <para>
-		/// This value can be overridden by the <see cref="MultiLeaderAnnotContext.BlockContentRotation"/> property
+		/// This value can be overridden by the <see cref="MultiLeaderObjectContextData.BlockContentRotation"/> property
 		/// when the <see cref="MultiLeaderPropertyOverrideFlags.BlockContentRotation"/> flag is set in the
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para>
@@ -557,7 +557,7 @@ namespace ACadSharp.Objects
 		/// </summary>
 		/// <remarks>
 		/// <para>
-		/// This value can be overridden by the <see cref="MultiLeaderAnnotContext.BlockContentConnection"/> property
+		/// This value can be overridden by the <see cref="MultiLeaderObjectContextData.BlockContentConnection"/> property
 		/// when the <see cref="MultiLeaderPropertyOverrideFlags.BlockContentConnection"/> flag is set in the
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para>
@@ -571,7 +571,7 @@ namespace ACadSharp.Objects
 		/// </summary>
 		/// <remarks>
 		/// <para>
-		/// This value can be overridden by the <see cref="MultiLeaderAnnotContext.ScaleFactor"/> property
+		/// This value can be overridden by the <see cref="MultiLeaderObjectContextData.ScaleFactor"/> property
 		/// when the <see cref="MultiLeaderPropertyOverrideFlags.ScaleFactor"/> flag is set in the
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para>
@@ -619,9 +619,9 @@ namespace ACadSharp.Objects
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para><para>
 		/// The value for all leader lines can be overridden for each individual leader line by the
-		/// <see cref="MultiLeaderAnnotContext.LeaderRoot.TextAttachmentDirection"/> property when the
+		/// <see cref="MultiLeaderObjectContextData.LeaderRoot.TextAttachmentDirection"/> property when the
 		/// <see cref="LeaderLinePropertOverrideFlags.TextAttachmentDirection"/> flag is set in the 
-		/// <see cref="MultiLeaderAnnotContext.LeaderLine.OverrideFlags"/> property.
+		/// <see cref="MultiLeaderObjectContextData.LeaderLine.OverrideFlags"/> property.
 		/// </para>
 		/// </remarks>
 		/// <value>
@@ -637,7 +637,7 @@ namespace ACadSharp.Objects
 		/// </summary>
 		/// <remarks>
 		/// <para>
-		/// This value can be overridden by the <see cref="MultiLeaderAnnotContext.TextBottomAttachment"/> property
+		/// This value can be overridden by the <see cref="MultiLeaderObjectContextData.TextBottomAttachment"/> property
 		/// when the <see cref="MultiLeaderPropertyOverrideFlags.TextBottomAttachment"/> flag is set in the
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para><para>
@@ -662,7 +662,7 @@ namespace ACadSharp.Objects
 		/// </summary>
 		/// <remarks>
 		/// <para>
-		/// This value can be overridden by the <see cref="MultiLeaderAnnotContext.TextTopAttachment"/> property
+		/// This value can be overridden by the <see cref="MultiLeaderObjectContextData.TextTopAttachment"/> property
 		/// when the <see cref="MultiLeaderPropertyOverrideFlags.TextTopAttachment"/> flag is set in the
 		/// <see cref="MultiLeader.PropertyOverrideFlags"/> property.
 		/// </para><para>

--- a/src/ACadSharp/Objects/ObjectContextData.cs
+++ b/src/ACadSharp/Objects/ObjectContextData.cs
@@ -1,0 +1,26 @@
+﻿using ACadSharp.Attributes;
+
+
+namespace ACadSharp.Objects
+{
+	[DxfSubClass(DxfSubclassMarker.ObjectContextData)]
+	public abstract class ObjectContextData : NonGraphicalObject
+	{
+		/// <inheritdoc/>
+		public override string SubclassMarker => DxfSubclassMarker.ObjectContextData;
+
+		//R2010
+
+		//BS	70	Version (default value is 3).
+		[DxfCodeValue(70)]
+		public short Version { get; set; } = 3;
+
+		//B	-	Has file to extension dictionary (default value is true).
+		//[DxfCodeValue()]
+		public bool HasFileToExtensionDictionary { get; set; } = true;
+
+		//B	290	Default flag (default value is false).
+		[DxfCodeValue(290)]
+		public bool Default { get; set; } = false;
+	}
+}


### PR DESCRIPTION
-  MultiLeaderObjectContextData (formally MultiLeaderAnnotContext) as standalone object.

* https://github.com/nanoLogika/ACadSharp/issues/10
* #632
* #629 