### PR TITLE
Hatch, apply transform fix.

### DIFF
--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.cs
@@ -96,9 +96,14 @@ namespace ACadSharp.Entities
 			/// <inheritdoc/>
 			public void ApplyTransform(Transform transform)
 			{
-				foreach (var e in this.Edges)
+				foreach (var edge in this.Edges)
 				{
-					e.ApplyTransform(transform);
+					edge.ApplyTransform(transform);
+				}
+
+				foreach (var entity in this.Entities)
+				{
+					entity.ApplyTransform(transform);
 				}
 			}
 


### PR DESCRIPTION
Applying transform to boundary entities as well as to edges, when applying transform to the hatch.

For several files I tried to open, entities where containing some of the boundary, and while hatches being part of the insert, they were missing applying transform when "unpacking" them, messing up the hatches badly.

This simple change fixes that missing behaviour.