### PR TITLE
Add TableStyle DXF writing support and enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ﻿# ACadSharp
-![Build&Test](https://github.com/DomCr/ACadSharp/actions/workflows/csharp.yml/badge.svg) ![License](https://img.shields.io/github/license/DomCr/ACadSharp) ![nuget](https://img.shields.io/nuget/v/Acadsharp) [![Coverage Status](https://coveralls.io/repos/github/DomCR/ACadSharp/badge.svg?branch=master)](https://coveralls.io/github/DomCR/ACadSharp?branch=master)
+![Build&Test](https://github.com/DomCr/ACadSharp/actions/workflows/csharp.yml/badge.svg) ![License](https://img.shields.io/github/license/DomCr/ACadSharp) ![nuget](https://img.shields.io/nuget/v/Acadsharp) ![downloads](https://img.shields.io/nuget/dt/ACadSharp) [![Coverage Status](https://coveralls.io/repos/github/DomCR/ACadSharp/badge.svg?branch=master)](https://coveralls.io/github/DomCR/ACadSharp?branch=master) 
 ---
 
 C# library to read/write cad files like dxf/dwg.

--- a/push-changes.sh
+++ b/push-changes.sh
@@ -1,0 +1,16 @@
+echo Prepare commit
+#Get commit details
+author=`git log -1 --format="%an"`
+email=`git log -1 --format="%ae"`
+
+git config --local user.email "$email"
+git config --local user.name "$author" 
+git add .
+if git diff-index --quiet HEAD; then
+  echo "Nothing changed"
+  exit 0
+fi
+
+echo "Pushing changes $BRANCH"
+git commit -m "Update project version to $VERSION"
+git push origin $BRANCH

--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>3.6.5</Version>
+		<Version>3.6.6</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>../ACadSharp.snk</AssemblyOriginatorKeyFile>

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
@@ -41,8 +41,7 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 			}
 
 			//Not compatible dictionaries
-			if (item.Name == CadDictionary.AcadTableStyle
-					|| item.Name == CadDictionary.AcadMaterial)
+			if (item.Name == CadDictionary.AcadMaterial)
 			{
 				return;
 			}
@@ -443,6 +442,9 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 			case SortEntitiesTable sortensTable:
 				this.writeSortentsTable(sortensTable);
 				break;
+			case TableStyle tableStyle:
+				this.writeTableStyle(tableStyle);
+				break;
 			case XRecord record:
 				this.writeXRecord(record);
 				break;
@@ -590,7 +592,6 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 			case Material:
 			case MultiLeaderObjectContextData:
 			case VisualStyle:
-			case TableStyle:
 			case ProxyObject:
 			case BlockRepresentationData:
 			case MTextAttributeObjectContextData:
@@ -604,6 +605,35 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 
 	private void writeAcdbPlaceHolder(AcdbPlaceHolder acdbPlaceHolder)
 	{
+	}
+
+	private void writeCellStyle(TableStyle.CellStyle cellStyle)
+	{
+		this._writer.WriteName(7, cellStyle.TextStyle);
+
+		this._writer.Write(140, cellStyle.TextHeight);
+		this._writer.Write(170, cellStyle.CellAlignment);
+
+		this._writer.Write(62, cellStyle.ContentColor.GetApproxIndex());
+		this._writer.Write(63, cellStyle.BackgroundColor.GetApproxIndex());
+		this._writer.Write(283, cellStyle.IsFillColorOn ? 1 : 0);
+
+		this._writer.Write(90, (int)cellStyle.Type);
+		this._writer.Write(91, (int)cellStyle.ValueDataType);
+
+		this.writeCellStyleBorder(cellStyle.TopBorder, 0);
+		this.writeCellStyleBorder(cellStyle.HorizontalInsideBorder, 1);
+		this.writeCellStyleBorder(cellStyle.BottomBorder, 2);
+		this.writeCellStyleBorder(cellStyle.LeftBorder, 3);
+		this.writeCellStyleBorder(cellStyle.VerticalInsideBorder, 4);
+		this.writeCellStyleBorder(cellStyle.RightBorder, 5);
+	}
+
+	private void writeCellStyleBorder(TableStyle.CellBorder border, int i)
+	{
+		this._writer.Write(274 + i, (short)border.LineWeight);
+		this._writer.Write(284 + i, border.IsInvisible ? 0 : 1);
+		this._writer.Write(64 + i, border.Color.GetApproxIndex());
 	}
 
 	private void writeDimensionAssociation(DimensionAssociation dimAssociation)
@@ -777,5 +807,27 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 		{
 			this._writer.Write(40, array[i]);
 		}
+	}
+
+	private void writeTableStyle(TableStyle style)
+	{
+		DxfClassMap map = DxfClassMap.Create<TableStyle>();
+
+		this._writer.Write(100, DxfSubclassMarker.TableStyle);
+
+		this._writer.Write(3, style.Description, map);
+
+		this._writer.Write(70, style.FlowDirection, map);
+		this._writer.Write(71, style.Flags, map);
+
+		this._writer.Write(40, style.HorizontalCellMargin, map);
+		this._writer.Write(41, style.VerticalCellMargin, map);
+
+		this._writer.Write(280, style.SuppressTitle ? 1 : 0, map);
+		this._writer.Write(281, style.SuppressHeaderRow ? 1 : 0, map);
+
+		this.writeCellStyle(style.DataCellStyle);
+		this.writeCellStyle(style.TitleCellStyle);
+		this.writeCellStyle(style.HeaderCellStyle);
 	}
 }

