### PR TITLE
issue-696 sortentities fix

### DIFF
--- a/src/ACadSharp.Tests/IO/LocalSampleTests.cs
+++ b/src/ACadSharp.Tests/IO/LocalSampleTests.cs
@@ -1,10 +1,7 @@
-﻿using ACadSharp.Entities;
-using ACadSharp.IO;
-using ACadSharp.Tables;
+﻿using ACadSharp.IO;
 using ACadSharp.Tests.TestModels;
 using System.Diagnostics;
 using System.IO;
-using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/src/ACadSharp.Tests/IO/LocalSampleTests.cs
+++ b/src/ACadSharp.Tests/IO/LocalSampleTests.cs
@@ -1,7 +1,10 @@
-﻿using ACadSharp.IO;
+﻿using ACadSharp.Entities;
+using ACadSharp.IO;
+using ACadSharp.Tables;
 using ACadSharp.Tests.TestModels;
 using System.Diagnostics;
 using System.IO;
+using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/src/ACadSharp.Tests/Objects/SortEntitiesTableTests.cs
+++ b/src/ACadSharp.Tests/Objects/SortEntitiesTableTests.cs
@@ -1,0 +1,39 @@
+﻿using ACadSharp.Entities;
+using ACadSharp.Tables;
+using System;
+using Xunit;
+
+namespace ACadSharp.Tests.Objects
+{
+	public class SortEntitiesTableTests
+	{
+		[Fact]
+		public void SortersOrderTest()
+		{
+			var blk = this.createBlock();
+
+			ulong before = 0;
+			foreach (var sorter in blk.SortEntitiesTable)
+			{
+				Assert.True(sorter.SortHandle > before);
+				before = sorter.SortHandle;
+			}
+		}
+
+		protected BlockRecord createBlock()
+		{
+			Random rnd = new Random();
+			var blk = new BlockRecord("my_block");
+			var sort = blk.CreateSortEntitiesTable();
+
+			for (ulong i = 0; i < 5; i++)
+			{
+				var pt = new Point();
+				blk.Entities.Add(pt);
+				sort.Add(pt, (ulong)rnd.Next(1, int.MaxValue));
+			}
+
+			return blk;
+		}
+	}
+}

--- a/src/ACadSharp.Tests/Tables/BlockRecordTests.cs
+++ b/src/ACadSharp.Tests/Tables/BlockRecordTests.cs
@@ -137,8 +137,7 @@ namespace ACadSharp.Tests.Tables
 			record.CreateSortEntitiesTable();
 
 			Assert.NotNull(record.SortEntitiesTable);
-			Assert.NotNull(record.SortEntitiesTable.Sorters);
-			Assert.Empty(record.SortEntitiesTable.Sorters);
+			Assert.Empty(record.SortEntitiesTable);
 		}
 
 		[Fact()]

--- a/src/ACadSharp.Tests/Tables/BlockRecordTests.cs
+++ b/src/ACadSharp.Tests/Tables/BlockRecordTests.cs
@@ -4,6 +4,7 @@ using ACadSharp.Objects;
 using ACadSharp.Tables;
 using ACadSharp.Tests.Common;
 using System;
+using System.Linq;
 using Xunit;
 
 namespace ACadSharp.Tests.Tables
@@ -96,6 +97,37 @@ namespace ACadSharp.Tests.Tables
 
 			Assert.NotNull(layout);
 			Assert.NotNull(layout.AssociatedBlock);
+		}
+
+		[Fact()]
+		public void CloneSortensTableTest()
+		{
+			string name = "my_block";
+			BlockRecord record = new BlockRecord(name);
+
+			Line l1 = new Line();
+			Line l2 = new Line();
+			Line l3 = new Line();
+			Line l4 = new Line();
+			Line l5 = new Line();
+
+			record.Entities.Add(l1);
+			record.Entities.Add(l2);
+			record.Entities.Add(l3);
+			record.Entities.Add(l4);
+			record.Entities.Add(l5);
+
+			record.CreateSortEntitiesTable();
+
+			record.SortEntitiesTable.Add(l1, 1);
+			record.SortEntitiesTable.Add(l3, 3);
+			record.SortEntitiesTable.Add(l4, 4);
+
+			BlockRecord clone = record.CloneTyped();
+
+			Assert.NotNull(clone.SortEntitiesTable);
+			Assert.NotEmpty(clone.SortEntitiesTable);
+			Assert.Equal(3, clone.SortEntitiesTable.Count());
 		}
 
 		[Fact()]

