### PR TITLE
Fixes #959 - Text override should be used and replace '<>' with actual measurement string

### DIFF
--- a/src/ACadSharp.Tests/Tables/DimensionStyleTests.cs
+++ b/src/ACadSharp.Tests/Tables/DimensionStyleTests.cs
@@ -197,7 +197,29 @@ namespace ACadSharp.Tests.Tables
 					},
 					new DimensionAligned(XYZ.Zero, new XYZ(10.25, 0, 0)),
 					"1.03E+01"
-				}
+				},
+				{
+					new DimensionStyle {
+						LinearUnitFormat = LinearUnitFormat.Decimal
+					},
+					new DimensionAligned { 
+						FirstPoint = XYZ.Zero, 
+						SecondPoint = new XYZ(10, 0, 0),
+						Text = "<> Dimension"
+						},
+					"10 Dimension"
+				},
+				{
+					new DimensionStyle {
+						LinearUnitFormat = LinearUnitFormat.Decimal
+					},
+					new DimensionAligned {
+						FirstPoint = XYZ.Zero,
+						SecondPoint = new XYZ(13, 0, 0),
+						Text = "A very long text with <> \\x\\p something"
+						},
+					"A very long text with 13 \\x\\p something"
+				},
 			};
 		}
 

--- a/src/ACadSharp/Entities/Dimension.cs
+++ b/src/ACadSharp/Entities/Dimension.cs
@@ -334,11 +334,6 @@ namespace ACadSharp.Entities
 		/// <returns></returns>
 		public string GetMeasurementText(DimensionStyle style)
 		{
-			if (!string.IsNullOrEmpty(this.Text))
-			{
-				return this.Text;
-			}
-
 			string text = string.Empty;
 			double value = style.ApplyRounding(this.Measurement);
 
@@ -406,7 +401,16 @@ namespace ACadSharp.Entities
 					break;
 			}
 
-			return $"{prefix}{text}{style.Suffix}";
+			var valueText = $"{prefix}{text}{style.Suffix}";
+
+			if (!string.IsNullOrEmpty(this.Text))
+			{
+				var styledText = this.Text;
+				styledText = styledText.Replace("<>", valueText);
+				return styledText;
+			}
+
+			return valueText;
 		}
 
 		/// <summary>


### PR DESCRIPTION
# Description
Fixes #959

# Tasks done in this PR
* [x] An evil bug have been defeated.

# Related Issues / Pull Requests
#959 
# Notes for reviewer
Added UnitTests