### PR TITLE
Issue 679 block record layout clone

### DIFF
--- a/src/ACadSharp.Tests/Tables/BlockRecordTests.cs
+++ b/src/ACadSharp.Tests/Tables/BlockRecordTests.cs
@@ -1,4 +1,5 @@
 ﻿using ACadSharp.Entities;
+using ACadSharp.Extensions;
 using ACadSharp.Tables;
 using ACadSharp.Tests.Common;
 using System;
@@ -111,6 +112,16 @@ namespace ACadSharp.Tests.Tables
 			Assert.NotNull(record.Document);
 			Assert.NotNull(record.BlockEntity.Document);
 			Assert.NotNull(record.BlockEnd.Document);
+		}
+
+		[Fact()]
+		public void ClonePaperSpaceTest()
+		{
+			CadDocument doc = new CadDocument();
+
+			BlockRecord record = doc.PaperSpace.CloneTyped();
+
+
 		}
 
 		[Fact()]

--- a/src/ACadSharp.Tests/Tables/BlockRecordTests.cs
+++ b/src/ACadSharp.Tests/Tables/BlockRecordTests.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Entities;
 using ACadSharp.Extensions;
+using ACadSharp.Objects;
 using ACadSharp.Tables;
 using ACadSharp.Tests.Common;
 using System;
@@ -9,20 +10,6 @@ namespace ACadSharp.Tests.Tables
 {
 	public class BlockRecordTests
 	{
-		[Fact()]
-		public void BlockRecordTest()
-		{
-			string name = "my_block";
-			BlockRecord record = new BlockRecord(name);
-
-			Assert.Equal(name, record.Name);
-
-			Assert.NotNull(record.BlockEntity);
-			Assert.Equal(record.Name, record.BlockEntity.Name);
-
-			Assert.NotNull(record.BlockEnd);
-		}
-
 		[Fact()]
 		public void AddEntityTest()
 		{
@@ -46,33 +33,69 @@ namespace ACadSharp.Tests.Tables
 		}
 
 		[Fact()]
-		public void NotAllowDuplicatesTest()
+		public void BlockRecordTest()
 		{
 			string name = "my_block";
 			BlockRecord record = new BlockRecord(name);
 
-			Line l1 = new Line();
+			Assert.Equal(name, record.Name);
 
-			record.Entities.Add(l1);
-			Assert.Throws<ArgumentException>(() => record.Entities.Add(l1));
+			Assert.NotNull(record.BlockEntity);
+			Assert.Equal(record.Name, record.BlockEntity.Name);
+
+			Assert.NotNull(record.BlockEnd);
 		}
 
 		[Fact()]
-		public void CreateSortensTableTest()
+		public void CloneDetachDocumentTest()
 		{
 			string name = "my_block";
 			BlockRecord record = new BlockRecord(name);
+			CadDocument doc = new CadDocument();
 
-			record.Entities.Add(new Line());
-			record.Entities.Add(new Line());
-			record.Entities.Add(new Line());
-			record.Entities.Add(new Line());
+			doc.BlockRecords.Add(record);
 
-			record.CreateSortEntitiesTable();
+			BlockRecord clone = (BlockRecord)record.Clone();
 
-			Assert.NotNull(record.SortEntitiesTable);
-			Assert.NotNull(record.SortEntitiesTable.Sorters);
-			Assert.Empty(record.SortEntitiesTable.Sorters);
+			Assert.Null(clone.Document);
+			Assert.Null(clone.BlockEntity.Document);
+			Assert.Null(clone.BlockEnd.Document);
+
+			Assert.NotNull(record.Document);
+			Assert.NotNull(record.BlockEntity.Document);
+			Assert.NotNull(record.BlockEnd.Document);
+		}
+
+		[Fact()]
+		public void CloneInDocumentTest()
+		{
+			string name = "my_block";
+			BlockRecord record = new BlockRecord(name);
+			CadDocument doc = new CadDocument();
+
+			doc.BlockRecords.Add(record);
+
+			Assert.NotNull(record.Document);
+			Assert.NotNull(record.BlockEntity.Document);
+			Assert.NotNull(record.BlockEnd.Document);
+		}
+
+		[Fact()]
+		public void ClonePaperSpaceTest()
+		{
+			CadDocument doc = new CadDocument();
+
+			BlockRecord record = doc.PaperSpace.CloneTyped();
+
+			Assert.NotNull(record);
+			Assert.Null(record.Layout);
+
+			//Test the layout keeps the block
+			Layout paper = doc.Layouts["Layout1"];
+			Layout layout = paper.CloneTyped();
+
+			Assert.NotNull(layout);
+			Assert.NotNull(layout.AssociatedBlock);
 		}
 
 		[Fact()]
@@ -101,47 +124,33 @@ namespace ACadSharp.Tests.Tables
 		}
 
 		[Fact()]
-		public void CloneInDocumentTest()
+		public void CreateSortensTableTest()
 		{
 			string name = "my_block";
 			BlockRecord record = new BlockRecord(name);
-			CadDocument doc = new CadDocument();
 
-			doc.BlockRecords.Add(record);
+			record.Entities.Add(new Line());
+			record.Entities.Add(new Line());
+			record.Entities.Add(new Line());
+			record.Entities.Add(new Line());
 
-			Assert.NotNull(record.Document);
-			Assert.NotNull(record.BlockEntity.Document);
-			Assert.NotNull(record.BlockEnd.Document);
+			record.CreateSortEntitiesTable();
+
+			Assert.NotNull(record.SortEntitiesTable);
+			Assert.NotNull(record.SortEntitiesTable.Sorters);
+			Assert.Empty(record.SortEntitiesTable.Sorters);
 		}
 
 		[Fact()]
-		public void ClonePaperSpaceTest()
-		{
-			CadDocument doc = new CadDocument();
-
-			BlockRecord record = doc.PaperSpace.CloneTyped();
-
-
-		}
-
-		[Fact()]
-		public void CloneDetachDocumentTest()
+		public void NotAllowDuplicatesTest()
 		{
 			string name = "my_block";
 			BlockRecord record = new BlockRecord(name);
-			CadDocument doc = new CadDocument();
 
-			doc.BlockRecords.Add(record);
+			Line l1 = new Line();
 
-			BlockRecord clone = (BlockRecord)record.Clone();
-
-			Assert.Null(clone.Document);
-			Assert.Null(clone.BlockEntity.Document);
-			Assert.Null(clone.BlockEnd.Document);
-
-			Assert.NotNull(record.Document);
-			Assert.NotNull(record.BlockEntity.Document);
-			Assert.NotNull(record.BlockEnd.Document);
+			record.Entities.Add(l1);
+			Assert.Throws<ArgumentException>(() => record.Entities.Add(l1));
 		}
 	}
 }