--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>3.0.7</Version>
+		<Version>3.1.0</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 	</PropertyGroup>
 

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
@@ -752,15 +752,15 @@ namespace ACadSharp.IO.DWG
 
 			//Common:
 			//Numentries BL number of entries
-			this._writer.WriteBitLong(sortEntitiesTable.Sorters.Count());
-			foreach (var item in sortEntitiesTable.Sorters)
+			this._writer.WriteBitLong(sortEntitiesTable.Count());
+			foreach (var item in sortEntitiesTable)
 			{
 				//Sort handle(numentries of these, CODE 0, i.e.part of the main bit stream, not of the handle bit stream!).
 				//The sort handle does not have to point to an entity (but it can).
 				//This is just the handle used for determining the drawing order of the entity specified by the entity handle in the handle bit stream.
 				//When the sortentstable doesn’t have a
 				//mapping from entity handle to sort handle, then the entity’s own handle is used for sorting.
-				this._writer.Main.HandleReference(item.Handle);
+				this._writer.Main.HandleReference(item.SortHandle);
 				this._writer.HandleReference(DwgReferenceType.SoftPointer, item.Entity);
 			}
 		}

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
@@ -760,7 +760,7 @@ namespace ACadSharp.IO.DWG
 				//This is just the handle used for determining the drawing order of the entity specified by the entity handle in the handle bit stream.
 				//When the sortentstable doesn’t have a
 				//mapping from entity handle to sort handle, then the entity’s own handle is used for sorting.
-				this._writer.HandleReference(item.Handle);
+				this._writer.Main.HandleReference(item.Handle);
 				this._writer.HandleReference(DwgReferenceType.SoftPointer, item.Entity);
 			}
 		}

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
@@ -502,10 +502,10 @@ namespace ACadSharp.IO.DXF
 
 			this._writer.WriteHandle(330, e.BlockOwner);
 
-			foreach (SortEntitiesTable.Sorter item in e.Sorters)
+			foreach (SortEntitiesTable.Sorter item in e)
 			{
 				this._writer.WriteHandle(331, item.Entity);
-				this._writer.Write(5, item.Handle);
+				this._writer.Write(5, item.SortHandle);
 			}
 		}
 

--- a/src/ACadSharp/IO/Templates/CadSortensTableTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadSortensTableTemplate.cs
@@ -42,7 +42,7 @@ namespace ACadSharp.IO.Templates
 			{
 				if (builder.TryGetCadObject(pair.Item2, out Entity entity))
 				{
-					this.CadObject.AddEntity(entity, pair.Item1.Value);
+					this.CadObject.Add(entity, pair.Item1.Value);
 				}
 				else
 				{

--- a/src/ACadSharp/Objects/SortEntitiesTable.Sorter.cs
+++ b/src/ACadSharp/Objects/SortEntitiesTable.Sorter.cs
@@ -8,43 +8,52 @@ namespace ACadSharp.Objects
 		/// <summary>
 		/// Entity sorter based in their position in the collection.
 		/// </summary>
-		public class Sorter
+		public class Sorter : System.IComparable<Sorter>
 		{
-			/// <inheritdoc/>
+			/// <summary>
+			/// Sorter handle, if this doesn't point to an entity, the value will match with <see cref="Entity"/>'s handle.
+			/// </summary>
 			[DxfCodeValue(5)]
-			public ulong Handle
-			{
-				get
-				{
-					if (this._handle.HasValue)
-					{
-						return this._handle.Value;
-					}
-					else
-					{
-						return this.Entity.Handle;
-					}
-				}
-				internal set { this._handle = value; }
-			}
+			public ulong SortHandle { get; set; }
 
 			/// <summary>
-			/// Soft-pointer ID/handle to an entity
+			/// Entity to set the order to.
 			/// </summary>
 			[DxfCodeValue(331)]
 			public Entity Entity { get; set; }
 
-			private ulong? _handle;
-
 			/// <summary>
 			/// Sorter constructor with the entity and handle.
 			/// </summary>
-			/// <param name="entity">Enity in the block to be sorted.</param>
-			/// <param name="handle">Sorter handle, will use the entity handle if null.</param>
-			public Sorter(Entity entity, ulong? handle = null)
+			/// <param name="entity">Entity in the block to be sorted.</param>
+			/// <param name="handle">Sorter handle.</param>
+			public Sorter(Entity entity, ulong handle)
 			{
 				this.Entity = entity;
-				this._handle = handle;
+				this.SortHandle = handle;
+			}
+
+			/// <inheritdoc/>
+			public override string ToString()
+			{
+				return $"{this.SortHandle} | {this.Entity?.ToString()}";
+			}
+
+			/// <inheritdoc/>
+			public int CompareTo(Sorter other)
+			{
+				if (this.SortHandle < other.SortHandle)
+				{
+					return -1;
+				}
+				else if (this.SortHandle > other.SortHandle)
+				{
+					return 1;
+				}
+				else
+				{
+					return 0;
+				}
 			}
 		}
 	}

--- a/src/ACadSharp/Objects/SortEntitiesTable.cs
+++ b/src/ACadSharp/Objects/SortEntitiesTable.cs
@@ -63,24 +63,6 @@ namespace ACadSharp.Objects
 		}
 
 		/// <summary>
