### PR TITLE
issue-897 Refactor SortEntitiesTable 

### DIFF
--- a/src/ACadSharp.Tests/Objects/SortEntitiesTableTests.cs
+++ b/src/ACadSharp.Tests/Objects/SortEntitiesTableTests.cs
@@ -1,39 +1,474 @@
 ﻿using ACadSharp.Entities;
+using ACadSharp.Objects;
 using ACadSharp.Tables;
 using System;
+using System.Linq;
 using Xunit;
 
-namespace ACadSharp.Tests.Objects
+namespace ACadSharp.Tests.Objects;
+
+public class SortEntitiesTableTests
 {
-	public class SortEntitiesTableTests
+	[Fact]
+	public void MoveToBottom_EntityAlreadyInTable_UpdatesHandleHigherThanMax()
 	{
-		[Fact]
-		public void SortersOrderTest()
-		{
-			var blk = this.createBlock();
+		BlockRecord record = new BlockRecord("test_block");
+		Line l1 = new Line();
+		Line l2 = new Line();
 
-			ulong before = 0;
-			foreach (var sorter in blk.SortEntitiesTable)
-			{
-				Assert.True(sorter.SortHandle > before);
-				before = sorter.SortHandle;
-			}
+		record.Entities.Add(l1);
+		record.Entities.Add(l2);
+
+		record.CreateSortEntitiesTable();
+		SortEntitiesTable table = record.SortEntitiesTable;
+
+		ulong handle1 = 10UL;
+		ulong handle2 = 20UL;
+
+		table.Add(l1, handle1);
+		table.Add(l2, handle2);
+
+		table.MoveToBottom(l1);
+
+		ulong l1SorterHandle = table.GetSorterHandle(l1);
+
+		Assert.True(l1SorterHandle > handle1);
+		Assert.True(l1SorterHandle > handle2);
+	}
+
+	[Fact]
+	public void MoveToBottom_EntityIsLastInEnumeration()
+	{
+		BlockRecord record = new BlockRecord("test_block");
+		Line l1 = new Line();
+		Line l2 = new Line();
+		Line l3 = new Line();
+
+		record.Entities.Add(l1);
+		record.Entities.Add(l2);
+		record.Entities.Add(l3);
+
+		record.CreateSortEntitiesTable();
+		SortEntitiesTable table = record.SortEntitiesTable;
+
+		table.Add(l1, 10UL);
+		table.Add(l2, 20UL);
+		table.Add(l3, 30UL);
+
+		table.MoveToBottom(l1);
+
+		var sorted = table.ToList();
+
+		Assert.Equal(l1, sorted[sorted.Count - 1].Entity);
+	}
+
+	[Fact]
+	public void MoveToBottom_EntityNotInTable_AddsWithHandleHigherThanMax()
+	{
+		BlockRecord record = new BlockRecord("test_block");
+		Line l1 = new Line();
+		Line l2 = new Line();
+		Line l3 = new Line();
+
+		record.Entities.Add(l1);
+		record.Entities.Add(l2);
+		record.Entities.Add(l3);
+
+		record.CreateSortEntitiesTable();
+		SortEntitiesTable table = record.SortEntitiesTable;
+
+		ulong handle1 = 10UL;
+		ulong handle2 = 20UL;
+
+		table.Add(l1, handle1);
+		table.Add(l2, handle2);
+
+		table.MoveToBottom(l3);
+
+		ulong l3SorterHandle = table.GetSorterHandle(l3);
+		ulong maxExisting = Math.Max(handle1, handle2);
+
+		Assert.True(l3SorterHandle > maxExisting);
+		Assert.True(record.GetSortedEntities().Last() == l3);
+	}
+
+	[Fact]
+	public void MoveToTop_EntityAlreadyInTable_UpdatesHandleLowerThanMin()
+	{
+		BlockRecord record = new BlockRecord("test_block");
+		Line l1 = new Line();
+		Line l2 = new Line();
+
+		record.Entities.Add(l1);
+		record.Entities.Add(l2);
+
+		record.CreateSortEntitiesTable();
+		SortEntitiesTable table = record.SortEntitiesTable;
+
+		ulong handle1 = 10UL;
+		ulong handle2 = 20UL;
+
+		table.Add(l1, handle1);
+		table.Add(l2, handle2);
+
+		table.MoveToTop(l1);
+
+		ulong l1SorterHandle = table.GetSorterHandle(l1);
+
+		Assert.True(l1SorterHandle < handle1);
+		Assert.True(l1SorterHandle < handle2);
+	}
+
+	[Fact]
+	public void MoveToTop_EntityIsFirstInEnumeration()
+	{
+		BlockRecord record = new BlockRecord("test_block");
+		Line l1 = new Line();
+		Line l2 = new Line();
+		Line l3 = new Line();
+
+		record.Entities.Add(l1);
+		record.Entities.Add(l2);
+		record.Entities.Add(l3);
+
+		record.CreateSortEntitiesTable();
+		SortEntitiesTable table = record.SortEntitiesTable;
+
+		table.Add(l1, 10UL);
+		table.Add(l2, 20UL);
+		table.Add(l3, 30UL);
+
+		table.MoveToTop(l3);
+
+		var sorted = table.ToList();
+
+		Assert.Equal(l3, sorted[0].Entity);
+	}
+
+	[Fact]
+	public void MoveToTop_EntityNotInTable_AddsWithHandleLowerThanMin()
+	{
+		BlockRecord record = new BlockRecord("test_block");
+		Line l1 = new Line();
+		Line l2 = new Line();
+		Line l3 = new Line();
+
+		record.Entities.Add(l1);
+		record.Entities.Add(l2);
+		record.Entities.Add(l3);
+
+		record.CreateSortEntitiesTable();
+		SortEntitiesTable table = record.SortEntitiesTable;
+
+		ulong handle1 = 10UL;
+		ulong handle2 = 20UL;
+
+		table.Add(l1, handle1);
+		table.Add(l2, handle2);
+
+		table.MoveToTop(l3);
+
+		ulong l3SorterHandle = table.GetSorterHandle(l3);
+		ulong minExisting = Math.Min(handle1, handle2);
+
+		Assert.True(l3SorterHandle < minExisting);
+		Assert.True(record.GetSortedEntities().First() == l3);
+	}
+
+	[Fact]
+	public void OneStepDown_CalledUntilBottom_EntityReachesBottom()
+	{
+		BlockRecord record = new BlockRecord("test_block");
+		Line l1 = new Line();
+		Line l2 = new Line();
+		Line l3 = new Line();
+
+		record.Entities.Add(l1);
+		record.Entities.Add(l2);
+		record.Entities.Add(l3);
+
+		record.CreateSortEntitiesTable();
+		SortEntitiesTable table = record.SortEntitiesTable;
+
+		table.Add(l1, 10UL);
+		table.Add(l2, 20UL);
+		table.Add(l3, 30UL);
+
+		// Move l1 down twice to reach the bottom
+		table.OneStepDown(l1);
+		table.OneStepDown(l1);
+
+		Assert.Equal(l1, table.Last().Entity);
+	}
+
+	[Fact]
+	public void OneStepDown_EntityAlreadyAtBottom_NoActionTaken()
+	{
+		BlockRecord record = new BlockRecord("test_block");
+		Line l1 = new Line();
+		Line l2 = new Line();
+		Line l3 = new Line();
+
+		record.Entities.Add(l1);
+		record.Entities.Add(l2);
+		record.Entities.Add(l3);
+
+		record.CreateSortEntitiesTable();
+		SortEntitiesTable table = record.SortEntitiesTable;
+
+		table.Add(l1, 10UL);
+		table.Add(l2, 20UL);
+		table.Add(l3, 30UL);
+
+		ulong bottomHandleBefore = table.Last().SortHandle;
+
+		table.OneStepDown(l3);
+
+		ulong bottomHandleAfter = table.Last().SortHandle;
+
+		Assert.Equal(l3, table.Last().Entity);
+		Assert.Equal(bottomHandleBefore, bottomHandleAfter);
+	}
+
+	[Fact]
+	public void OneStepDown_EntityAtTop_MovesDownOneStep()
+	{
+		BlockRecord record = new BlockRecord("test_block");
+		Line l1 = new Line();
+		Line l2 = new Line();
+		Line l3 = new Line();
+
+		record.Entities.Add(l1);
+		record.Entities.Add(l2);
+		record.Entities.Add(l3);
+
+		record.CreateSortEntitiesTable();
+		SortEntitiesTable table = record.SortEntitiesTable;
+
+		table.Add(l1, 10UL);
+		table.Add(l2, 20UL);
+		table.Add(l3, 30UL);
+
+		// Before: l1(10) < l2(20) < l3(30)
+		table.OneStepDown(l1);
+
+		var sorted = table.ToList();
+
+		// After: l1 swaps with l2 → l2 < l1 < l3
+		Assert.Equal(l2, sorted[0].Entity);
+		Assert.Equal(l1, sorted[1].Entity);
+		Assert.Equal(l3, sorted[2].Entity);
+	}
+
+	[Fact]
+	public void OneStepDown_EntityInMiddle_MovesDownOneStep()
+	{
+		BlockRecord record = new BlockRecord("test_block");
+		Line l1 = new Line();
+		Line l2 = new Line();
+		Line l3 = new Line();
+
+		record.Entities.Add(l1);
+		record.Entities.Add(l2);
+		record.Entities.Add(l3);
+
+		record.CreateSortEntitiesTable();
+		SortEntitiesTable table = record.SortEntitiesTable;
+
+		table.Add(l1, 10UL);
+		table.Add(l2, 20UL);
+		table.Add(l3, 30UL);
+
+		// Before: l1(10) < l2(20) < l3(30)
+		table.OneStepDown(l2);
+
+		var sorted = table.ToList();
+
+		// After: l2 swaps with l3 → l1 < l3 < l2
+		Assert.Equal(l1, sorted[0].Entity);
+		Assert.Equal(l3, sorted[1].Entity);
+		Assert.Equal(l2, sorted[2].Entity);
+	}
+
+	[Fact]
+	public void OneStepDown_EntityNotInTable_NoActionTaken()
+	{
+		var blk = this.createBlock();
+		SortEntitiesTable table = blk.SortEntitiesTable;
+
+		var handlesBefore = table.Select(s => s.SortHandle).ToArray();
+
+		var outsider = new Point();
+		blk.Entities.Add(outsider);
+		// outsider is NOT added to the sort table
+
+		table.OneStepDown(outsider);
+
+		var handlesAfter = table.Select(s => s.SortHandle).ToArray();
+
+		Assert.Equal(handlesBefore, handlesAfter);
+	}
+
+	[Fact]
+	public void OneStepUp_CalledUntilTop_EntityReachesTop()
+	{
+		BlockRecord record = new BlockRecord("test_block");
+		Line l1 = new Line();
+		Line l2 = new Line();
+		Line l3 = new Line();
+
+		record.Entities.Add(l1);
+		record.Entities.Add(l2);
+		record.Entities.Add(l3);
+
+		record.CreateSortEntitiesTable();
+		SortEntitiesTable table = record.SortEntitiesTable;
+
+		table.Add(l1, 10UL);
+		table.Add(l2, 20UL);
+		table.Add(l3, 30UL);
+
+		// Move l3 up twice to reach the top
+		table.OneStepUp(l3);
+		table.OneStepUp(l3);
+
+		Assert.Equal(l3, table.First().Entity);
+	}
+
+	[Fact]
+	public void OneStepUp_EntityAlreadyAtTop_NoActionTaken()
+	{
+		BlockRecord record = new BlockRecord("test_block");
+		Line l1 = new Line();
+		Line l2 = new Line();
+		Line l3 = new Line();
+
+		record.Entities.Add(l1);
+		record.Entities.Add(l2);
+		record.Entities.Add(l3);
+
+		record.CreateSortEntitiesTable();
+		SortEntitiesTable table = record.SortEntitiesTable;
+
+		table.Add(l1, 10UL);
+		table.Add(l2, 20UL);
+		table.Add(l3, 30UL);
+
+		ulong topHandleBefore = table.First().SortHandle;
+
+		table.OneStepUp(l1);
+
+		ulong topHandleAfter = table.First().SortHandle;
+
+		Assert.Equal(l1, table.First().Entity);
+		Assert.Equal(topHandleBefore, topHandleAfter);
+	}
+
+	[Fact]
+	public void OneStepUp_EntityAtBottom_MovesUpOneStep()
+	{
+		BlockRecord record = new BlockRecord("test_block");
+		Line l1 = new Line();
+		Line l2 = new Line();
+		Line l3 = new Line();
+
+		record.Entities.Add(l1);
+		record.Entities.Add(l2);
+		record.Entities.Add(l3);
+
+		record.CreateSortEntitiesTable();
+		SortEntitiesTable table = record.SortEntitiesTable;
+
+		table.Add(l1, 10UL);
+		table.Add(l2, 20UL);
+		table.Add(l3, 30UL);
+
+		// Before: l1(10) < l2(20) < l3(30)
+		table.OneStepUp(l3);
+
+		var sorted = table.ToList();
+
+		// After: l3 swaps with l2 → l1 < l3 < l2
+		Assert.Equal(l1, sorted[0].Entity);
+		Assert.Equal(l3, sorted[1].Entity);
+		Assert.Equal(l2, sorted[2].Entity);
+	}
+
+	[Fact]
+	public void OneStepUp_EntityInMiddle_MovesUpOneStep()
+	{
+		BlockRecord record = new BlockRecord("test_block");
+		Line l1 = new Line();
+		Line l2 = new Line();
+		Line l3 = new Line();
+
+		record.Entities.Add(l1);
+		record.Entities.Add(l2);
+		record.Entities.Add(l3);
+
+		record.CreateSortEntitiesTable();
+		SortEntitiesTable table = record.SortEntitiesTable;
+
+		table.Add(l1, 10UL);
+		table.Add(l2, 20UL);
+		table.Add(l3, 30UL);
+
+		// Before: l1(10) < l2(20) < l3(30)
+		table.OneStepUp(l2);
+
+		var sorted = table.ToList();
+
+		// After: l2 swaps with l1 → l2 < l1 < l3
+		Assert.Equal(l2, sorted[0].Entity);
+		Assert.Equal(l1, sorted[1].Entity);
+		Assert.Equal(l3, sorted[2].Entity);
+	}
+
+	[Fact]
+	public void OneStepUp_EntityNotInTable_NoActionTaken()
+	{
+		var blk = this.createBlock();
+		SortEntitiesTable table = blk.SortEntitiesTable;
+
+		var handlesBefore = table.Select(s => s.SortHandle).ToArray();
+
+		var outsider = new Point();
+		blk.Entities.Add(outsider);
+		// outsider is NOT added to the sort table
+
+		table.OneStepUp(outsider);
+
+		var handlesAfter = table.Select(s => s.SortHandle).ToArray();
+
+		Assert.Equal(handlesBefore, handlesAfter);
+	}
+
+	[Fact]
+	public void SortersOrderTest()
+	{
+		var blk = this.createBlock();
+
+		ulong before = 0;
+		foreach (var sorter in blk.SortEntitiesTable)
+		{
+			Assert.True(sorter.SortHandle > before);
+			before = sorter.SortHandle;
+		}
+	}
+
+	protected BlockRecord createBlock()
+	{
+		Random rnd = new Random();
+		var blk = new BlockRecord("my_block");
+		var sort = blk.CreateSortEntitiesTable();
+
+		for (ulong i = 0; i < 5; i++)
+		{
+			var pt = new Point();
+			blk.Entities.Add(pt);
+			sort.Add(pt, (ulong)rnd.Next(1, int.MaxValue));
 		}
 
-		protected BlockRecord createBlock()
-		{
-			Random rnd = new Random();
-			var blk = new BlockRecord("my_block");
-			var sort = blk.CreateSortEntitiesTable();
-
-			for (ulong i = 0; i < 5; i++)
-			{
-				var pt = new Point();
-				blk.Entities.Add(pt);
-				sort.Add(pt, (ulong)rnd.Next(1, int.MaxValue));
-			}
-
-			return blk;
-		}
+		return blk;
 	}
 }

--- a/src/ACadSharp.Tests/Tables/BlockRecordTests.cs
+++ b/src/ACadSharp.Tests/Tables/BlockRecordTests.cs
@@ -4,6 +4,7 @@ using ACadSharp.Objects;
 using ACadSharp.Tables;
 using ACadSharp.Tables.Collections;
 using ACadSharp.Tests.Common;
+using CSMath;
 using System;
 using System.IO;
 using System.Linq;
@@ -107,11 +108,17 @@ namespace ACadSharp.Tests.Tables
 			string name = "my_block";
 			BlockRecord record = new BlockRecord(name);
 
-			Line l1 = new Line() { Handle = 10 };
-			Line l2 = new Line() { Handle = 11 };
-			Line l3 = new Line() { Handle = 12 };
-			Line l4 = new Line() { Handle = 13 };
-			Line l5 = new Line() { Handle = 14 };
+			var p1 = new XYZ(1);
+			var p2 = new XYZ(2);
+			var p3 = new XYZ(3);
+			var p4 = new XYZ(4);
+			var p5 = new XYZ(5);
+
+			var l1 = new Point(p1) { Handle = 10 };
+			var l2 = new Point(p2) { Handle = 11 };
+			var l3 = new Point(p3) { Handle = 12 };
+			var l4 = new Point(p4) { Handle = 13 };
+			var l5 = new Point(p5) { Handle = 14 };
 
 			record.Entities.Add(l1);
 			record.Entities.Add(l2);
@@ -140,19 +147,15 @@ namespace ACadSharp.Tests.Tables
 
 			BlockRecord clone = record.CloneTyped();
 
-			Assert.NotNull(clone.SortEntitiesTable);
-			Assert.NotEmpty(clone.SortEntitiesTable);
-			Assert.Equal(5, clone.SortEntitiesTable.Count());
+			Assert.Null(clone.SortEntitiesTable);
 
 			sorted = clone.GetSortedEntities().ToArray();
 
-			Assert.NotNull(clone.SortEntitiesTable);
-			Assert.NotNull(clone.SortEntitiesTable.BlockOwner);
-
-			Assert.Equal(clone, clone.SortEntitiesTable.BlockOwner);
-
-			Assert.NotEqual(clone.SortEntitiesTable.Owner, record.SortEntitiesTable.Owner);
-			Assert.NotEqual(clone.SortEntitiesTable.BlockOwner, record.SortEntitiesTable.BlockOwner);
+			Assert.Equal(l1.Location, p1);
+			Assert.Equal(l3.Location, p3);
+			Assert.Equal(l5.Location, p5);
+			Assert.Equal(l4.Location, p4);
+			Assert.Equal(l2.Location, p2);
 		}
 
 		[Fact()]

