### PR TITLE
Handle angles in radians for hatch arc/ellipse edges

### DIFF
--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>3.4.22</Version>
+		<Version>3.4.23</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>../ACadSharp.snk</AssemblyOriginatorKeyFile>

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.Arc.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.Arc.cs
@@ -26,7 +26,7 @@ namespace ACadSharp.Entities
 				/// <summary>
 				/// End angle.
 				/// </summary>
-				[DxfCodeValue(51)]
+				[DxfCodeValue(DxfReferenceType.IsAngle, 51)]
 				public double EndAngle { get; set; }
 
 				/// <summary>
@@ -41,7 +41,7 @@ namespace ACadSharp.Entities
 				/// <summary>
 				/// Start angle.
 				/// </summary>
-				[DxfCodeValue(50)]
+				[DxfCodeValue(DxfReferenceType.IsAngle, 50)]
 				public double StartAngle { get; set; }
 
 				/// <inheritdoc/>

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.Ellipse.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.Ellipse.cs
@@ -26,7 +26,7 @@ namespace ACadSharp.Entities
 				/// <summary>
 				/// End angle.
 				/// </summary>
-				[DxfCodeValue(51)]
+				[DxfCodeValue(DxfReferenceType.IsAngle, 51)]
 				public double EndAngle { get; set; }
 
 				/// <summary>
@@ -44,7 +44,7 @@ namespace ACadSharp.Entities
 				/// <summary>
 				/// Start angle.
 				/// </summary>
-				[DxfCodeValue(50)]
+				[DxfCodeValue(DxfReferenceType.IsAngle, 50)]
 				public double StartAngle { get; set; }
 
 				/// <inheritdoc/>

--- a/src/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
@@ -2058,10 +2058,10 @@ namespace ACadSharp.IO.DXF
 								arc.Radius = this._reader.ValueAsDouble;
 								break;
 							case 50:
-								arc.StartAngle = this._reader.ValueAsDouble;
+								arc.StartAngle = MathHelper.DegToRad(this._reader.ValueAsDouble);
 								break;
 							case 51:
-								arc.EndAngle = this._reader.ValueAsDouble;
+								arc.EndAngle = MathHelper.DegToRad(this._reader.ValueAsDouble);
 								break;
 							case 73:
 								arc.CounterClockWise = this._reader.ValueAsBool;
@@ -2094,10 +2094,10 @@ namespace ACadSharp.IO.DXF
 								ellipse.MinorToMajorRatio = this._reader.ValueAsDouble;
 								break;
 							case 50:
-								ellipse.StartAngle = this._reader.ValueAsDouble;
+								ellipse.StartAngle = MathHelper.DegToRad(this._reader.ValueAsDouble);
 								break;
 							case 51:
-								ellipse.EndAngle = this._reader.ValueAsDouble;
+								ellipse.EndAngle = MathHelper.DegToRad(this._reader.ValueAsDouble);
 								break;
 							case 73:
 								ellipse.CounterClockWise = this._reader.ValueAsBool;


### PR DESCRIPTION
# Description

Updated StartAngle and EndAngle properties for arc and ellipse boundary paths to use DxfReferenceType.IsAngle. DXF reader now converts group codes 50 and 51 from degrees to radians, ensuring internal consistency for angle representation.