-		/// Add an entity above all existing entities in the table.
-		/// </summary>
-		/// <param name="entity"></param>
-		public void AddAbove(Entity entity)
-		{
-			throw new NotImplementedException();
-		}
-
-		/// <summary>
-		/// Add an entity below all existing entities in the table.
-		/// </summary>
-		/// <param name="entity"></param>
-		public void AddBelow(Entity entity)
-		{
-			throw new NotImplementedException();
-		}
-
-		/// <summary>
 		/// Removes all elements in the collection.
 		/// </summary>
 		public void Clear()

--- a/src/ACadSharp/Objects/SortEntitiesTable.cs
+++ b/src/ACadSharp/Objects/SortEntitiesTable.cs
@@ -4,6 +4,7 @@ using ACadSharp.Tables;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ACadSharp.Objects
 {
@@ -19,24 +20,24 @@ namespace ACadSharp.Objects
 	public partial class SortEntitiesTable : NonGraphicalObject, IEnumerable<SortEntitiesTable.Sorter>
 	{
 		/// <summary>
-		/// Dictionary entry name for the object <see cref="SortEntitiesTable"/>
+		/// Block owner where the table is applied
 		/// </summary>
-		public const string DictionaryEntryName = "ACAD_SORTENTS";
-
-		/// <inheritdoc/>
-		public override ObjectType ObjectType => ObjectType.UNLISTED;
+		[DxfCodeValue(330)]
+		public BlockRecord BlockOwner { get; internal set; }
 
 		/// <inheritdoc/>
 		public override string ObjectName => DxfFileToken.ObjectSortEntsTable;
 
 		/// <inheritdoc/>
+		public override ObjectType ObjectType => ObjectType.UNLISTED;
+
+		/// <inheritdoc/>
 		public override string SubclassMarker => DxfSubclassMarker.SortentsTable;
 
 		/// <summary>
-		/// Block owner where the table is applied
+		/// Dictionary entry name for the object <see cref="SortEntitiesTable"/>
 		/// </summary>
-		[DxfCodeValue(330)]
-		public BlockRecord BlockOwner { get; internal set; }
+		public const string DictionaryEntryName = "ACAD_SORTENTS";
 
 		private List<Sorter> _sorters = new();
 
@@ -62,6 +63,24 @@ namespace ACadSharp.Objects
 		}
 
 		/// <summary>
+		/// Add an entity above all existing entities in the table.
+		/// </summary>
+		/// <param name="entity"></param>
+		public void AddAbove(Entity entity)
+		{
+			throw new NotImplementedException();
+		}
+
+		/// <summary>
+		/// Add an entity below all existing entities in the table.
+		/// </summary>
+		/// <param name="entity"></param>
+		public void AddBelow(Entity entity)
+		{
+			throw new NotImplementedException();
+		}
+
+		/// <summary>
 		/// Removes all elements in the collection.
 		/// </summary>
 		public void Clear()
@@ -80,6 +99,41 @@ namespace ACadSharp.Objects
 		IEnumerator IEnumerable.GetEnumerator()
 		{
 			return this.GetEnumerator();
+		}
+
+		/// <summary>
+		/// Get the sorter handle of an entity, if is not in the sorter table it will return the entity's handle.
+		/// </summary>
+		/// <param name="entity"></param>
+		/// <returns></returns>
+		public ulong GetSorterHandle(Entity entity)
+		{
+			Sorter sorter = this._sorters.FirstOrDefault(s => s.Entity.Equals(entity));
+
+			if (sorter is not null)
+			{
+				return sorter.SortHandle;
+			}
+			else
+			{
+				return entity.Handle;
+			}
+		}
+
+		/// <summary>
+		/// Removes the first occurrence of a specific object from the sorters table.
+		/// </summary>
+		/// <param name="entity"></param>
+		/// <returns></returns>
+		public bool Remove(Entity entity)
+		{
+			var sorter = _sorters.FirstOrDefault(s => s.Entity.Equals(entity));
+			if (sorter is null)
+			{
+				return false;
+			}
+
+			return _sorters.Remove(sorter);
 		}
 	}
 }

