### PR TITLE
Improve DXF DIMENSION handling and refactor builder logic

### DIFF
--- a/src/ACadSharp.Tests/IO/LocalSampleTests.cs
+++ b/src/ACadSharp.Tests/IO/LocalSampleTests.cs
@@ -52,7 +52,9 @@ namespace ACadSharp.Tests.IO
 
 			CadDocument doc = DxfReader.Read(test.Path, this.onNotification);
 
-			if(doc.Header.Version < ACadVersion.AC1012)
+			var item = doc.Entities.OfType<Insert>().FirstOrDefault(i => i.Block.Name == "DRM10__1");
+
+			if (doc.Header.Version < ACadVersion.AC1012)
 			{
 				doc.Header.Version = ACadVersion.AC1032;
 				doc.CreateDefaults();

--- a/src/ACadSharp.Tests/IO/LocalSampleTests.cs
+++ b/src/ACadSharp.Tests/IO/LocalSampleTests.cs
@@ -52,8 +52,6 @@ namespace ACadSharp.Tests.IO
 
 			CadDocument doc = DxfReader.Read(test.Path, this.onNotification);
 
-			var item = doc.Entities.OfType<Insert>().FirstOrDefault(i => i.Block.Name == "DRM10__1");
-
 			if (doc.Header.Version < ACadVersion.AC1012)
 			{
 				doc.Header.Version = ACadVersion.AC1032;

--- a/src/ACadSharp.Tests/IO/LocalSampleTests.cs
+++ b/src/ACadSharp.Tests/IO/LocalSampleTests.cs
@@ -51,6 +51,13 @@ namespace ACadSharp.Tests.IO
 				return;
 
 			CadDocument doc = DxfReader.Read(test.Path, this.onNotification);
+
+			if(doc.Header.Version < ACadVersion.AC1012)
+			{
+				doc.Header.Version = ACadVersion.AC1032;
+				doc.CreateDefaults();
+			}
+
 			if (!TestVariables.SaveOutputInStream)
 			{
 				DxfWriter.Write(Path.Combine(TestVariables.DesktopFolder, "output", "test.dxf"), doc, notification: onNotification);

--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>3.4.23</Version>
+		<Version>3.4.24</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>../ACadSharp.snk</AssemblyOriginatorKeyFile>

--- a/src/ACadSharp/IO/CadDocumentBuilder.cs
+++ b/src/ACadSharp/IO/CadDocumentBuilder.cs
@@ -7,335 +7,334 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace ACadSharp.IO
+namespace ACadSharp.IO;
+
+internal abstract class CadDocumentBuilder
 {
-	internal abstract class CadDocumentBuilder
+	public event NotificationEventHandler OnNotification;
+
+	public AppIdsTable AppIds { get; set; } = new AppIdsTable();
+
+	public BlockRecordsTable BlockRecords { get; set; } = new BlockRecordsTable();
+
+	public DimensionStylesTable DimensionStyles { get; set; } = new DimensionStylesTable();
+
+	public CadDocument DocumentToBuild { get; }
+
+	public ulong InitialHandSeed { get; set; } = 0;
+
+	public abstract bool KeepUnknownEntities { get; }
+
+	public abstract bool KeepUnknownNonGraphicalObjects { get; }
+
+	public LayersTable Layers { get; set; } = new LayersTable();
+
+	public LineTypesTable LineTypesTable { get; set; } = new LineTypesTable();
+
+	public TextStylesTable TextStyles { get; set; } = new TextStylesTable();
+
+	public UCSTable UCSs { get; set; } = new UCSTable();
+
+	public ACadVersion Version { get; }
+
+	public ViewsTable Views { get; set; } = new ViewsTable();
+
+	public VPortsTable VPorts { get; set; } = new VPortsTable();
+
+	protected Dictionary<ulong, CadObject> cadObjects = new();
+
+	protected Dictionary<ulong, ICadObjectTemplate> cadObjectsTemplates = new();
+
+	protected Dictionary<ulong, ICadDictionaryTemplate> dictionaryTemplates = new();
+
+	protected Dictionary<ulong, ICadTableEntryTemplate> tableEntryTemplates = new();
+
+	protected Dictionary<ulong, ICadTableTemplate> tableTemplates = new();
+
+	protected Dictionary<ulong, ICadObjectTemplate> templatesMap = new();
+
+	protected List<ICadObjectTemplate> unassignedObjects = new();
+
+	public CadDocumentBuilder(ACadVersion version, CadDocument document)
 	{
-		public event NotificationEventHandler OnNotification;
+		this.Version = version;
+		this.DocumentToBuild = document;
+	}
 
-		public AppIdsTable AppIds { get; set; } = new AppIdsTable();
-
-		public BlockRecordsTable BlockRecords { get; set; } = new BlockRecordsTable();
-
-		public DimensionStylesTable DimensionStyles { get; set; } = new DimensionStylesTable();
-
-		public CadDocument DocumentToBuild { get; }
-
-		public ulong InitialHandSeed { get; set; } = 0;
-
-		public abstract bool KeepUnknownEntities { get; }
-
-		public abstract bool KeepUnknownNonGraphicalObjects { get; }
-
-		public LayersTable Layers { get; set; } = new LayersTable();
-
-		public LineTypesTable LineTypesTable { get; set; } = new LineTypesTable();
-
-		public TextStylesTable TextStyles { get; set; } = new TextStylesTable();
-
-		public UCSTable UCSs { get; set; } = new UCSTable();
-
-		public ACadVersion Version { get; }
-
-		public ViewsTable Views { get; set; } = new ViewsTable();
-
-		public VPortsTable VPorts { get; set; } = new VPortsTable();
-
-		protected Dictionary<ulong, CadObject> cadObjects = new();
-
-		protected Dictionary<ulong, ICadObjectTemplate> cadObjectsTemplates = new();
-
-		protected Dictionary<ulong, ICadDictionaryTemplate> dictionaryTemplates = new();
-
-		protected Dictionary<ulong, ICadTableEntryTemplate> tableEntryTemplates = new();
-
-		protected Dictionary<ulong, ICadTableTemplate> tableTemplates = new();
-
-		protected Dictionary<ulong, ICadObjectTemplate> templatesMap = new();
-
-		protected List<ICadObjectTemplate> unassignedObjects = new();
-
-		public CadDocumentBuilder(ACadVersion version, CadDocument document)
+	public void AddTemplate(ICadObjectTemplate template)
+	{
+		if (!this.addToMap(template))
 		{
-			this.Version = version;
-			this.DocumentToBuild = document;
+			return;
 		}
 
-		public void AddTemplate(ICadObjectTemplate template)
+		switch (template)
 		{
-			if (!this.addToMap(template))
-			{
-				return;
-			}
+			case ICadDictionaryTemplate dictionaryTemplate:
+				this.dictionaryTemplates.Add(dictionaryTemplate.CadObject.Handle, dictionaryTemplate);
+				break;
+			case ICadTableTemplate tableTemplate:
+				this.tableTemplates.Add(tableTemplate.CadObject.Handle, tableTemplate);
+				break;
+			case ICadTableEntryTemplate tableEntryTemplate:
+				this.tableEntryTemplates.Add(tableEntryTemplate.CadObject.Handle, tableEntryTemplate);
+				break;
+			default:
+				this.cadObjectsTemplates.Add(template.CadObject.Handle, template);
+				break;
+		}
+	}
 
-			switch (template)
-			{
-				case ICadDictionaryTemplate dictionaryTemplate:
-					this.dictionaryTemplates.Add(dictionaryTemplate.CadObject.Handle, dictionaryTemplate);
-					break;
-				case ICadTableTemplate tableTemplate:
-					this.tableTemplates.Add(tableTemplate.CadObject.Handle, tableTemplate);
-					break;
-				case ICadTableEntryTemplate tableEntryTemplate:
-					this.tableEntryTemplates.Add(tableEntryTemplate.CadObject.Handle, tableEntryTemplate);
-					break;
-				default:
-					this.cadObjectsTemplates.Add(template.CadObject.Handle, template);
-					break;
-			}
+	public virtual void BuildDocument()
+	{
+		foreach (ICadTableEntryTemplate template in this.tableEntryTemplates.Values)
+		{
+			template.Build(this);
 		}
 
-		public virtual void BuildDocument()
+		foreach (CadTemplate template in this.cadObjectsTemplates.Values)
 		{
-			foreach (ICadTableEntryTemplate template in this.tableEntryTemplates.Values)
-			{
-				template.Build(this);
-			}
+			template.Build(this);
+		}
+	}
 
-			foreach (CadTemplate template in this.cadObjectsTemplates.Values)
-			{
-				template.Build(this);
-			}
+	public void BuildTable<T>(Table<T> table)
+		where T : TableEntry
+	{
+		if (this.tableTemplates.TryGetValue(table.Handle, out ICadTableTemplate template))
+		{
+			template.Build(this);
+		}
+		else
+		{
+			this.Notify($"Table {table.ObjectName} not found in the document", NotificationType.Warning);
+		}
+	}
+
+	public void BuildTables()
+	{
+		this.BuildTable(this.AppIds);
+		this.BuildTable(this.TextStyles);
+		this.BuildTable(this.LineTypesTable);
+		this.BuildTable(this.Layers);
+		this.BuildTable(this.UCSs);
+		this.BuildTable(this.Views);
+		this.BuildTable(this.BlockRecords);
+		this.BuildTable(this.DimensionStyles);
+		this.BuildTable(this.VPorts);
+	}
+
+	public T GetObjectTemplate<T>(ulong handle) where T : CadTemplate
+	{
+		if (this.templatesMap.TryGetValue(handle, out ICadObjectTemplate template))
+		{
+			return (T)template;
 		}
 
-		public void BuildTable<T>(Table<T> table)
-			where T : TableEntry
+		return null;
+	}
+
+	public void Notify(string message, NotificationType notificationType = NotificationType.None, Exception exception = null)
+	{
+		this.OnNotification?.Invoke(this, new NotificationEventArgs(message, notificationType, exception));
+	}
+
+	public void RegisterTables()
+	{
+		this.DocumentToBuild.RegisterCollection(this.AppIds);
+		this.DocumentToBuild.RegisterCollection(this.TextStyles);
+		this.DocumentToBuild.RegisterCollection(this.LineTypesTable);
+		this.DocumentToBuild.RegisterCollection(this.Layers);
+		this.DocumentToBuild.RegisterCollection(this.UCSs);
+		this.DocumentToBuild.RegisterCollection(this.Views);
+		this.DocumentToBuild.RegisterCollection(this.BlockRecords);
+		this.DocumentToBuild.RegisterCollection(this.DimensionStyles);
+		this.DocumentToBuild.RegisterCollection(this.VPorts);
+	}
+
+	public bool TryGetCadObject<T>(ulong? handle, out T value) where T : CadObject
+	{
+		if (!handle.HasValue || handle == 0)
 		{
-			if (this.tableTemplates.TryGetValue(table.Handle, out ICadTableTemplate template))
-			{
-				template.Build(this);
-			}
-			else
-			{
-				this.Notify($"Table {table.ObjectName} not found in the document", NotificationType.Warning);
-			}
+			value = null;
+			return false;
 		}
 
-		public void BuildTables()
+		if (this.cadObjects.TryGetValue(handle.Value, out CadObject obj))
 		{
-			this.BuildTable(this.AppIds);
-			this.BuildTable(this.TextStyles);
-			this.BuildTable(this.LineTypesTable);
-			this.BuildTable(this.Layers);
-			this.BuildTable(this.UCSs);
-			this.BuildTable(this.Views);
-			this.BuildTable(this.BlockRecords);
-			this.BuildTable(this.DimensionStyles);
-			this.BuildTable(this.VPorts);
-		}
-
-		public T GetObjectTemplate<T>(ulong handle) where T : CadTemplate
-		{
-			if (this.templatesMap.TryGetValue(handle, out ICadObjectTemplate template))
-			{
-				return (T)template;
-			}
-
-			return null;
-		}
-
-		public void Notify(string message, NotificationType notificationType = NotificationType.None, Exception exception = null)
-		{
-			this.OnNotification?.Invoke(this, new NotificationEventArgs(message, notificationType, exception));
-		}
-
-		public void RegisterTables()
-		{
-			this.DocumentToBuild.RegisterCollection(this.AppIds);
-			this.DocumentToBuild.RegisterCollection(this.TextStyles);
-			this.DocumentToBuild.RegisterCollection(this.LineTypesTable);
-			this.DocumentToBuild.RegisterCollection(this.Layers);
-			this.DocumentToBuild.RegisterCollection(this.UCSs);
-			this.DocumentToBuild.RegisterCollection(this.Views);
-			this.DocumentToBuild.RegisterCollection(this.BlockRecords);
-			this.DocumentToBuild.RegisterCollection(this.DimensionStyles);
-			this.DocumentToBuild.RegisterCollection(this.VPorts);
-		}
-
-		public bool TryGetCadObject<T>(ulong? handle, out T value) where T : CadObject
-		{
-			if (!handle.HasValue || handle == 0)
+			if (obj is UnknownEntity && !this.KeepUnknownEntities)
 			{
 				value = null;
 				return false;
 			}
 
-			if (this.cadObjects.TryGetValue(handle.Value, out CadObject obj))
+			if (obj is UnknownNonGraphicalObject && !this.KeepUnknownNonGraphicalObjects)
 			{
-				if (obj is UnknownEntity && !this.KeepUnknownEntities)
-				{
-					value = null;
-					return false;
-				}
-
-				if (obj is UnknownNonGraphicalObject && !this.KeepUnknownNonGraphicalObjects)
-				{
-					value = null;
-					return false;
-				}
-
-				if (obj is T)
-				{
-					value = (T)obj;
-					return true;
-				}
-			}
-
-			value = null;
-			return false;
-		}
-
-		public bool TryGetObjectTemplate<T>(ulong? handle, out T value)
-			where T : ICadObjectTemplate
-		{
-			if (!handle.HasValue || handle == 0)
-			{
-				value = default;
+				value = null;
 				return false;
 			}
 
-			if (this.templatesMap.TryGetValue(handle.Value, out ICadObjectTemplate template))
+			if (obj is T)
 			{
-				if (template is T)
-				{
-					value = (T)template;
-					return true;
-				}
+				value = (T)obj;
+				return true;
 			}
+		}
 
+		value = null;
+		return false;
+	}
+
+	public bool TryGetObjectTemplate<T>(ulong? handle, out T value)
+		where T : ICadObjectTemplate
+	{
+		if (!handle.HasValue || handle == 0)
+		{
 			value = default;
 			return false;
 		}
 
-		public bool TryGetTableEntry<T>(string name, out T entry)
-			where T : TableEntry
+		if (this.templatesMap.TryGetValue(handle.Value, out ICadObjectTemplate template))
 		{
-			//Only to be used when the tables are build
-			if (string.IsNullOrEmpty(name))
+			if (template is T)
 			{
-				entry = null;
-				return false;
+				value = (T)template;
+				return true;
 			}
-
-			Table<T> table = null;
-			if (typeof(T) == typeof(AppId))
-			{
-				table = this.AppIds as Table<T>;
-			}
-			else if (typeof(T) == typeof(Layer))
-			{
-				table = this.Layers as Table<T>;
-			}
-			else if (typeof(T) == typeof(LineType))
-			{
-				table = this.LineTypesTable as Table<T>;
-			}
-			else if (typeof(T) == typeof(UCS))
-			{
-				table = this.UCSs as Table<T>;
-			}
-			else if (typeof(T) == typeof(View))
-			{
-				table = this.Views as Table<T>;
-			}
-			else if (typeof(T) == typeof(DimensionStyle))
-			{
-				table = this.DimensionStyles as Table<T>;
-			}
-			else if (typeof(T) == typeof(TextStyle))
-			{
-				table = this.TextStyles as Table<T>;
-			}
-			else if (typeof(T) == typeof(VPortsTable))
-			{
-				table = this.VPorts as Table<T>;
-			}
-			else if (typeof(T) == typeof(BlockRecord))
-			{
-				table = this.BlockRecords as Table<T>;
-			}
-
-			if (table == null)
-			{
-				entry = null;
-				return false;
-			}
-
-			return table.TryGetValue(name, out entry);
 		}
 
-		protected void buildDictionaries()
+		value = default;
+		return false;
+	}
+
+	public bool TryGetTableEntry<T>(string name, out T entry)
+		where T : TableEntry
+	{
+		//Only to be used when the tables are build
+		if (string.IsNullOrEmpty(name))
 		{
-			foreach (ICadDictionaryTemplate dictionaryTemplate in dictionaryTemplates.Values)
-			{
-				dictionaryTemplate.Build(this);
-			}
-
-			if (this.DocumentToBuild.RootDictionary == null)
-			{
-				var root = this.dictionaryTemplates.Values.Select(t => t.CadObject).OfType<CadDictionary>().Where(d => d.Owner == null);
-				if (root.Count() > 1 || !root.Any())
-				{
-					this.Notify($"The root dictionary could not be found.", NotificationType.Warning);
-				}
-				else
-				{
-					this.DocumentToBuild.RootDictionary = root.FirstOrDefault();
-				}
-			}
-
-			this.DocumentToBuild.UpdateCollections(true, false);
+			entry = null;
+			return false;
 		}
 
-		protected void createMissingHandles()
+		Table<T> table = null;
+		if (typeof(T) == typeof(AppId))
 		{
-			foreach (var template in this.unassignedObjects)
-			{
-				template.CadObject.Handle = this.InitialHandSeed + 1;
-				this.AddTemplate(template);
-			}
-
-			this.unassignedObjects.Clear();
+			table = this.AppIds as Table<T>;
+		}
+		else if (typeof(T) == typeof(Layer))
+		{
+			table = this.Layers as Table<T>;
+		}
+		else if (typeof(T) == typeof(LineType))
+		{
+			table = this.LineTypesTable as Table<T>;
+		}
+		else if (typeof(T) == typeof(UCS))
+		{
+			table = this.UCSs as Table<T>;
+		}
+		else if (typeof(T) == typeof(View))
+		{
+			table = this.Views as Table<T>;
+		}
+		else if (typeof(T) == typeof(DimensionStyle))
+		{
+			table = this.DimensionStyles as Table<T>;
+		}
+		else if (typeof(T) == typeof(TextStyle))
+		{
+			table = this.TextStyles as Table<T>;
+		}
+		else if (typeof(T) == typeof(VPortsTable))
+		{
+			table = this.VPorts as Table<T>;
+		}
+		else if (typeof(T) == typeof(BlockRecord))
+		{
+			table = this.BlockRecords as Table<T>;
 		}
 
-		protected void registerTable<T, R>(T table)
-			where T : Table<R>
-			where R : TableEntry
+		if (table == null)
 		{
-			if (table == null)
+			entry = null;
+			return false;
+		}
+
+		return table.TryGetValue(name, out entry);
+	}
+
+	protected void buildDictionaries()
+	{
+		foreach (ICadDictionaryTemplate dictionaryTemplate in dictionaryTemplates.Values)
+		{
+			dictionaryTemplate.Build(this);
+		}
+
+		if (this.DocumentToBuild.RootDictionary == null)
+		{
+			var root = this.dictionaryTemplates.Values.Select(t => t.CadObject).OfType<CadDictionary>().Where(d => d.Owner == null);
+			if (root.Count() > 1 || !root.Any())
 			{
-				this.DocumentToBuild.RegisterCollection((T)Activator.CreateInstance(typeof(T)));
+				this.Notify($"The root dictionary could not be found.", NotificationType.Warning);
 			}
 			else
 			{
-				this.DocumentToBuild.RegisterCollection(table);
+				this.DocumentToBuild.RootDictionary = root.FirstOrDefault();
 			}
 		}
 
-		private bool addToMap(ICadObjectTemplate template)
+		this.DocumentToBuild.UpdateCollections(true, false);
+	}
+
+	protected void createMissingHandles()
+	{
+		foreach (var template in this.unassignedObjects)
 		{
-			if (template.CadObject.Handle == 0)
-			{
-				this.unassignedObjects.Add(template);
-				return false;
-			}
-
-			if (this.templatesMap.ContainsKey(template.CadObject.Handle))
-			{
-				this.Notify($"Repeated handle found {template.CadObject.Handle}.", NotificationType.Warning);
-				template.CadObject.Handle = 0;
-				this.unassignedObjects.Add(template);
-				return false;
-			}
-
-			if (template.CadObject.Handle > this.InitialHandSeed)
-			{
-				this.InitialHandSeed = template.CadObject.Handle;
-			}
-
-			this.templatesMap.Add(template.CadObject.Handle, template);
-			this.cadObjects.Add(template.CadObject.Handle, template.CadObject);
-			return true;
+			template.CadObject.Handle = this.InitialHandSeed + 1;
+			this.AddTemplate(template);
 		}
+
+		this.unassignedObjects.Clear();
+	}
+
+	protected void registerTable<T, R>(T table)
+		where T : Table<R>
+		where R : TableEntry
+	{
+		if (table == null)
+		{
+			this.DocumentToBuild.RegisterCollection((T)Activator.CreateInstance(typeof(T)));
+		}
+		else
+		{
+			this.DocumentToBuild.RegisterCollection(table);
+		}
+	}
+
+	private bool addToMap(ICadObjectTemplate template)
+	{
+		if (template.CadObject.Handle == 0)
+		{
+			this.unassignedObjects.Add(template);
+			return false;
+		}
+
+		if (this.templatesMap.ContainsKey(template.CadObject.Handle))
+		{
+			this.Notify($"Repeated handle found {template.CadObject.Handle}.", NotificationType.Warning);
+			template.CadObject.Handle = 0;
+			this.unassignedObjects.Add(template);
+			return false;
+		}
+
+		if (template.CadObject.Handle > this.InitialHandSeed)
+		{
+			this.InitialHandSeed = template.CadObject.Handle;
+		}
+
+		this.templatesMap.Add(template.CadObject.Handle, template);
+		this.cadObjects.Add(template.CadObject.Handle, template.CadObject);
+		return true;
 	}
 }

--- a/src/ACadSharp/IO/DXF/DxfStreamReader/DxfBlockSectionReader.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamReader/DxfBlockSectionReader.cs
@@ -158,7 +158,7 @@ namespace ACadSharp.IO.DXF
 
 				if (entityTemplate.OwnerHandle == null)
 				{
-					recordTemplate.OwnedObjectsHandlers.Add(entityTemplate.CadObject.Handle);
+					recordTemplate.ReferenceTemplates.Add(entityTemplate);
 				}
 				else if (this._builder.TryGetObjectTemplate(entityTemplate.OwnerHandle, out ICadOwnerTemplate owner))
 				{
@@ -166,7 +166,7 @@ namespace ACadSharp.IO.DXF
 				}
 				else
 				{
-					_builder.OrphanTemplates.Add(entityTemplate);
+					this._builder.OrphanTemplates.Add(entityTemplate);
 				}
 			}
 

--- a/src/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
@@ -164,7 +164,13 @@ namespace ACadSharp.IO.DXF
 				case DxfFileToken.EntityCircle:
 					return this.readEntityCodes<Circle>(new CadEntityTemplate<Circle>(), this.readCircle);
 				case DxfFileToken.EntityDimension:
-					return this.readEntityCodes<Dimension>(new CadDimensionTemplate(), this.readDimension);
+					var dimTemplate = this.readEntityCodes<Dimension>(new CadDimensionTemplate(), this.readDimension);
+					if (dimTemplate.CadObject is CadDimensionTemplate.DimensionPlaceholder)
+					{
+						this._builder.Notify($"[{DxfFileToken.EntityDimension}] No subtype found, object discarded.", NotificationType.Warning);
+						return null;
+					}
+					return dimTemplate;
 				case DxfFileToken.Entity3DFace:
 					return this.readEntityCodes<Face3D>(new CadEntityTemplate<Face3D>(), this.readEntitySubclassMap);
 				case DxfFileToken.EntityEllipse:
@@ -755,11 +761,56 @@ namespace ACadSharp.IO.DXF
 					var dim = new DimensionLinear();
 					tmp.SetDimensionObject(dim);
 					dim.Rotation = this._reader.ValueAsAngle;
-					map.SubClasses.Add(DxfSubclassMarker.LinearDimension, DxfClassMap.Create<DimensionLinear>());
+					if (!map.SubClasses.ContainsKey(DxfSubclassMarker.LinearDimension))
+					{
+						map.SubClasses.Add(DxfSubclassMarker.LinearDimension, DxfClassMap.Create<DimensionLinear>());
+					}
 					return true;
 				case 70:
 					//Flags do not have set
 					tmp.SetDimensionFlags((DimensionType)this._reader.ValueAsShort);
+
+					if (tmp.CadObject is CadDimensionTemplate.DimensionPlaceholder placeholder && this._builder.Version < ACadVersion.AC1012)
+					{
+						switch (placeholder.Flags)
+						{
+							case DimensionType.Linear:
+								tmp.SetDimensionObject(new DimensionLinear());
+								map.SubClasses.Add(DxfSubclassMarker.AlignedDimension, DxfClassMap.Create<DimensionAligned>());
+								map.SubClasses.Add(DxfSubclassMarker.LinearDimension, DxfClassMap.Create<DimensionLinear>());
+								break;
+							case DimensionType.Aligned:
+								tmp.SetDimensionObject(new DimensionAligned());
+								map.SubClasses.Add(DxfSubclassMarker.AlignedDimension, DxfClassMap.Create<DimensionAligned>());
+								break;
+							case DimensionType.Angular:
+								tmp.SetDimensionObject(new DimensionAngular2Line());
+								map.SubClasses.Add(DxfSubclassMarker.Angular2LineDimension, DxfClassMap.Create<DimensionAngular2Line>());
+								break;
+							case DimensionType.Diameter:
+								tmp.SetDimensionObject(new DimensionDiameter());
+								map.SubClasses.Add(DxfSubclassMarker.DiametricDimension, DxfClassMap.Create<DimensionDiameter>());
+								break;
+							case DimensionType.Radius:
+								tmp.SetDimensionObject(new DimensionRadius());
+								map.SubClasses.Add(DxfSubclassMarker.RadialDimension, DxfClassMap.Create<DimensionRadius>());
+								break;
+							case DimensionType.Angular3Point:
+								tmp.SetDimensionObject(new DimensionAngular3Pt());
+								map.SubClasses.Add(DxfSubclassMarker.Angular3PointDimension, DxfClassMap.Create<DimensionAngular3Pt>());
+								break;
+							case DimensionType.Ordinate:
+							case DimensionType.OrdinateTypeX:
+							case DimensionType.Ordinate | DimensionType.OrdinateTypeX:
+								tmp.SetDimensionObject(new DimensionOrdinate());
+								map.SubClasses.Add(DxfSubclassMarker.OrdinateDimension, DxfClassMap.Create<DimensionOrdinate>());
+								break;
+							case DimensionType.BlockReference:
+							case DimensionType.TextUserDefinedLocation:
+							default:
+								break;
+						}
+					}
 					return true;
 				//Measurement - read only
 				case 42:

--- a/src/ACadSharp/IO/Templates/CadBlockRecordTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadBlockRecordTemplate.cs
@@ -5,108 +5,118 @@ using ACadSharp.Tables;
 using CSUtilities.Extensions;
 using System.Collections.Generic;
 
-namespace ACadSharp.IO.Templates
+namespace ACadSharp.IO.Templates;
+
+internal class CadBlockRecordTemplate : CadTableEntryTemplate<BlockRecord>, ICadOwnerTemplate
 {
-	internal class CadBlockRecordTemplate : CadTableEntryTemplate<BlockRecord>, ICadOwnerTemplate
+	public ulong? BeginBlockHandle { get; set; }
+
+	public CadBlockEntityTemplate BlockEntityTemplate { get; set; }
+
+	public ulong? EndBlockHandle { get; set; }
+
+	public ulong? FirstEntityHandle { get; set; }
+
+	public List<ulong> InsertHandles { get; } = new();
+
+	public ulong? LastEntityHandle { get; set; }
+
+	public ulong? LayoutHandle { get; set; }
+
+	public HashSet<ulong> OwnedObjectsHandlers { get; } = new();
+
+	public HashSet<CadEntityTemplate> ReferenceTemplates { get; } = new HashSet<CadEntityTemplate>();
+
+	public CadBlockRecordTemplate() : base(new BlockRecord())
 	{
-		public ulong? FirstEntityHandle { get; set; }
+	}
 
-		public ulong? LastEntityHandle { get; set; }
+	public CadBlockRecordTemplate(BlockRecord block) : base(block)
+	{
+	}
 
-		public ulong? BeginBlockHandle { get; set; }
-
-		public ulong? EndBlockHandle { get; set; }
-
-		public ulong? LayoutHandle { get; set; }
-
-		public HashSet<ulong> OwnedObjectsHandlers { get; set; } = new();
-
-		public List<ulong> InsertHandles { get; set; } = new();
-
-		public CadBlockEntityTemplate BlockEntityTemplate { get; set; }
-
-		public CadBlockRecordTemplate() : base(new BlockRecord()) { }
-
-		public CadBlockRecordTemplate(BlockRecord block) : base(block) { }
-
-		protected override void build(CadDocumentBuilder builder)
+	public void SetBlockToRecord(CadDocumentBuilder builder, DWG.DwgHeaderHandlesCollection headerHandles)
+	{
+		if (builder.TryGetCadObject(this.BeginBlockHandle, out Block block))
 		{
-			base.build(builder);
-
-			if (builder.TryGetCadObject(this.LayoutHandle, out Layout layout))
+			if (!block.Name.IsNullOrEmpty())
 			{
-				this.CadObject.Layout = layout;
+				this.CadObject.Name = block.Name;
 			}
 
-			if (this.FirstEntityHandle.HasValue && this.FirstEntityHandle.Value != 0)
-			{
-				foreach (Entity e in this.getEntitiesCollection<Entity>(builder, this.FirstEntityHandle.Value, this.LastEntityHandle.Value))
-				{
-					this.addEntity(builder, e);
-				}
-			}
-			else
-			{
-				if (this.BlockEntityTemplate != null)
-				{
-					this.OwnedObjectsHandlers.UnionWith(this.BlockEntityTemplate.OwnedObjectsHandlers);
-				}
+			block.Flags = this.CadObject.BlockEntity.Flags;
+			block.BasePoint = this.CadObject.BlockEntity.BasePoint;
+			block.XRefPath = this.CadObject.BlockEntity.XRefPath;
+			block.Comments = this.CadObject.BlockEntity.Comments;
+			block.IsUnloaded = this.CadObject.BlockEntity.IsUnloaded;
 
-				foreach (ulong handle in this.OwnedObjectsHandlers)
+			this.CadObject.BlockEntity = block;
+		}
+
+		if (builder.TryGetCadObject(this.EndBlockHandle, out BlockEnd blockEnd))
+		{
+			this.CadObject.BlockEnd = blockEnd;
+		}
+
+		this.ensureCorrectNaming(builder, headerHandles.MODEL_SPACE, BlockRecord.ModelSpaceName);
+		this.ensureCorrectNaming(builder, headerHandles.PAPER_SPACE, BlockRecord.PaperSpaceName);
+	}
+
+	protected override void build(CadDocumentBuilder builder)
+	{
+		base.build(builder);
+
+		if (builder.TryGetCadObject(this.LayoutHandle, out Layout layout))
+		{
+			this.CadObject.Layout = layout;
+		}
+
+		if (this.FirstEntityHandle.HasValue && this.FirstEntityHandle.Value != 0)
+		{
+			foreach (Entity e in this.getEntitiesCollection<Entity>(builder, this.FirstEntityHandle.Value, this.LastEntityHandle.Value))
+			{
+				this.addEntity(builder, e);
+			}
+		}
+		else
+		{
+			if (this.BlockEntityTemplate != null)
+			{
+				this.OwnedObjectsHandlers.UnionWith(this.BlockEntityTemplate.OwnedObjectsHandlers);
+			}
+
+			foreach (ulong handle in this.OwnedObjectsHandlers)
+			{
+				if (builder.TryGetCadObject(handle, out Entity child))
 				{
-					if (builder.TryGetCadObject(handle, out Entity child))
-					{
-						this.addEntity(builder, child);
-					}
+					this.addEntity(builder, child);
 				}
 			}
 		}
 
-		public void SetBlockToRecord(CadDocumentBuilder builder, DWG.DwgHeaderHandlesCollection headerHandles)
+		foreach (var item in this.ReferenceTemplates)
 		{
-			if (builder.TryGetCadObject(this.BeginBlockHandle, out Block block))
-			{
-				if (!block.Name.IsNullOrEmpty())
-				{
-					this.CadObject.Name = block.Name;
-				}
+			this.addEntity(builder, item.CadObject);
+		}
+	}
 
-				block.Flags = this.CadObject.BlockEntity.Flags;
-				block.BasePoint = this.CadObject.BlockEntity.BasePoint;
-				block.XRefPath = this.CadObject.BlockEntity.XRefPath;
-				block.Comments = this.CadObject.BlockEntity.Comments;
-				block.IsUnloaded = this.CadObject.BlockEntity.IsUnloaded;
-
-				this.CadObject.BlockEntity = block;
-			}
-
-			if (builder.TryGetCadObject(this.EndBlockHandle, out BlockEnd blockEnd))
-			{
-				this.CadObject.BlockEnd = blockEnd;
-			}
-
-			this.ensureCorrectNaming(builder, headerHandles.MODEL_SPACE, BlockRecord.ModelSpaceName);
-			this.ensureCorrectNaming(builder, headerHandles.PAPER_SPACE, BlockRecord.PaperSpaceName);
+	private void addEntity(CadDocumentBuilder builder, Entity entity)
+	{
+		if (!builder.KeepUnknownEntities && entity is UnknownEntity)
+		{
+			return;
 		}
 
-		private void ensureCorrectNaming(CadDocumentBuilder builder, ulong? handle, string expected)
-		{
-			if (this.CadObject.Handle == handle
-				&& !this.CadObject.Name.Equals(expected, System.StringComparison.InvariantCultureIgnoreCase))
-			{
-				builder.Notify($"Invalid name for {this.CadObject.Name} changed to {expected}", NotificationType.Warning);
-				this.CadObject.Name = expected;
-			}
-		}
+		this.CadObject.Entities.Add(entity);
+	}
 
-		private void addEntity(CadDocumentBuilder builder, Entity entity)
+	private void ensureCorrectNaming(CadDocumentBuilder builder, ulong? handle, string expected)
+	{
+		if (this.CadObject.Handle == handle
+			&& !this.CadObject.Name.Equals(expected, System.StringComparison.InvariantCultureIgnoreCase))
 		{
-			if (!builder.KeepUnknownEntities && entity is UnknownEntity)
-			{
-				return;
-			}
-
-			this.CadObject.Entities.Add(entity);
+			builder.Notify($"Invalid name for {this.CadObject.Name} changed to {expected}", NotificationType.Warning);
+			this.CadObject.Name = expected;
 		}
 	}
 }

--- a/src/ACadSharp/IO/Templates/CadDimensionTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadDimensionTemplate.cs
@@ -2,111 +2,108 @@
 using ACadSharp.Tables;
 using CSMath;
 
-namespace ACadSharp.IO.Templates
+namespace ACadSharp.IO.Templates;
+
+internal class CadDimensionTemplate : CadEntityTemplate
 {
-	internal class CadDimensionTemplate : CadEntityTemplate
+	public ulong? StyleHandle { get; set; }
+
+	public ulong? BlockHandle { get; set; }
+
+	public string BlockName { get; set; }
+
+	public string StyleName { get; set; }
+
+	public CadDimensionTemplate() : base(new DimensionPlaceholder()) { }
+
+	public CadDimensionTemplate(Dimension dimension) : base(dimension) { }
+
+	protected override void build(CadDocumentBuilder builder)
 	{
-		public ulong? StyleHandle { get; set; }
+		base.build(builder);
 
-		public ulong? BlockHandle { get; set; }
+		Dimension dimension = this.CadObject as Dimension;
 
-		public string BlockName { get; set; }
-
-		public string StyleName { get; set; }
-
-		public CadDimensionTemplate() : base(new DimensionPlaceholder()) { }
-
-		public CadDimensionTemplate(Dimension dimension) : base(dimension) { }
-
-		protected override void build(CadDocumentBuilder builder)
+		if (this.getTableReference(builder, this.StyleHandle, this.StyleName, out DimensionStyle style))
 		{
-			base.build(builder);
-
-			Dimension dimension = this.CadObject as Dimension;
-
-			if (this.getTableReference(builder, this.StyleHandle, this.StyleName, out DimensionStyle style))
-			{
-				dimension.Style = style;
-			}
-
-			if (this.getTableReference(builder, this.BlockHandle, this.BlockName, out BlockRecord block))
-			{
-				dimension.Block = block;
-			}
+			dimension.Style = style;
 		}
 
-		public class DimensionPlaceholder : Dimension
+		if (this.getTableReference(builder, this.BlockHandle, this.BlockName, out BlockRecord block))
 		{
-			public override ObjectType ObjectType { get { return ObjectType.INVALID; } }
+			dimension.Block = block;
+		}
+	}
 
-			public override double Measurement { get; }
+	public class DimensionPlaceholder : Dimension
+	{
+		public override ObjectType ObjectType { get { return ObjectType.INVALID; } }
 
-			public DimensionPlaceholder() : base(DimensionType.Linear) { }
+		public override double Measurement { get; }
 
-			public override BoundingBox GetBoundingBox()
-			{
-				throw new System.InvalidOperationException();
-			}
+		public DimensionPlaceholder() : base(DimensionType.Linear) { }
 
-			public override void ApplyTransform(Transform transform)
-			{
-				throw new System.NotImplementedException();
-			}
-
-			public override void UpdateBlock()
-			{
-				throw new System.NotImplementedException();
-			}
+		public override BoundingBox GetBoundingBox()
+		{
+			throw new System.InvalidOperationException();
 		}
 
-		public void SetDimensionFlags(DimensionType flags)
+		public override void ApplyTransform(Transform transform)
 		{
-			Dimension dimension = this.CadObject as Dimension;
-			dimension.Flags = flags;
+			throw new System.NotImplementedException();
 		}
 
-		public void SetDimensionObject(Dimension dimension)
+		public override void UpdateBlock()
 		{
-			dimension.Handle = this.CadObject.Handle;
-			dimension.Owner = this.CadObject.Owner;
-
-			dimension.XDictionary = this.CadObject.XDictionary;
-			//dimensionAligned.Reactors = this.CadObject.Reactors;
-			//dimensionAligned.ExtendedData = this.CadObject.ExtendedData;
-
-			dimension.Color = this.CadObject.Color;
-			dimension.LineWeight = this.CadObject.LineWeight;
-			dimension.LineTypeScale = this.CadObject.LineTypeScale;
-			dimension.IsInvisible = this.CadObject.IsInvisible;
-			dimension.Transparency = this.CadObject.Transparency;
-
-			Dimension source = this.CadObject as Dimension;
-
-			dimension.Version = source.Version;
-			dimension.DefinitionPoint = source.DefinitionPoint;
-			dimension.TextMiddlePoint = source.TextMiddlePoint;
-			dimension.InsertionPoint = source.InsertionPoint;
-			dimension.Normal = source.Normal;
-			dimension.IsTextUserDefinedLocation = source.IsTextUserDefinedLocation;
-			dimension.AttachmentPoint = source.AttachmentPoint;
-			dimension.LineSpacingStyle = source.LineSpacingStyle;
-			dimension.LineSpacingFactor = source.LineSpacingFactor;
-			//dimensionAligned.Measurement = dimension.Measurement;
-			dimension.Text = source.Text;
-			dimension.TextRotation = source.TextRotation;
-			dimension.HorizontalDirection = source.HorizontalDirection;
-
-			dimension.Flags = source.Flags;
-
-			if (this.CadObject is DimensionAligned aligned &&
-				dimension is DimensionLinear linear)
-			{
-				linear.FirstPoint = aligned.FirstPoint;
-				linear.SecondPoint = aligned.SecondPoint;
-				linear.ExtLineRotation = aligned.ExtLineRotation;
-			}
-
-			this.CadObject = dimension;
+			throw new System.NotImplementedException();
 		}
+	}
+
+	public void SetDimensionFlags(DimensionType flags)
+	{
+		Dimension dimension = this.CadObject as Dimension;
+		dimension.Flags = flags;
+	}
+
+	public void SetDimensionObject(Dimension dimension)
+	{
+		dimension.Handle = this.CadObject.Handle;
+		dimension.Owner = this.CadObject.Owner;
+
+		dimension.XDictionary = this.CadObject.XDictionary;
+		//dimension.ExtendedData = this.CadObject.ExtendedData;
+
+		dimension.Color = this.CadObject.Color;
+		dimension.LineWeight = this.CadObject.LineWeight;
+		dimension.LineTypeScale = this.CadObject.LineTypeScale;
+		dimension.IsInvisible = this.CadObject.IsInvisible;
+		dimension.Transparency = this.CadObject.Transparency;
+
+		Dimension source = this.CadObject as Dimension;
+
+		dimension.Version = source.Version;
+		dimension.DefinitionPoint = source.DefinitionPoint;
+		dimension.TextMiddlePoint = source.TextMiddlePoint;
+		dimension.InsertionPoint = source.InsertionPoint;
+		dimension.Normal = source.Normal;
+		dimension.IsTextUserDefinedLocation = source.IsTextUserDefinedLocation;
+		dimension.AttachmentPoint = source.AttachmentPoint;
+		dimension.LineSpacingStyle = source.LineSpacingStyle;
+		dimension.LineSpacingFactor = source.LineSpacingFactor;
+		dimension.Text = source.Text;
+		dimension.TextRotation = source.TextRotation;
+		dimension.HorizontalDirection = source.HorizontalDirection;
+
+		dimension.Flags = source.Flags;
+
+		if (this.CadObject is DimensionAligned aligned &&
+			dimension is DimensionLinear linear)
+		{
+			linear.FirstPoint = aligned.FirstPoint;
+			linear.SecondPoint = aligned.SecondPoint;
+			linear.ExtLineRotation = aligned.ExtLineRotation;
+		}
+
+		this.CadObject = dimension;
 	}
 }


### PR DESCRIPTION
# Description

- Enhance support for DIMENSION entities, especially for pre-AC1012 DXF files, by resolving dimension types based on flags..
- Refactor CadDocumentBuilder: clarify property definitions, method structure, and template/handle management for better maintainability.
- Improve CadDimensionTemplate to ensure accurate property transfer when setting dimension objects.
- Improve the Blocks section reading.

# TODO 

Some styles do not implicitly have the property values in the dxf which it might cause some differences when saving the file due it's differences with the default values. This issue affects all dxf versions.