### PR TITLE
Issue-998 Improve Insert.GetBoundingBox for rotation and scaling

### DIFF
--- a/src/ACadSharp.Tests/Entities/InsertTest.cs
+++ b/src/ACadSharp.Tests/Entities/InsertTest.cs
@@ -105,6 +105,56 @@ public class InsertTest
 	}
 
 	[Fact]
+	public void GetBoundingBoxForRotatedInsert()
+	{
+		var l = new Line(XYZ.Zero, new XYZ(10, 0, 0));
+		BlockRecord record = new BlockRecord(this._blockName);
+		record.Entities.Add(l);
+
+		Insert insert = new Insert(record);
+		insert.Rotation = MathHelper.HalfPI;
+
+		var box = insert.GetBoundingBox();
+
+		Assert.Equal(XYZ.Zero, box.Min);
+		Assert.Equal(new XYZ(0, 10, 0), box.Max);
+	}
+
+	[Fact]
+	public void GetBoundingBoxForScaledInsert()
+	{
+		var l = new Line(XYZ.Zero, new XYZ(10, 10, 0));
+		BlockRecord record = new BlockRecord(this._blockName);
+		record.Entities.Add(l);
+
+		Insert insert = new Insert(record);
+
+		//Scale
+		insert.XScale = 2;
+
+		var box = insert.GetBoundingBox();
+
+		Assert.Equal(XYZ.Zero, box.Min);
+		Assert.Equal(new XYZ(20, 10, 0), box.Max);
+	}
+
+	[Fact]
+	public void GetBoundingBoxTest()
+	{
+		var l = new Line(XYZ.Zero, new XYZ(10, 10, 0));
+		BlockRecord record = new BlockRecord(this._blockName);
+
+		record.Entities.Add(l);
+
+		Insert insert = new Insert(record);
+
+		var lineBox = l.GetBoundingBox();
+		var box = insert.GetBoundingBox();
+
+		Assert.Equal(lineBox, box);
+	}
+
+	[Fact]
 	public void LinkedAttributes()
 	{
 		BlockRecord record = new BlockRecord(this._blockName);

--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>3.4.26</Version>
+		<Version>3.4.27</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>../ACadSharp.snk</AssemblyOriginatorKeyFile>

--- a/src/ACadSharp/Entities/Insert.cs
+++ b/src/ACadSharp/Entities/Insert.cs
@@ -364,6 +364,13 @@ public class Insert : Entity
 		var min = box.Min * scale + this.InsertPoint;
 		var max = box.Max * scale + this.InsertPoint;
 
+		if (this.Rotation != 0)
+		{
+			var t = Transform.CreateRotation(this.Normal, this.Rotation);
+			min = t.ApplyRotation(min);
+			max = t.ApplyRotation(max);
+		}
+
 		return new BoundingBox(min, max);
 	}
 

--- a/src/ACadSharp/Entities/Insert.cs
+++ b/src/ACadSharp/Entities/Insert.cs
@@ -360,16 +360,10 @@ public class Insert : Entity
 	{
 		BoundingBox box = this.Block.GetBoundingBox();
 
-		var scale = new XYZ(this.XScale, this.YScale, this.ZScale);
-		var min = box.Min * scale + this.InsertPoint;
-		var max = box.Max * scale + this.InsertPoint;
+		var t = this.GetTransform();
 
-		if (this.Rotation != 0)
-		{
-			var t = Transform.CreateRotation(this.Normal, this.Rotation);
-			min = t.ApplyRotation(min);
-			max = t.ApplyRotation(max);
-		}
+		var min = t.ApplyTransform(box.Min);
+		var max = t.ApplyTransform(box.Max);
 
 		return new BoundingBox(min, max);
 	}


### PR DESCRIPTION
# Description

Add unit tests for Insert.GetBoundingBox covering rotation, scaling, and default cases. Update GetBoundingBox to correctly apply rotation to bounding box corners, ensuring accurate results for transformed inserts.