--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>3.0.0</Version>
+		<Version>3.0.1</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 	</PropertyGroup>
 

--- a/src/ACadSharp/Objects/Layout.cs
+++ b/src/ACadSharp/Objects/Layout.cs
@@ -19,107 +19,6 @@ namespace ACadSharp.Objects
 	[DxfSubClass(DxfSubclassMarker.Layout)]
 	public class Layout : PlotSettings
 	{
-		public const string ModelLayoutName = "Model";
-
-		public const string PaperLayoutName = "Layout1";
-
-		/// <inheritdoc/>
-		public override ObjectType ObjectType => ObjectType.LAYOUT;
-
-		/// <inheritdoc/>
-		public override string ObjectName => DxfFileToken.ObjectLayout;
-
-		/// <inheritdoc/>
-		public override string SubclassMarker => DxfSubclassMarker.Layout;
-
-		/// <summary>
-		/// Layout name.
-		/// </summary>
-		[DxfCodeValue(1)]
-		public override string Name
-		{
-			get
-			{
-				return base.Name;
-			}
-			set
-			{
-				base.Name = value;
-			}
-		}
-
-		/// <summary>
-		/// Layout flags.
-		/// </summary>
-		[DxfCodeValue(70)]
-		public LayoutFlags LayoutFlags { get; set; }
-
-		/// <summary>
-		/// Tab order. This number is an ordinal indicating this layout's ordering in the tab control that is attached to the drawing window. Note that the “Model” tab always appears as the first tab regardless of its tab order.
-		/// </summary>
-		[DxfCodeValue(71)]
-		public int TabOrder { get; set; }
-
-		/// <summary>
-		/// Minimum limits for this layout (defined by LIMMIN while this layout is current).
-		/// </summary>
-		[DxfCodeValue(10, 20)]
-		public XY MinLimits { get; set; } = new XY(-20.0, -7.5);
-
-		/// <summary>
-		/// Maximum limits for this layout(defined by LIMMAX while this layout is current).
-		/// </summary>
-		[DxfCodeValue(11, 21)]
-		public XY MaxLimits { get; set; } = new XY(277.0, 202.5);
-
-		/// <summary>
-		/// Insertion base point for this layout(defined by INSBASE while this layout is current).
-		/// </summary>
-		[DxfCodeValue(12, 22, 32)]
-		public XYZ InsertionBasePoint { get; set; }
-
-		/// <summary>
-		/// Minimum extents for this layout(defined by EXTMIN while this layout is current).
-		/// </summary>
-		[DxfCodeValue(14, 24, 34)]
-		public XYZ MinExtents { get; set; } = new XYZ(25.7, 19.5, 0.0);
-
-		/// <summary>
-		/// Maximum extents for this layout(defined by EXTMAX while this layout is current).
-		/// </summary>
-		[DxfCodeValue(15, 25, 35)]
-		public XYZ MaxExtents { get; set; } = new XYZ(231.3, 175.5, 0.0);
-
-		/// <summary>
-		/// Layout elevation.
-		/// </summary>
-		[DxfCodeValue(146)]
-		public double Elevation { get; set; }
-
-		/// <summary>
-		/// UCS origin.
-		/// </summary>
-		[DxfCodeValue(13, 23, 33)]
-		public XYZ Origin { get; set; } = XYZ.Zero;
-
-		/// <summary>
-		/// UCS X-axis.
-		/// </summary>
-		[DxfCodeValue(16, 26, 36)]
-		public XYZ XAxis { get; set; } = XYZ.AxisX;
-
-		/// <summary>
-		/// UCS Y-axis.
-		/// </summary>
-		[DxfCodeValue(17, 27, 37)]
-		public XYZ YAxis { get; set; } = XYZ.AxisY;
-
-		/// <summary>
-		/// Orthographic type of UCS.
-		/// </summary>
-		[DxfCodeValue(76)]
-		public OrthographicType UcsOrthographicType { get; set; }
-
 		/// <summary>
 		/// The associated paper space block table record.
 		/// </summary>
@@ -140,6 +39,120 @@ namespace ACadSharp.Objects
 		}
 
 		/// <summary>