--- a/src/ACadSharp/Objects/SortEntitiesTable.cs
+++ b/src/ACadSharp/Objects/SortEntitiesTable.cs
@@ -2,6 +2,7 @@
 using ACadSharp.Entities;
 using ACadSharp.Tables;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace ACadSharp.Objects
@@ -15,7 +16,7 @@ namespace ACadSharp.Objects
 	/// </remarks>
 	[DxfName(DxfFileToken.ObjectSortEntsTable)]
 	[DxfSubClass(DxfSubclassMarker.SortentsTable)]
-	public partial class SortEntitiesTable : NonGraphicalObject
+	public partial class SortEntitiesTable : NonGraphicalObject, IEnumerable<SortEntitiesTable.Sorter>
 	{
 		/// <summary>
 		/// Dictionary entry name for the object <see cref="SortEntitiesTable"/>
@@ -37,11 +38,6 @@ namespace ACadSharp.Objects
 		[DxfCodeValue(330)]
 		public BlockRecord BlockOwner { get; internal set; }
 
-		/// <summary>
-		/// List of the <see cref="BlockOwner"/> entities sorted.
-		/// </summary>
-		public IEnumerable<Sorter> Sorters { get { return this._sorters; } }
-
 		private List<Sorter> _sorters = new();
 
 		internal SortEntitiesTable()
@@ -58,16 +54,32 @@ namespace ACadSharp.Objects
 		/// Sorter attached to an entity.
 		/// </summary>
 		/// <param name="entity">Entity in the block to be sorted.</param>
-		/// <param name="sorterHandle">Sorter handle, will use the entity handle if null.</param>
+		/// <param name="sorterHandle">Sorter handle.</param>
 		/// <exception cref="ArgumentException"></exception>
-		public void AddEntity(Entity entity, ulong? sorterHandle = null)
+		public void Add(Entity entity, ulong sorterHandle)
 		{
 			this._sorters.Add(new Sorter(entity, sorterHandle));
 		}
 
-		internal void OnAddEntity(object sender, CollectionChangedEventArgs e)
+		/// <summary>
+		/// Removes all elements in the collection.
+		/// </summary>
+		public void Clear()
 		{
-			this._sorters.Add(new Sorter((Entity)e.Item));
+			this._sorters.Clear();
+		}
+
+		/// <inheritdoc/>
+		public IEnumerator<Sorter> GetEnumerator()
+		{
+			this._sorters.Sort();
+			return this._sorters.GetEnumerator();
+		}
+
+		/// <inheritdoc/>
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return this.GetEnumerator();
 		}
 	}
 }

--- a/src/ACadSharp/Tables/BlockRecord.cs
+++ b/src/ACadSharp/Tables/BlockRecord.cs
@@ -300,7 +300,7 @@ namespace ACadSharp.Tables
 		}
 
 		/// <summary>
-		///
+		/// Create an entity sorter table for this block.
 		/// </summary>
 		/// <returns></returns>
 		public SortEntitiesTable CreateSortEntitiesTable()

--- a/src/ACadSharp/Tables/BlockRecord.cs
+++ b/src/ACadSharp/Tables/BlockRecord.cs
@@ -350,6 +350,32 @@ namespace ACadSharp.Tables
 			return box;
 		}
 
