### PR TITLE
Dwg ignore entities

### DIFF
--- a/src/ACadSharp.Tests/IO/RewriteSamplesTests.cs
+++ b/src/ACadSharp.Tests/IO/RewriteSamplesTests.cs
@@ -23,7 +23,7 @@ namespace ACadSharp.Tests.IO
 
 		[Theory]
 		[MemberData(nameof(DwgFiles))]
-		public void ReadUserDwg(FileModel test)
+		public void ReadDwgWriteDwg(FileModel test)
 		{
 			if (string.IsNullOrEmpty(test.Path))
 				return;

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Entities.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Entities.cs
@@ -14,18 +14,6 @@ namespace ACadSharp.IO.DWG
 			List<Entity> children = new List<Entity>();
 			Seqend seqend = null;
 
-			//Ignored Entities
-			switch (entity)
-			{
-				case ProxyEntity:
-				case TableEntity:
-				case UnknownEntity:
-				case Solid3D:
-				case Mesh:
-					this.notify($"Entity type not implemented {entity.GetType().FullName}", NotificationType.NotImplemented);
-					return;
-			}
-
 			this.writeCommonEntityData(entity);
 
 			switch (entity)

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.cs
@@ -213,7 +213,7 @@ namespace ACadSharp.IO.DWG
 
 				this._prev = null;
 				this._next = null;
-				Entity[] arr = blkRecord.Entities.ToArray();
+				Entity[] arr = getCompatibleEntities(blkRecord.Entities);
 				for (int i = 0; i < arr.Length; i++)
 				{
 					this._prev = arr.ElementAtOrDefault(i - 1);
@@ -227,6 +227,28 @@ namespace ACadSharp.IO.DWG
 				this._next = null;
 
 				this.writeBlockEnd(blkRecord.BlockEnd);
+			}
+		}
+
+		private Entity[] getCompatibleEntities(IEnumerable<Entity> entities)
+		{
+			return entities.Where(e => this.isEntitySupported(e)).ToArray();
+
+		}
+
+		private bool isEntitySupported(Entity entity)
+		{
+			switch (entity)
+			{
+				case ProxyEntity:
+				case TableEntity:
+				case UnknownEntity:
+				case Mesh:
+				case Solid3D:
+					this.notify($"Entity type not implemented {entity.GetType().FullName}", NotificationType.NotImplemented);
+					return false;
+				default:
+					return true;
 			}
 		}
 


### PR DESCRIPTION
# Description

Ignore the not supported entities without interfering with the prev next storage design.