+		/// UCSTableRecord of base UCS if UCS is orthographic (<see cref="UcsOrthographicType"/> is non-zero).
+		/// </summary>
+		/// <remarks>
+		/// If not present and <see cref="UcsOrthographicType"/> is non-zero, then base UCS is taken to be WORLD.
+		/// </remarks>
+		[DxfCodeValue(DxfReferenceType.Handle, 346)]
+		public UCS BaseUCS { get; set; }
+
+		/// <summary>
+		/// Layout elevation.
+		/// </summary>
+		[DxfCodeValue(146)]
+		public double Elevation { get; set; }
+
+		/// <summary>
+		/// Insertion base point for this layout(defined by INSBASE while this layout is current).
+		/// </summary>
+		[DxfCodeValue(12, 22, 32)]
+		public XYZ InsertionBasePoint { get; set; }
+
+		/// <summary>
+		/// If true, the layout is a paper space.
+		/// </summary>
+		public bool IsPaperSpace
+		{
+			get
+			{
+				return !this.Name.Equals(ModelLayoutName, StringComparison.InvariantCultureIgnoreCase);
+			}
+		}
+
+		/// <summary>
+		/// Layout flags.
+		/// </summary>
+		[DxfCodeValue(70)]
+		public LayoutFlags LayoutFlags { get; set; }
+
+		/// <summary>
+		/// Maximum extents for this layout(defined by EXTMAX while this layout is current).
+		/// </summary>
+		[DxfCodeValue(15, 25, 35)]
+		public XYZ MaxExtents { get; set; } = new XYZ(231.3, 175.5, 0.0);
+
+		/// <summary>
+		/// Maximum limits for this layout(defined by LIMMAX while this layout is current).
+		/// </summary>
+		[DxfCodeValue(11, 21)]
+		public XY MaxLimits { get; set; } = new XY(277.0, 202.5);
+
+		/// <summary>
+		/// Minimum extents for this layout(defined by EXTMIN while this layout is current).
+		/// </summary>
+		[DxfCodeValue(14, 24, 34)]
+		public XYZ MinExtents { get; set; } = new XYZ(25.7, 19.5, 0.0);
+
+		/// <summary>
+		/// Minimum limits for this layout (defined by LIMMIN while this layout is current).
+		/// </summary>
+		[DxfCodeValue(10, 20)]
+		public XY MinLimits { get; set; } = new XY(-20.0, -7.5);
+
+		/// <summary>
+		/// Layout name.
+		/// </summary>
+		[DxfCodeValue(1)]
+		public override string Name
+		{
+			get
+			{
+				return base.Name;
+			}
+			set
+			{
+				base.Name = value;
+			}
+		}
+
+		/// <inheritdoc/>
+		public override string ObjectName => DxfFileToken.ObjectLayout;
+
+		/// <inheritdoc/>
+		public override ObjectType ObjectType => ObjectType.LAYOUT;
+
+		/// <summary>
+		/// UCS origin.
+		/// </summary>
+		[DxfCodeValue(13, 23, 33)]
+		public XYZ Origin { get; set; } = XYZ.Zero;
+
+		/// <inheritdoc/>
+		public override string SubclassMarker => DxfSubclassMarker.Layout;
+
+		/// <summary>
+		/// Tab order. This number is an ordinal indicating this layout's ordering in the tab control that is attached to the drawing window. Note that the “Model” tab always appears as the first tab regardless of its tab order.
+		/// </summary>
+		[DxfCodeValue(71)]
+		public int TabOrder { get; set; }
+
+		/// <summary>
+		/// UCS Table Record if UCS is a named UCS.
+		/// </summary>
+		/// <remarks>
+		/// If not present, then UCS is unnamed.
+		/// </remarks>
+		[DxfCodeValue(DxfReferenceType.Handle, 345)]
+		public UCS UCS { get; set; }
+
+		/// <summary>
+		/// Orthographic type of UCS.
+		/// </summary>
+		[DxfCodeValue(76)]
+		public OrthographicType UcsOrthographicType { get; set; }
+
+		/// <summary>
 		/// Viewport that was last active in this layout when the layout was current.
 		/// </summary>
 		[DxfCodeValue(DxfReferenceType.Handle, 331)]
