### PR TITLE
Version 3.0

### DIFF
--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>1.1.22</Version>
+		<Version>3.0.0</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 	</PropertyGroup>
 

--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net5.0;net6.0;net7.0;net48;netstandard2.1;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net5.0;net6.0;net7.0;net8.0;net9.0;net48;netstandard2.1;netstandard2.0</TargetFrameworks>
 		<Authors>DomCr</Authors>
 		<PackageId>ACadSharp</PackageId>
 		<PackageTags>C# Dwg Dxf</PackageTags>


### PR DESCRIPTION
# Description

Add target frameworks .Net8 and .Net9.

This PR is also meant to fix the version issue in Nuget, the Beta version was wrongly set to 2.0.0-Beta making it seem that it would be a beta for the 2.0.0 version of `ACadSharp`.