### PR TITLE
refactor: use System.Convert where applicable in group code value conversion

### DIFF
--- a/src/ACadSharp/XData/ExtendedDataRecord.cs
+++ b/src/ACadSharp/XData/ExtendedDataRecord.cs
@@ -41,30 +41,30 @@ namespace ACadSharp.XData
 			switch (groupCode)
 			{
 				case GroupCodeValueType.Bool:
-					return new ExtendedDataInteger16((short)(((bool)value) ? 1 : 0));
+					return new ExtendedDataInteger16((short)((System.Convert.ToBoolean(value)) ? 1 : 0));
 				case GroupCodeValueType.Point3D:
 					return new ExtendedDataCoordinate((XYZ)value);
 				case GroupCodeValueType.Handle:
 				case GroupCodeValueType.ObjectId:
-					return new ExtendedDataHandle((ulong)value);
+					return new ExtendedDataHandle(System.Convert.ToUInt64(value));
 				case GroupCodeValueType.String:
 				case GroupCodeValueType.Comment:
 				case GroupCodeValueType.ExtendedDataString:
-					return new ExtendedDataString((string)value);
+					return new ExtendedDataString(System.Convert.ToString(value));
 				case GroupCodeValueType.Chunk:
 				case GroupCodeValueType.ExtendedDataChunk:
 					return new ExtendedDataBinaryChunk((byte[])value);
 				case GroupCodeValueType.ExtendedDataHandle:
-					return new ExtendedDataHandle((ulong)value);
+					return new ExtendedDataHandle(System.Convert.ToUInt64(value));
 				case GroupCodeValueType.Double:
 				case GroupCodeValueType.ExtendedDataDouble:
-					return new ExtendedDataReal((double)value);
+					return new ExtendedDataReal(System.Convert.ToDouble(value));
 				case GroupCodeValueType.Int16:
 				case GroupCodeValueType.ExtendedDataInt16:
-					return new ExtendedDataInteger16((short)value);
+					return new ExtendedDataInteger16(System.Convert.ToInt16(value));
 				case GroupCodeValueType.Int32:
 				case GroupCodeValueType.ExtendedDataInt32:
-					return new ExtendedDataInteger32((int)value);
+					return new ExtendedDataInteger32(System.Convert.ToInt32(value));
 				case GroupCodeValueType.None:
 				case GroupCodeValueType.Byte:
 				case GroupCodeValueType.Int64:


### PR DESCRIPTION
# Description

This PR normalizes value conversion by using `System.Convert` where applicable, while preserving the original switch order and formatting.
When calling `SetDimensionOverride()`, some override style values caused issues because explicit casts were not always valid.
For example, `ArrowHead.SeparateBlocks` raised an error because an `Int16` was expected, while the provided value was correctly a `bool`.
I tested these changes with my use cases, and everything worked as expected.

# Tasks done in this PR
* [ ] Something awesome.
* [x] An evil bug have been defeated.
* [ ] Code cleanup and maintenance has been done.