### PR TITLE
Issue/1061 insert addattribute refactor

### DIFF
--- a/src/ACadSharp.Tests/Entities/InsertTest.cs
+++ b/src/ACadSharp.Tests/Entities/InsertTest.cs
@@ -62,7 +62,7 @@ public class InsertTest
 		};
 		insert.Attributes.Add(att1);
 
-		Assert.Equal(new XYZ(15, 15, 0), att1.InsertPoint);
+		Assert.Equal(new CSMath.XYZ(5, 5, 0), att1.InsertPoint);
 
 		Insert clone = insert.CloneTyped();
 
@@ -75,7 +75,7 @@ public class InsertTest
 			InsertPoint = new CSMath.XYZ(5, 5, 0)
 		};
 		clone.Attributes.Add(att2);
-		Assert.Equal(new XYZ(15, 15, 0), att2.InsertPoint);
+		Assert.Equal(new CSMath.XYZ(5, 5, 0), att2.InsertPoint);
 	}
 
 	[Fact]

--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>3.6.4</Version>
+		<Version>3.6.5</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>../ACadSharp.snk</AssemblyOriginatorKeyFile>

--- a/src/ACadSharp/Entities/Insert.cs
+++ b/src/ACadSharp/Entities/Insert.cs
@@ -238,7 +238,12 @@ public class Insert : Entity
 
 		foreach (var item in block.AttributeDefinitions)
 		{
-			this.Attributes.Add(new AttributeEntity(item));
+			var att = new AttributeEntity(item);
+
+			Transform transform = this.GetTransform();
+			att.ApplyTransform(transform);
+
+			this.Attributes.Add(att);
 		}
 	}
 
@@ -407,6 +412,9 @@ public class Insert : Entity
 			{
 				AttributeEntity att = new AttributeEntity(attdef);
 
+				Transform transform = this.GetTransform();
+				att.ApplyTransform(transform);
+
 				this.Attributes.Add(att);
 			}
 		}
@@ -443,12 +451,5 @@ public class Insert : Entity
 	private void initCollections()
 	{
 		this.Attributes = new SeqendCollection<AttributeEntity>(this);
-		this.Attributes.OnAdd += this.onAddAttribute;
-	}
-
-	private void onAddAttribute(object sender, CollectionChangedEventArgs e)
-	{
-		Transform transform = this.GetTransform();
-		(e.Item as AttributeEntity).ApplyTransform(transform);
 	}
 }


### PR DESCRIPTION
# Description

Fix the auto transform for add attribute method at the Insert entity.

This PR fixes the changes made in:
- https://github.com/DomCR/ACadSharp/pull/1017

The PR intended to update the position of the attributes added but after further investigation the position update only is rellevant when the attributes are generated using the att definition in the block record, otherwise the att is completely independent from it.

Note: the attributes usually need an attribute definition to exists, but it seems that the dxf/dwg format allow the attributes to live without one in the `Insert` entity.