### PR TITLE
[DWG][AC1021] Fix issue "Array dimensions exceeded supported range"

### DIFF
--- a/src/ACadSharp/IO/DWG/DwgReader.cs
+++ b/src/ACadSharp/IO/DWG/DwgReader.cs
@@ -1100,8 +1100,6 @@ namespace ACadSharp.IO
 
 		private Stream getSectionBuffer21(DwgFileHeaderAC21 fileheader, string sectionName)
 		{
-			Stream stream = null;
-
 			if (!fileheader.Descriptors.TryGetValue(sectionName, out DwgSectionDescriptor section))
 				return null;
 
@@ -1110,17 +1108,17 @@ namespace ACadSharp.IO
 			foreach (DwgLocalSectionMap page in section.LocalSections)
 				totalLength += page.DecompressedSize;
 
-			//Total buffer for the page
-			byte[] pagesBuffer = new byte[totalLength];
+			MemoryStream memoryStream = HugeMemoryStream.Create((long)totalLength);
 
-			long currOffset = 0;
 			foreach (DwgLocalSectionMap page in section.LocalSections)
 			{
 				if (page.IsEmpty)
 				{
 					//Page is empty, fill the gap with 0s
 					for (int i = 0; i < (int)page.DecompressedSize; ++i)
-						pagesBuffer[(int)currOffset++] = 0;
+					{
+						memoryStream.WriteByte(0);
+					}
 				}
 				else
 				{
@@ -1157,14 +1155,13 @@ namespace ACadSharp.IO
 						pageBytes = arr;
 					}
 
-					for (int i = 0; i < (int)page.DecompressedSize; ++i)
-						pagesBuffer[(int)currOffset++] = pageBytes[i];
+					memoryStream.Write(pageBytes, 0, (int)page.DecompressedSize);
 				}
 			}
 
-			stream = new MemoryStream(pagesBuffer, 0, pagesBuffer.Length, false, true);
+			memoryStream.Position = 0L;
 
-			return stream;
+			return memoryStream;
 		}
 
 		/// <summary>


### PR DESCRIPTION
# Description
Fixed issue "Array dimensions exceeded supported range" when read file .dwg 2GB+ version AC1021

<img width="1208" height="621" alt="AC1021  Array dimensions exceeded supported range" src="https://github.com/user-attachments/assets/3643eb57-4c82-4e9e-b9ab-de97160f87a9" />

# Todo
Resolved: Using HugeMemoryStream