--- a/src/ACadSharp.Tests/Tables/BlockRecordTests.cs
+++ b/src/ACadSharp.Tests/Tables/BlockRecordTests.cs
@@ -10,233 +10,232 @@ using System.IO;
 using System.Linq;
 using Xunit;
 
-namespace ACadSharp.Tests.Tables
+namespace ACadSharp.Tests.Tables;
+
+public class BlockRecordTests : TableEntryCommonTests<BlockRecord>
 {
-	public class BlockRecordTests : TableEntryCommonTests<BlockRecord>
+	[Fact()]
+	public void AddEntityTest()
 	{
-		[Fact()]
-		public void AddEntityTest()
+		string name = "my_block";
+		BlockRecord record = new BlockRecord(name);
+
+		Line l1 = new Line();
+		Line l2 = new Line();
+		Line l3 = new Line();
+		Line l4 = new Line();
+
+		record.Entities.Add(l1);
+		record.Entities.Add(l2);
+		record.Entities.Add(l3);
+		record.Entities.Add(l4);
+
+		foreach (Entity e in record.Entities)
 		{
-			string name = "my_block";
-			BlockRecord record = new BlockRecord(name);
-
-			Line l1 = new Line();
-			Line l2 = new Line();
-			Line l3 = new Line();
-			Line l4 = new Line();
-
-			record.Entities.Add(l1);
-			record.Entities.Add(l2);
-			record.Entities.Add(l3);
-			record.Entities.Add(l4);
-
-			foreach (Entity e in record.Entities)
-			{
-				Assert.Equal(record, e.Owner);
-			}
+			Assert.Equal(record, e.Owner);
 		}
+	}
 
-		[Fact()]
-		public void BlockRecordTest()
-		{
-			string name = "my_block";
-			BlockRecord record = new BlockRecord(name);
+	[Fact()]
+	public void BlockRecordTest()
+	{
+		string name = "my_block";
+		BlockRecord record = new BlockRecord(name);
 
-			Assert.Equal(name, record.Name);
+		Assert.Equal(name, record.Name);
 
-			Assert.NotNull(record.BlockEntity);
-			Assert.Equal(record.Name, record.BlockEntity.Name);
+		Assert.NotNull(record.BlockEntity);
+		Assert.Equal(record.Name, record.BlockEntity.Name);
 
-			Assert.NotNull(record.BlockEnd);
-		}
+		Assert.NotNull(record.BlockEnd);
+	}
 
-		[Fact()]
-		public void CloneDetachDocumentTest()
-		{
-			string name = "my_block";
-			BlockRecord record = new BlockRecord(name);
-			CadDocument doc = new CadDocument();
+	[Fact()]
+	public void CloneDetachDocumentTest()
+	{
+		string name = "my_block";
+		BlockRecord record = new BlockRecord(name);
+		CadDocument doc = new CadDocument();
 
-			doc.BlockRecords.Add(record);
+		doc.BlockRecords.Add(record);
 
-			BlockRecord clone = (BlockRecord)record.Clone();
+		BlockRecord clone = (BlockRecord)record.Clone();
 
-			Assert.Null(clone.Document);
-			Assert.Null(clone.BlockEntity.Document);
-			Assert.Null(clone.BlockEnd.Document);
+		Assert.Null(clone.Document);
+		Assert.Null(clone.BlockEntity.Document);
+		Assert.Null(clone.BlockEnd.Document);
 
-			Assert.NotNull(record.Document);
-			Assert.NotNull(record.BlockEntity.Document);
-			Assert.NotNull(record.BlockEnd.Document);
-		}
+		Assert.NotNull(record.Document);
+		Assert.NotNull(record.BlockEntity.Document);
+		Assert.NotNull(record.BlockEnd.Document);
+	}
 
-		[Fact()]
-		public void CloneInDocumentTest()
-		{
-			string name = "my_block";
-			BlockRecord record = new BlockRecord(name);
-			CadDocument doc = new CadDocument();
+	[Fact()]
+	public void CloneInDocumentTest()
+	{
+		string name = "my_block";
+		BlockRecord record = new BlockRecord(name);
+		CadDocument doc = new CadDocument();
 
-			doc.BlockRecords.Add(record);
+		doc.BlockRecords.Add(record);
 
-			Assert.NotNull(record.Document);
-			Assert.NotNull(record.BlockEntity.Document);
-			Assert.NotNull(record.BlockEnd.Document);
-		}
+		Assert.NotNull(record.Document);
+		Assert.NotNull(record.BlockEntity.Document);
+		Assert.NotNull(record.BlockEnd.Document);
+	}
 
-		[Fact()]
-		public void ClonePaperSpaceTest()
-		{
-			CadDocument doc = new CadDocument();
+	[Fact()]
+	public void ClonePaperSpaceTest()
+	{
+		CadDocument doc = new CadDocument();
 
-			BlockRecord record = doc.PaperSpace.CloneTyped();
+		BlockRecord record = doc.PaperSpace.CloneTyped();
 
-			Assert.NotNull(record);
-			Assert.Null(record.Layout);
+		Assert.NotNull(record);
+		Assert.Null(record.Layout);
 
-			//Test the layout keeps the block
-			Layout paper = doc.Layouts["Layout1"];
-			Layout layout = paper.CloneTyped();
+		//Test the layout keeps the block
+		Layout paper = doc.Layouts["Layout1"];
+		Layout layout = paper.CloneTyped();
 
-			Assert.NotNull(layout);
-			Assert.NotNull(layout.AssociatedBlock);
-		}
+		Assert.NotNull(layout);
+		Assert.NotNull(layout.AssociatedBlock);
+	}
 
-		[Fact()]
-		public void CloneSortensTableTest()
-		{
-			string name = "my_block";
-			BlockRecord record = new BlockRecord(name);
+	[Fact()]
+	public void CloneSortensTableTest()
+	{
+		string name = "my_block";
+		BlockRecord record = new BlockRecord(name);
 
-			var p1 = new XYZ(1);
-			var p2 = new XYZ(2);
-			var p3 = new XYZ(3);
-			var p4 = new XYZ(4);
-			var p5 = new XYZ(5);
+		var p1 = new XYZ(1);
+		var p2 = new XYZ(2);
+		var p3 = new XYZ(3);
+		var p4 = new XYZ(4);
+		var p5 = new XYZ(5);
 
-			var l1 = new Point(p1) { Handle = 10 };
-			var l2 = new Point(p2) { Handle = 11 };
-			var l3 = new Point(p3) { Handle = 12 };
-			var l4 = new Point(p4) { Handle = 13 };
-			var l5 = new Point(p5) { Handle = 14 };
+		var l1 = new Point(p1) { Handle = 10 };
+		var l2 = new Point(p2) { Handle = 11 };
+		var l3 = new Point(p3) { Handle = 12 };
+		var l4 = new Point(p4) { Handle = 13 };
+		var l5 = new Point(p5) { Handle = 14 };
 
-			record.Entities.Add(l1);
-			record.Entities.Add(l2);
-			record.Entities.Add(l3);
-			record.Entities.Add(l4);
-			record.Entities.Add(l5);
+		record.Entities.Add(l1);
+		record.Entities.Add(l2);
+		record.Entities.Add(l3);
+		record.Entities.Add(l4);
+		record.Entities.Add(l5);
 
-			record.CreateSortEntitiesTable();
+		record.CreateSortEntitiesTable();
 
-			record.SortEntitiesTable.Add(l1, 1);
-			record.SortEntitiesTable.Add(l3, 3);
-			record.SortEntitiesTable.Add(l4, 8);
-			record.SortEntitiesTable.Add(l5, 4);
+		record.SortEntitiesTable.Add(l1, 1);
+		record.SortEntitiesTable.Add(l3, 3);
+		record.SortEntitiesTable.Add(l4, 8);
+		record.SortEntitiesTable.Add(l5, 4);
 
-			var sorted = record.GetSortedEntities().ToArray();
+		var sorted = record.GetSortedEntities().ToArray();
 
-			Assert.NotNull(record.SortEntitiesTable);
-			Assert.NotEmpty(record.SortEntitiesTable);
-			Assert.Equal(4, record.SortEntitiesTable.Count());
+		Assert.NotNull(record.SortEntitiesTable);
+		Assert.NotEmpty(record.SortEntitiesTable);
+		Assert.Equal(4, record.SortEntitiesTable.Count());
 
-			Assert.Equal(l1, sorted[0]);
-			Assert.Equal(l3, sorted[1]);
-			Assert.Equal(l5, sorted[2]);
-			Assert.Equal(l4, sorted[3]);
-			Assert.Equal(l2, sorted[4]);
+		Assert.Equal(l1, sorted[0]);
+		Assert.Equal(l3, sorted[1]);
+		Assert.Equal(l5, sorted[2]);
+		Assert.Equal(l4, sorted[3]);
+		Assert.Equal(l2, sorted[4]);
 
-			BlockRecord clone = record.CloneTyped();
+		BlockRecord clone = record.CloneTyped();
 
-			Assert.Null(clone.SortEntitiesTable);
+		Assert.Null(clone.SortEntitiesTable);
 
-			sorted = clone.GetSortedEntities().ToArray();
+		sorted = clone.GetSortedEntities().ToArray();
 
-			Assert.Equal(l1.Location, p1);
-			Assert.Equal(l3.Location, p3);
-			Assert.Equal(l5.Location, p5);
-			Assert.Equal(l4.Location, p4);
-			Assert.Equal(l2.Location, p2);
-		}
+		Assert.Equal(l1.Location, p1);
+		Assert.Equal(l3.Location, p3);
+		Assert.Equal(l5.Location, p5);
+		Assert.Equal(l4.Location, p4);
+		Assert.Equal(l2.Location, p2);
+	}
 
-		[Fact()]
-		public void CloneTest()
-		{
-			string name = "my_block";
-			BlockRecord record = new BlockRecord(name);
+	[Fact()]
+	public void CloneTest()
+	{
+		string name = "my_block";
+		BlockRecord record = new BlockRecord(name);
 
-			Line l1 = new Line();
-			Line l2 = new Line();
-			Line l3 = new Line();
-			Line l4 = new Line();
+		Line l1 = new Line();
+		Line l2 = new Line();
+		Line l3 = new Line();
+		Line l4 = new Line();
 
-			record.Entities.Add(l1);
-			record.Entities.Add(l2);
-			record.Entities.Add(l3);
-			record.Entities.Add(l4);
+		record.Entities.Add(l1);
+		record.Entities.Add(l2);
+		record.Entities.Add(l3);
+		record.Entities.Add(l4);
 
-			BlockRecord clone = record.Clone() as BlockRecord;
+		BlockRecord clone = record.Clone() as BlockRecord;
 
-			CadObjectTestUtils.AssertTableEntryClone(record, clone);
+		CadObjectTestUtils.AssertTableEntryClone(record, clone);
 
-			Assert.NotEqual(clone.BlockEntity.Owner, record);
+		Assert.NotEqual(clone.BlockEntity.Owner, record);
 
-			CadObjectTestUtils.AssertEntityCollection(record.Entities, clone.Entities);
-		}
+		CadObjectTestUtils.AssertEntityCollection(record.Entities, clone.Entities);
+	}
 
-		[Fact()]
-		public void CreateSortensTableTest()
-		{
-			string name = "my_block";
-			BlockRecord record = new BlockRecord(name);
+	[Fact()]
+	public void CreateSortensTableTest()
+	{
+		string name = "my_block";
+		BlockRecord record = new BlockRecord(name);
 
-			record.Entities.Add(new Line());
-			record.Entities.Add(new Line());
-			record.Entities.Add(new Line());
-			record.Entities.Add(new Line());
+		record.Entities.Add(new Line());
+		record.Entities.Add(new Line());
+		record.Entities.Add(new Line());
+		record.Entities.Add(new Line());
 
-			record.CreateSortEntitiesTable();
+		record.CreateSortEntitiesTable();
 
-			Assert.NotNull(record.SortEntitiesTable);
-			Assert.Empty(record.SortEntitiesTable);
-		}
+		Assert.NotNull(record.SortEntitiesTable);
+		Assert.Empty(record.SortEntitiesTable);
+	}
 
-		[Fact()]
-		public void CreateXRef()
-		{
-			string name = "my_block";
-			string path = Path.Combine(TestVariables.SamplesFolder, "sample_AC1032.dwg");
-			BlockRecord record = new BlockRecord(name, path);
+	[Fact()]
+	public void CreateXRef()
+	{
+		string name = "my_block";
+		string path = Path.Combine(TestVariables.SamplesFolder, "sample_AC1032.dwg");
+		BlockRecord record = new BlockRecord(name, path);
 
-			Assert.Equal(name, record.Name);
-			Assert.Equal(path, record.BlockEntity.XRefPath);
-			Assert.True(record.Flags.HasFlag(Blocks.BlockTypeFlags.XRef));
-			Assert.True(record.Flags.HasFlag(Blocks.BlockTypeFlags.XRefResolved));
-			Assert.False(record.Flags.HasFlag(Blocks.BlockTypeFlags.XRefOverlay));
+		Assert.Equal(name, record.Name);
+		Assert.Equal(path, record.BlockEntity.XRefPath);
+		Assert.True(record.Flags.HasFlag(Blocks.BlockTypeFlags.XRef));
+		Assert.True(record.Flags.HasFlag(Blocks.BlockTypeFlags.XRefResolved));
+		Assert.False(record.Flags.HasFlag(Blocks.BlockTypeFlags.XRefOverlay));
 
-			BlockRecord overlay = new BlockRecord(name, path, true);
+		BlockRecord overlay = new BlockRecord(name, path, true);
 
-			Assert.Equal(name, overlay.Name);
-			Assert.Equal(path, overlay.BlockEntity.XRefPath);
-			Assert.True(overlay.Flags.HasFlag(Blocks.BlockTypeFlags.XRef));
-			Assert.True(overlay.Flags.HasFlag(Blocks.BlockTypeFlags.XRefResolved));
-			Assert.True(overlay.Flags.HasFlag(Blocks.BlockTypeFlags.XRefOverlay));
-		}
+		Assert.Equal(name, overlay.Name);
+		Assert.Equal(path, overlay.BlockEntity.XRefPath);
+		Assert.True(overlay.Flags.HasFlag(Blocks.BlockTypeFlags.XRef));
+		Assert.True(overlay.Flags.HasFlag(Blocks.BlockTypeFlags.XRefResolved));
+		Assert.True(overlay.Flags.HasFlag(Blocks.BlockTypeFlags.XRefOverlay));
+	}
 
-		[Fact()]
-		public void NotAllowDuplicatesTest()
-		{
-			string name = "my_block";
-			BlockRecord record = new BlockRecord(name);
+	[Fact()]
+	public void NotAllowDuplicatesTest()
+	{
+		string name = "my_block";
+		BlockRecord record = new BlockRecord(name);
 
-			Line l1 = new Line();
+		Line l1 = new Line();
 
-			record.Entities.Add(l1);
-			Assert.Throws<ArgumentException>(() => record.Entities.Add(l1));
-		}
+		record.Entities.Add(l1);
+		Assert.Throws<ArgumentException>(() => record.Entities.Add(l1));
+	}
 
-		protected override Table<BlockRecord> getTable(CadDocument document)
-		{
-			return document.BlockRecords;
-		}
+	protected override Table<BlockRecord> getTable(CadDocument document)
+	{
+		return document.BlockRecords;
 	}
 }

