### PR TITLE
issue-1048 Update boundary point handling and front plane logic

### DIFF
--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>3.5.4</Version>
+		<Version>3.5.5</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>../ACadSharp.snk</AssemblyOriginatorKeyFile>

--- a/src/ACadSharp/IO/DXF/DxfStreamReader/DxfObjectsSectionReader.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamReader/DxfObjectsSectionReader.cs
@@ -1754,13 +1754,14 @@ namespace ACadSharp.IO.DXF
 					return true;
 				case 20:
 					var pt = filter.BoundaryPoints.LastOrDefault();
-					filter.BoundaryPoints.Add(new CSMath.XY(pt.X, this._reader.ValueAsDouble));
+					filter.BoundaryPoints[filter.BoundaryPoints.Count - 1] = new CSMath.XY(pt.X, this._reader.ValueAsDouble);
 					return true;
 				case 40:
 					if (filter.ClipFrontPlane && !tmp.HasFrontPlane)
 					{
 						filter.FrontDistance = this._reader.ValueAsDouble;
 						tmp.HasFrontPlane = true;
+						return true;
 					}
 
 					double[] array = new double[16]


### PR DESCRIPTION
# Description

Modified group code 20 handling to update the Y value of the last boundary point instead of adding a new point, ensuring correct pairing of X and Y coordinates. Added an early return after setting front plane properties for group code 40 to prevent unintended code execution.
