### PR TITLE
Fix #796

### DIFF
--- a/src/ACadSharp/Objects/Evaluations/EvaluationGraph.GraphNode.cs
+++ b/src/ACadSharp/Objects/Evaluations/EvaluationGraph.GraphNode.cs
@@ -77,8 +77,8 @@ namespace ACadSharp.Objects.Evaluations
 			{
 				Node clone = (Node)MemberwiseClone();
 
-				clone.Next = (Node)Next.Clone();
-				clone.Expression = (EvaluationExpression)Expression.Clone();
+				clone.Next = (Node)Next?.Clone();
+				clone.Expression = (EvaluationExpression)Expression?.Clone();
 
 				return clone;
 			}


### PR DESCRIPTION
- EvaluationGraph.Node.Clone(): Account for Next == null, Expression == null