### PR TITLE
fix: Handling bit promotision that c/c++ might do with sign extension

### DIFF
--- a/src/ACadSharp/IO/DXF/DxfReader.cs
+++ b/src/ACadSharp/IO/DXF/DxfReader.cs
@@ -386,7 +386,7 @@ namespace ACadSharp.IO
 						break;
 					//Proxy capabilities flag.
 					case 90:
-						curr.ProxyFlags = (ProxyFlags)this._reader.ValueAsUShort;
+						curr.ProxyFlags = (ProxyFlags)(ushort)this._reader.ValueAsInt; 
 						break;
 					//Instance count for a custom class
 					case 91:


### PR DESCRIPTION
I had a one file where:

EXAC_ESW
90
-64511

That value was throwing exception in DxfReader.

However, after closely analyzing it:
-64511 (signed 16-bit) == 1025 (unsigned)

The intention for ProxyFlag was cleary like so, it seems it's about bit operations that apparently some .cad editors might so on this value.

This fix helps for this case and analogous, doesn't break things.