--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>3.6.2</Version>
+		<Version>3.6.3</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>../ACadSharp.snk</AssemblyOriginatorKeyFile>

--- a/src/ACadSharp/Objects/SortEntitiesTable.Sorter.cs
+++ b/src/ACadSharp/Objects/SortEntitiesTable.Sorter.cs
@@ -1,59 +1,58 @@
 ﻿using ACadSharp.Attributes;
 using ACadSharp.Entities;
 
-namespace ACadSharp.Objects
+namespace ACadSharp.Objects;
+
+public partial class SortEntitiesTable
 {
-	public partial class SortEntitiesTable
+	/// <summary>
+	/// Entity sorter based in their position in the collection.
+	/// </summary>
+	public class Sorter : System.IComparable<Sorter>
 	{
 		/// <summary>
-		/// Entity sorter based in their position in the collection.
+		/// Sorter handle, if this doesn't point to an entity, the value will match with <see cref="Entity"/>'s handle.
 		/// </summary>
-		public class Sorter : System.IComparable<Sorter>
+		[DxfCodeValue(5)]
+		public ulong SortHandle { get; set; }
+
+		/// <summary>
+		/// Entity to set the order to.
+		/// </summary>
+		[DxfCodeValue(331)]
+		public Entity Entity { get; set; }
+
+		/// <summary>
+		/// Sorter constructor with the entity and handle.
+		/// </summary>
+		/// <param name="entity">Entity in the block to be sorted.</param>
+		/// <param name="handle">Sorter handle.</param>
+		public Sorter(Entity entity, ulong handle)
 		{
-			/// <summary>
-			/// Sorter handle, if this doesn't point to an entity, the value will match with <see cref="Entity"/>'s handle.
-			/// </summary>
-			[DxfCodeValue(5)]
-			public ulong SortHandle { get; set; }
+			this.Entity = entity;
+			this.SortHandle = handle;
+		}
 
-			/// <summary>
-			/// Entity to set the order to.
-			/// </summary>
-			[DxfCodeValue(331)]
-			public Entity Entity { get; set; }
+		/// <inheritdoc/>
+		public override string ToString()
+		{
+			return $"{this.SortHandle} | {this.Entity?.ToString()}";
+		}
 
-			/// <summary>
-			/// Sorter constructor with the entity and handle.
-			/// </summary>
-			/// <param name="entity">Entity in the block to be sorted.</param>
-			/// <param name="handle">Sorter handle.</param>
-			public Sorter(Entity entity, ulong handle)
+		/// <inheritdoc/>
+		public int CompareTo(Sorter other)
+		{
+			if (this.SortHandle < other.SortHandle)
 			{
-				this.Entity = entity;
-				this.SortHandle = handle;
+				return -1;
 			}
-
-			/// <inheritdoc/>
-			public override string ToString()
+			else if (this.SortHandle > other.SortHandle)
 			{
-				return $"{this.SortHandle} | {this.Entity?.ToString()}";
+				return 1;
 			}
-
-			/// <inheritdoc/>
-			public int CompareTo(Sorter other)
+			else
 			{
-				if (this.SortHandle < other.SortHandle)
-				{
-					return -1;
-				}
-				else if (this.SortHandle > other.SortHandle)
-				{
-					return 1;
-				}
-				else
-				{
-					return 0;
-				}
+				return 0;
 			}
 		}
 	}

--- a/src/ACadSharp/Objects/SortEntitiesTable.cs
+++ b/src/ACadSharp/Objects/SortEntitiesTable.cs
@@ -6,126 +6,219 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace ACadSharp.Objects
+namespace ACadSharp.Objects;
+
+/// <summary>
+/// Represents a <see cref="SortEntitiesTable"/> object
+/// </summary>
+/// <remarks>
+/// Object name <see cref="DxfFileToken.ObjectSortEntsTable"/> <br/>
+/// Dxf class name <see cref="DxfSubclassMarker.SortentsTable"/>
+/// </remarks>
+[DxfName(DxfFileToken.ObjectSortEntsTable)]
+[DxfSubClass(DxfSubclassMarker.SortentsTable)]
+public partial class SortEntitiesTable : NonGraphicalObject, IEnumerable<SortEntitiesTable.Sorter>
 {
 	/// <summary>
-	/// Represents a <see cref="SortEntitiesTable"/> object
+	/// Block owner where the table is applied
 	/// </summary>
-	/// <remarks>
-	/// Object name <see cref="DxfFileToken.ObjectSortEntsTable"/> <br/>
-	/// Dxf class name <see cref="DxfSubclassMarker.SortentsTable"/>
-	/// </remarks>
-	[DxfName(DxfFileToken.ObjectSortEntsTable)]
-	[DxfSubClass(DxfSubclassMarker.SortentsTable)]
-	public partial class SortEntitiesTable : NonGraphicalObject, IEnumerable<SortEntitiesTable.Sorter>
+	[DxfCodeValue(330)]
+	public BlockRecord BlockOwner { get; internal set; }
+
+	/// <inheritdoc/>
+	public override string ObjectName => DxfFileToken.ObjectSortEntsTable;
+
+	/// <inheritdoc/>
+	public override ObjectType ObjectType => ObjectType.UNLISTED;
+
+	/// <inheritdoc/>
+	public override string SubclassMarker => DxfSubclassMarker.SortentsTable;
+
+	/// <summary>
+	/// Dictionary entry name for the object <see cref="SortEntitiesTable"/>
+	/// </summary>
+	public const string DictionaryEntryName = "ACAD_SORTENTS";
+
+	private List<Sorter> _sorters = new();
+
+	internal SortEntitiesTable()
 	{
-		/// <summary>
-		/// Block owner where the table is applied
-		/// </summary>
-		[DxfCodeValue(330)]
-		public BlockRecord BlockOwner { get; internal set; }
+		this.Name = DictionaryEntryName;
+	}
 
-		/// <inheritdoc/>
-		public override string ObjectName => DxfFileToken.ObjectSortEntsTable;
+	internal SortEntitiesTable(BlockRecord owner) : this()
+	{
+		this.BlockOwner = owner;
+	}
 
-		/// <inheritdoc/>
-		public override ObjectType ObjectType => ObjectType.UNLISTED;
+	/// <summary>
+	/// Sorter attached to an entity.
+	/// </summary>
+	/// <param name="entity">Entity in the block to be sorted.</param>
+	/// <param name="sorterHandle">Sorter handle.</param>
+	/// <exception cref="ArgumentException"></exception>
+	public void Add(Entity entity, ulong sorterHandle)
+	{
+		this._sorters.Add(new Sorter(entity, sorterHandle));
+	}
 
-		/// <inheritdoc/>
-		public override string SubclassMarker => DxfSubclassMarker.SortentsTable;
+	/// <summary>
+	/// Removes all elements in the collection.
+	/// </summary>
+	public void Clear()
+	{
+		this._sorters.Clear();
+	}
 
-		/// <summary>
-		/// Dictionary entry name for the object <see cref="SortEntitiesTable"/>
-		/// </summary>
-		public const string DictionaryEntryName = "ACAD_SORTENTS";
+	/// <inheritdoc/>
+	public override CadObject Clone()
+	{
+		SortEntitiesTable clone = (SortEntitiesTable)base.Clone();
 
-		private List<Sorter> _sorters = new();
+		clone._sorters = new List<Sorter>();
 
-		internal SortEntitiesTable()
+		return clone;
+	}
+
+	/// <inheritdoc/>
+	public IEnumerator<Sorter> GetEnumerator()
+	{
+		this._sorters.Sort();
+		return this._sorters.GetEnumerator();
+	}
+
+	/// <inheritdoc/>
+	IEnumerator IEnumerable.GetEnumerator()
+	{
+		return this.GetEnumerator();
+	}
+
+	/// <summary>
+	/// Get the sorter handle of an entity, if is not in the sorter table it will return the entity's handle.
+	/// </summary>
+	/// <param name="entity"></param>
+	/// <returns></returns>
+	public ulong GetSorterHandle(Entity entity)
+	{
+		Sorter sorter = this._sorters.FirstOrDefault(s => s.Entity.Equals(entity));
+
+		if (sorter is not null)
 		{
-			this.Name = DictionaryEntryName;
+			return sorter.SortHandle;
+		}
+		else
+		{
+			return entity.Handle;
+		}
+	}
+
+	/// <summary>
+	/// Moves the specified entity to the bottom of the draw order.
+	/// </summary>
+	/// <param name="entity">Entity to move to the bottom.</param>
+	public void MoveToBottom(Entity entity)
+	{
+		ulong maxHandle = this._sorters.Count > 0
+			? this._sorters.Max(s => s.SortHandle)
+			: entity.Handle;
+
+		ulong newHandle = maxHandle < ulong.MaxValue ? maxHandle + 1 : ulong.MaxValue;
+
+		Sorter existing = this._sorters.FirstOrDefault(s => s.Entity.Equals(entity));
+		if (existing is not null)
+		{
+			existing.SortHandle = newHandle;
+		}
+		else
+		{
+			this._sorters.Add(new Sorter(entity, newHandle));
+		}
+	}
+
+	/// <summary>
+	/// Moves the specified entity to the top of the draw order.
+	/// </summary>
+	/// <param name="entity">Entity to move to the top.</param>
+	public void MoveToTop(Entity entity)
+	{
+		ulong minHandle = this._sorters.Count > 0
+			? this._sorters.Min(s => s.SortHandle)
+			: entity.Handle;
+
+		ulong sorter = minHandle > 0 ? minHandle - 1 : 0;
+
+		Sorter existing = this._sorters.FirstOrDefault(s => s.Entity.Equals(entity));
+		if (existing is not null)
+		{
+			existing.SortHandle = sorter;
+		}
+		else
+		{
+			this._sorters.Add(new Sorter(entity, sorter));
+		}
+	}
+
+	/// <summary>
+	/// Removes the first occurrence of a specific object from the sorters table.
+	/// </summary>
+	/// <param name="entity"></param>
+	/// <returns></returns>
+	public bool Remove(Entity entity)
+	{
+		var sorter = this._sorters.FirstOrDefault(s => s.Entity.Equals(entity));
+		if (sorter is null)
+		{
+			return false;
 		}
 
-		internal SortEntitiesTable(BlockRecord owner) : this()
+		return this._sorters.Remove(sorter);
+	}
+
+	/// <summary>
+	/// Moves the specified entity one step up in the draw order.
+	/// If the entity is not in the table or is already at the top, no action is taken.
+	/// </summary>
+	/// <param name="entity">Entity to move one step up.</param>
+	public void OneStepUp(Entity entity)
+	{
+		Sorter existing = this._sorters.FirstOrDefault(s => s.Entity.Equals(entity));
+		if (existing is null)
 		{
-			this.BlockOwner = owner;
+			return;
 		}
 
-		/// <summary>
-		/// Sorter attached to an entity.
-		/// </summary>
-		/// <param name="entity">Entity in the block to be sorted.</param>
-		/// <param name="sorterHandle">Sorter handle.</param>
-		/// <exception cref="ArgumentException"></exception>
-		public void Add(Entity entity, ulong sorterHandle)
+		int index = this._sorters.OrderBy(s => s.SortHandle).ToList().IndexOf(existing);
+		if (index <= 0 || _sorters.Count < 2)
 		{
-			this._sorters.Add(new Sorter(entity, sorterHandle));
+			return;
 		}
 
-		/// <summary>
-		/// Removes all elements in the collection.
-		/// </summary>
-		public void Clear()
+		Sorter previous = this._sorters[index - 1];
+		(existing.SortHandle, previous.SortHandle) = (previous.SortHandle, existing.SortHandle);
+	}
+
+	/// <summary>
+	/// Moves the specified entity one step down in the draw order.
+	/// If the entity is not in the table or is already at the bottom, no action is taken.
+	/// </summary>
+	/// <param name="entity">Entity to move one step down.</param>
+	public void OneStepDown(Entity entity)
+	{
+		Sorter existing = this._sorters.FirstOrDefault(s => s.Entity.Equals(entity));
+		if (existing is null)
 		{
-			this._sorters.Clear();
+			return;
 		}
 
-		/// <inheritdoc/>
-		public override CadObject Clone()
+		this._sorters.Sort();
+
+		int index = this._sorters.IndexOf(existing);
+		if (index < 0 || index >= this._sorters.Count - 1)
 		{
-			SortEntitiesTable clone = (SortEntitiesTable)base.Clone();
-
-			clone._sorters = new List<Sorter>();
-
-			return clone;
+			return;
 		}
 
-		/// <inheritdoc/>
-		public IEnumerator<Sorter> GetEnumerator()
-		{
-			this._sorters.Sort();
-			return this._sorters.GetEnumerator();
-		}
-
-		/// <inheritdoc/>
-		IEnumerator IEnumerable.GetEnumerator()
-		{
-			return this.GetEnumerator();
-		}
-
-		/// <summary>
-		/// Get the sorter handle of an entity, if is not in the sorter table it will return the entity's handle.
-		/// </summary>
-		/// <param name="entity"></param>
-		/// <returns></returns>
-		public ulong GetSorterHandle(Entity entity)
-		{
-			Sorter sorter = this._sorters.FirstOrDefault(s => s.Entity.Equals(entity));
-
-			if (sorter is not null)
-			{
-				return sorter.SortHandle;
-			}
-			else
-			{
-				return entity.Handle;
-			}
-		}
-
-		/// <summary>
-		/// Removes the first occurrence of a specific object from the sorters table.
-		/// </summary>
-		/// <param name="entity"></param>
-		/// <returns></returns>
-		public bool Remove(Entity entity)
-		{
-			var sorter = _sorters.FirstOrDefault(s => s.Entity.Equals(entity));
-			if (sorter is null)
-			{
-				return false;
-			}
-
-			return _sorters.Remove(sorter);
-		}
+		Sorter next = this._sorters[index + 1];
+		(existing.SortHandle, next.SortHandle) = (next.SortHandle, existing.SortHandle);
 	}
 }

--- a/src/ACadSharp/Tables/BlockRecord.cs
+++ b/src/ACadSharp/Tables/BlockRecord.cs
@@ -388,19 +388,14 @@ public class BlockRecord : TableEntry, IGeometricEntity
 
 		if (this.SortEntitiesTable != null)
 		{
-			clone.SortEntitiesTable.BlockOwner = clone;
+			clone.XDictionary.Remove(SortEntitiesTable.DictionaryEntryName);
 		}
 
 		clone.Entities = new CadObjectCollection<Entity>(clone);
-		foreach (var item in this.Entities)
+		foreach (var item in this.GetSortedEntities())
 		{
 			var e = (Entity)item.Clone();
 			clone.Entities.Add(e);
-
-			if (this.SortEntitiesTable != null)
-			{
-				clone.SortEntitiesTable.Add(e, this.SortEntitiesTable.GetSorterHandle(item));
-			}
 		}
 
 		clone.BlockEntity = (Block)this.BlockEntity.Clone();


### PR DESCRIPTION
# Description

This fix ensures that when cloning a `BlockRecord` the order of the entities is preserved. 