+		/// <summary>
+		/// Get the entities in this block record sorted by it's handle and the sorter assigned if is present.
+		/// </summary>
+		/// <remarks>
+		/// If the record is not in a document the entities will not be sorted unless there is a
+		/// <see cref="SortEntitiesTable"/> assigned to the block.
+		/// </remarks>
+		/// <returns></returns>
+		public IEnumerable<Entity> GetSortedEntities()
+		{
+			if (this.SortEntitiesTable != null)
+			{
+				return this.Entities.OrderBy(e => e.Handle);
+			}
+
+			List<(ulong, Entity)> entities = new();
+
+			foreach (var entity in this.Entities)
+			{
+				ulong sorter = this.SortEntitiesTable.GetSorterHandle(entity);
+				entities.Add((sorter, entity));
+			}
+
+			return entities.OrderBy(e => e.Item1).Select(e => e.Item2);
+		}
+
 		internal override void AssignDocument(CadDocument doc)
 		{
 			base.AssignDocument(doc);

--- a/src/ACadSharp/Tables/BlockRecord.cs
+++ b/src/ACadSharp/Tables/BlockRecord.cs
@@ -285,10 +285,22 @@ namespace ACadSharp.Tables
 
 			clone.Layout = null;
 
+			if (this.SortEntitiesTable != null)
+			{
+				clone.CreateSortEntitiesTable();
+			}
+
 			clone.Entities = new CadObjectCollection<Entity>(clone);
 			foreach (var item in this.Entities)
 			{
-				clone.Entities.Add((Entity)item.Clone());
+				var e = (Entity)item.Clone();
+				clone.Entities.Add(e);
+
+				if (this.SortEntitiesTable != null
+					&& this.SortEntitiesTable.Select(s => s.Entity).Contains(item))
+				{
+					clone.SortEntitiesTable.Add(e, this.SortEntitiesTable.GetSorterHandle(item));
+				}
 			}
 
 			clone.BlockEntity = (Block)this.BlockEntity.Clone();


### PR DESCRIPTION
# Description

Fix for `SortEntitiesTable` and exploration of how this works on the view.

# Conclusions 

- Entities can be repeated.
- The entities are drawn using the handle value, unless they are assigned to the `SortEntitiesTable`.
- `SortHandle` overrides the `Entity.Handle` value for the drawing order.
- Adding entities with other owners doesn't take any negative effect.

# Tests

The drawing contains a 2 lines and 1 wipeout, 1 line is below the other is above. The sort table looks:

![image](https://github.com/user-attachments/assets/297a55dd-b4bb-4141-b189-524d78798fab)

```C#
var below = doc.GetCadObject<Line>(598);
var above = doc.GetCadObject<Line>(599);
var wipeout = doc.GetCadObject<Wipeout>(600);
```

{600 | LINE:599} //Line above
{599 | WIPEOUT:600}  //Wipeout

## Add an entity:

Adding the following entry doesn't change any order:
```C#
sort.AddEntity(below, wipeout.Handle);
```
{600 | LINE:598}

Adding the following entry doesn't change any order:
```C#
sort.AddEntity(below, wipeout.Handle);
sort.AddEntity(wipeout, below.Handle);
```
{600 | LINE:598}
{598 | WIPEOUT:600} 

## Test order:

Resetting the table and adding the following entries only takes effect for the below line.
```C#
sort.Clear();
sort.AddEntity(below, wipeout.Handle);
sort.AddEntity(above, wipeout.Handle);
sort.AddEntity(wipeout, below.Handle);
sort.AddEntity(wipeout, above.Handle);
```

![image](https://github.com/user-attachments/assets/1ad7d850-2ac1-4511-b2fd-2c51294af46b)

Resetting the table and adding the following entries places both lines above the wipeout.
```C#
sort.Clear();
sort.AddEntity(below, wipeout.Handle);
sort.AddEntity(wipeout, below.Handle);
```

![image](https://github.com/user-attachments/assets/f5a52ebe-711c-472d-9520-e1aabdf10bf0)

## Change handle

Enforcing a new handle for the Line below, like 700, will change the drawing order, meaning that the handles of the entities stablish the drawing order if it's not specified for the table.

## Single entry

By adding only the following entry to the table the wipeout is placed below all the entities.
```C#
sort.Clear();
sort.AddEntity(wipeout, 400);
```
![image](https://github.com/user-attachments/assets/1cb0f946-c964-4218-839d-38bad6005a6d)

It seems that the table overrides the handle of the entity and process the drawing order, which means that by only changing the `SortHandle` is enough to stablish the drawing order.

## Invert order

This code using simplified handles sort the entities in the invert way of the initial file.
```C#
sort.Clear();
sort.AddEntity(above, 1);
sort.AddEntity(wipeout, 2);
sort.AddEntity(below, 3);
```
OR
```C#
sort.Clear();
sort.AddEntity(below, 3);
sort.AddEntity(above, 1);
sort.AddEntity(wipeout, 2);
```

![image](https://github.com/user-attachments/assets/f6a76e25-7728-4268-b1e1-c28c77598da1)


