### PR TITLE
Added missing MEASUREMENT system header variable

### DIFF
--- a/src/ACadSharp/IO/DwgWriter.cs
+++ b/src/ACadSharp/IO/DwgWriter.cs
@@ -386,7 +386,7 @@ namespace ACadSharp.IO
 			//Int16	2	Template description string length in bytes(the ODA always writes 0 here).
 			writer.Write<short>(0);
 			//UInt16	2	MEASUREMENT system variable(0 = English, 1 = Metric).
-			writer.Write<ushort>((ushort)1);
+			writer.Write<ushort>((ushort)this._document.Header.MeasurementUnits);
 
 			this._fileHeaderWriter.AddSection(DwgSectionDefinition.Template, stream, true);
 		}

--- a/src/ACadSharp/IO/DxfWriterConfiguration.cs
+++ b/src/ACadSharp/IO/DxfWriterConfiguration.cs
@@ -41,6 +41,7 @@ namespace ACadSharp.IO
 			"$EXTNAMES",
 			"$INSBASE",
 			"$INSUNITS",
+			"$MEASUREMENT",
 			"$LTSCALE",
 			"$LWDISPLAY",
 			"$PDMODE",


### PR DESCRIPTION
I'm not sure if it's mandatory on the DXF side, but I would add it anyway.