@@ -158,37 +171,6 @@ namespace ACadSharp.Objects
 			}
 		}
 
-		/// <summary>
-		/// UCS Table Record if UCS is a named UCS.
-		/// </summary>
-		/// <remarks>
-		/// If not present, then UCS is unnamed.
-		/// </remarks>
-		[DxfCodeValue(DxfReferenceType.Handle, 345)]
-		public UCS UCS { get; set; }
-
-		/// <summary>
-		/// UCSTableRecord of base UCS if UCS is orthographic (<see cref="UcsOrthographicType"/> is non-zero).
-		/// </summary>
-		/// <remarks>
-		/// If not present and <see cref="UcsOrthographicType"/> is non-zero, then base UCS is taken to be WORLD.
-		/// </remarks>
-		[DxfCodeValue(DxfReferenceType.Handle, 346)]
-		public UCS BaseUCS { get; set; }
-
-		/// <summary>
-		/// If true, the layout is a paper space.
-		/// </summary>
-		public bool IsPaperSpace
-		{
-			get
-			{
-				return !this.Name.Equals(ModelLayoutName, StringComparison.InvariantCultureIgnoreCase);
-			}
-		}
-
-		//333	Shade plot ID
-
 		public IEnumerable<Viewport> Viewports
 		{
 			get
@@ -197,20 +179,39 @@ namespace ACadSharp.Objects
 			}
 		}
 
-		private Viewport _lastViewport;
+		/// <summary>
+		/// UCS X-axis.
+		/// </summary>
+		[DxfCodeValue(16, 26, 36)]
+		public XYZ XAxis { get; set; } = XYZ.AxisX;
+
+		/// <summary>
+		/// UCS Y-axis.
+		/// </summary>
+		[DxfCodeValue(17, 27, 37)]
+		public XYZ YAxis { get; set; } = XYZ.AxisY;
+
+		public const string ModelLayoutName = "Model";
+
+		public const string PaperLayoutName = "Layout1";
 
 		private BlockRecord _blockRecord;
 
-		internal Layout() : base()
+		//333	Shade plot ID
+		private Viewport _lastViewport;
+
+		public Layout(string name) : this(name, name)
 		{
 		}
-
-		public Layout(string name) : this(name, name) { }
 
 		public Layout(string name, string blockName) : base()
 		{
 			this.Name = name;
 			this._blockRecord = new BlockRecord(blockName);
+		}
+
+		internal Layout() : base()
+		{
 		}
 
 		/// <inheritdoc/>

--- a/src/ACadSharp/Tables/BlockRecord.cs
+++ b/src/ACadSharp/Tables/BlockRecord.cs
@@ -283,11 +283,7 @@ namespace ACadSharp.Tables
 		{
 			BlockRecord clone = (BlockRecord)base.Clone();
 
-			Layout layout = (Layout)(this.Layout?.Clone());
-			if (layout is not null)
-			{
-				layout.AssociatedBlock = this;
-			}
+			clone.Layout = null;
 
 			clone.Entities = new CadObjectCollection<Entity>(clone);
 			foreach (var item in this.Entities)


### PR DESCRIPTION
# Description

Fix for the `Clone()` method and Blocks associated to a `Layout`.

Changes in functionality and behavior:
- The cloned `Block` will be unlinked from the `Layout`.
- The cloned `Layout` will keep the `Block`.