### PR TITLE
issue-1038 Update Mesh version, DXF asserts, and edge crease handling

### DIFF
--- a/src/ACadSharp.Tests/IO/WriterSingleObjectTests.cs
+++ b/src/ACadSharp.Tests/IO/WriterSingleObjectTests.cs
@@ -1405,6 +1405,11 @@ public abstract class WriterSingleObjectTests : IOTestsBase
 
 			mesh.Faces.Add([0, 1, 2, 3]);
 
+			//mesh.Edges.Add(new Mesh.Edge { Start = 0, End = 1 });
+			//mesh.Edges.Add(new Mesh.Edge { Start = 1, End = 2 });
+			//mesh.Edges.Add(new Mesh.Edge { Start = 2, End = 3 });
+			//mesh.Edges.Add(new Mesh.Edge { Start = 0, End = 3 });
+
 			this.Document.Entities.Add(mesh);
 		}
 

--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>3.6.6</Version>
+		<Version>3.6.7</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>../ACadSharp.snk</AssemblyOriginatorKeyFile>

--- a/src/ACadSharp/Entities/Mesh.cs
+++ b/src/ACadSharp/Entities/Mesh.cs
@@ -54,7 +54,7 @@ public partial class Mesh : Entity
 	/// Version number
 	/// </summary>
 	[DxfCodeValue(71)]
-	public short Version { get; internal set; }
+	public short Version { get; set; } = 2;
 
 	/// <summary>
 	/// Vertex count of level 0

--- a/src/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
@@ -1258,8 +1258,6 @@ namespace ACadSharp.IO.DXF
 						tmp.CadObject.Faces.Add(face);
 					}
 
-					Debug.Assert(this._reader.Code == 90);
-
 					return true;
 				case 94:
 					int numEdges = this._reader.ValueAsInt;
@@ -1280,8 +1278,6 @@ namespace ACadSharp.IO.DXF
 						tmp.CadObject.Edges.Add(edge);
 					}
 
-					Debug.Assert(this._reader.Code == 90);
-
 					return true;
 				case 95:
 					this._reader.ReadNext();
@@ -1297,8 +1293,6 @@ namespace ACadSharp.IO.DXF
 							this._reader.ReadNext();
 						}
 					}
-
-					Debug.Assert(this._reader.Code == 140);
 
 					return true;
 				default:

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
@@ -765,7 +765,7 @@ namespace ACadSharp.IO.DXF
 			this._writer.Write(95, mesh.Edges.Count, map);
 			foreach (Mesh.Edge edge in mesh.Edges)
 			{
-				this._writer.Write(140, edge.Crease);
+				this._writer.Write(140, edge.Crease.HasValue ? edge.Crease.Value : 0.0d);
 			}
 
 			this._writer.Write(90, 0);


### PR DESCRIPTION
# Description

- Set Mesh.Version default to 2 and make setter public.
- Remove Debug.Assert checks for DXF codes after faces/edges.
- Write 0.0 for null edge crease values in DXF writer.
- Add commented-out mesh edge code in WriterSingleObjectTests.