--- a/src/ACadSharp/Objects/TableStyle.CellBorder.cs
+++ b/src/ACadSharp/Objects/TableStyle.CellBorder.cs
@@ -4,34 +4,70 @@ namespace ACadSharp.Objects;
 
 public partial class TableStyle
 {
+	/// <summary>
+	/// Represents the border settings for a cell, including appearance, visibility, and style options.
+	/// </summary>
+	/// <remarks>Use this class to configure the visual and printing characteristics of cell borders in a drawing or
+	/// table. The properties allow customization of color, line weight, border type, and visibility. Changes to these
+	/// settings affect how borders are displayed in the editor and when plotted or printed.</remarks>
 	public class CellBorder
 	{
+		/// <summary>
+		/// Gets or sets a value indicating whether a border is applied.
+		/// </summary>
 		public bool ApplyBorder { get; set; } = false;
 
-		//[DxfCodeValue(62)]
-		//64-69
-		public Color Color { get; set; }
+		/// <summary>
+		/// Gets or sets the color associated with the entity.
+		/// </summary>
+		[DxfCodeValue(64)]
+		public Color Color { get; set; } = Color.ByBlock;
 
+		/// <summary>
+		/// Gets or sets the spacing distance between parallel lines in a double-line entity.
+		/// </summary>
+		/// <remarks>The value determines the distance between the two lines when rendering double-line geometry.
+		/// Adjust this property to control the visual separation of the lines. The unit of measurement is typically
+		/// consistent with the drawing's coordinate system.</remarks>
 		[DxfCodeValue(40)]
 		public double DoubleLineSpacing { get; set; }
 
+		/// <summary>
+		/// Gets the set of flags that describe the characteristics of the cell's edges.
+		/// </summary>
+		/// <remarks>Use these flags to determine which edges of the cell have specific properties, such as visibility
+		/// or formatting. The meaning of each flag is defined by the CellEdgeFlags enumeration.</remarks>
 		[DxfCodeValue(95)]
 		public CellEdgeFlags EdgeFlags { get; }
 
-		//284-289
+		/// <summary>
+		/// Gets or sets a value indicating whether the border is invisible. Invisible borders are not plotted and do not print, but they are still visible in the drawing editor.
+		/// </summary>
 		[DxfCodeValue(284)]
 		public bool IsInvisible { get; set; } = false;
 
-		//274-279
+		/// <summary>
+		/// Gets or sets the line weight to use when rendering the entity.
+		/// </summary>
 		[DxfCodeValue(274)]
-		public LineWeightType LineWeight { get; set; }
+		public LineWeightType LineWeight { get; set; } = LineWeightType.ByBlock;
 
+		/// <summary>
+		/// Gets or sets the set of flags that specify which border properties are overridden.
+		/// </summary>
 		[DxfCodeValue(90)]
 		public BorderPropertyFlags PropertyOverrideFlags { get; set; }
 
+		/// <summary>
+		/// Gets or sets the border style type to be applied.
+		/// </summary>
 		[DxfCodeValue(91)]
-		public BorderType Type { get; set; }
+		public BorderType Type { get; set; } = BorderType.Single;
 
+		/// <summary>
+		/// Initializes a new instance of the CellBorder class with the specified edge flags.
+		/// </summary>
+		/// <param name="edgeFlags">The set of edge flags that define which borders are applied to the cell.</param>
 		public CellBorder(CellEdgeFlags edgeFlags)
 		{
 			this.EdgeFlags = edgeFlags;

--- a/src/ACadSharp/Objects/TableStyle.cs
+++ b/src/ACadSharp/Objects/TableStyle.cs
@@ -42,13 +42,13 @@ public partial class TableStyle : NonGraphicalObject
 	/// Meaning unknown.
 	/// </summary>
 	[DxfCodeValue(71)]
-	public short Flags { get; internal set; }
+	public short Flags { get; set; }
 
 	/// <summary>
 	/// Gets or sets the direction in which table rows and columns are arranged.
 	/// </summary>
 	[DxfCodeValue(70)]
-	public TableFlowDirectionType FlowDirection { get; set; }
+	public TableFlowDirectionType FlowDirection { get; set; } = TableFlowDirectionType.Down;
 
 	/// <summary>
 	/// Gets the style settings applied to the header cells of the table.


### PR DESCRIPTION
# Description

Implemented writeTableStyle in DxfObjectsSectionWriter to serialize TableStyle and its cell styles. Added helper methods for writing cell styles and borders. Improved TableStyle.CellBorder with documentation, defaults, and property initialization. Made TableStyle.Flags settable and set a default for FlowDirection. Removed TableStyle from the "not implemented" notification list.
