### PR TITLE
Expose public TableEntity.CellStyleOverride accessor and table-level cell-style defaults

### DIFF
--- a/src/ACadSharp/Entities/TableEntity.cs
+++ b/src/ACadSharp/Entities/TableEntity.cs
@@ -2,6 +2,7 @@
 using ACadSharp.Objects;
 using ACadSharp.Tables;
 using CSMath;
+using System;
 using System.Collections.Generic;
 
 namespace ACadSharp.Entities;
@@ -110,6 +111,25 @@ public partial class TableEntity : Insert
 	[DxfCodeValue(DxfReferenceType.Handle, 343)]
 	internal BlockRecord TableBlock { get { return this.Block; } }
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="TableEntity"/> class.
+	/// </summary>
+	public TableEntity() : base()
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="TableEntity"/> class
+	/// bound to the given anonymous <see cref="BlockRecord"/> that will host the table cache.
+	/// </summary>
+	/// <param name="block">Anonymous block record used as the table's owning block (DXF 343).</param>
+	/// <exception cref="ArgumentNullException"></exception>
+	public TableEntity(BlockRecord block) : base()
+	{
+		if (block is null) throw new ArgumentNullException(nameof(block));
+		this.Block = block;
+	}
+
 	/// <inheritdoc/>
 	public override CadObject Clone()
 	{
@@ -134,4 +154,15 @@ public partial class TableEntity : Insert
 	{
 		return this.Rows[row].Cells[column];
 	}
+
+	/// <summary>
+	/// Gets the collection of merged cell ranges associated with this table.
+	/// </summary>
+	public List<CellRange> MergedCellRanges { get { return this.Content.MergedCellRanges; } }
+
+	/// <summary>
+	/// Gets the cell style override applied at the table level.
+	/// Use this to set table-level overrides such as flow direction (FlowDirectionBottomToTop).
+	/// </summary>
+	public TableStyle.CellStyle CellStyleOverride { get { return this.Content.CellStyleOverride; } }
 }

--- a/src/ACadSharp/Objects/TableStyle.CellStyle.cs
+++ b/src/ACadSharp/Objects/TableStyle.CellStyle.cs
@@ -24,6 +24,8 @@ public partial class TableStyle
 				{
 					Name = DataCellStyleName,
 					StyleClass = CellStyleClass.Label,
+					Id = 3,
+					HasData = true,
 				};
 
 				return data;
@@ -41,6 +43,8 @@ public partial class TableStyle
 				{
 					Name = HeaderCellStyleName,
 					StyleClass = CellStyleClass.Data,
+					Id = 2,
+					HasData = true,
 				};
 
 				return data;
@@ -58,11 +62,37 @@ public partial class TableStyle
 				{
 					Name = TitleCellStyleName,
 					StyleClass = CellStyleClass.Data,
+					Id = 1,
+					HasData = true,
 				};
 
 				return data;
 			}
 		}
+
+		/// <summary>
+		/// Gets the default cell style used as the table's overall ("Table") style.
+		/// </summary>
+		public static CellStyle DefaultTableCellStyle
+		{
+			get
+			{
+				var data = new CellStyle
+				{
+					Name = TableCellStyleName,
+					StyleClass = CellStyleClass.Label,
+					Id = 4,
+					HasData = true,
+				};
+
+				return data;
+			}
+		}
+
+		/// <summary>
+		/// The name constant for the default table-level cell style.
+		/// </summary>
+		public const string TableCellStyleName = "Table";
 
 		/// <summary>
 		/// Gets or sets the background (fill) color of the cell content.

--- a/src/ACadSharp/Objects/TableStyle.cs
+++ b/src/ACadSharp/Objects/TableStyle.cs
@@ -79,7 +79,7 @@ public partial class TableStyle : NonGraphicalObject
 	[DxfCodeValue(280)]
 	public bool SuppressTitle { get; set; }
 
-	public CellStyle TableCellStyle { get; set; } = new();
+	public CellStyle TableCellStyle { get; set; } = CellStyle.DefaultTableCellStyle;
 
 	public CellStyle TitleCellStyle { get; set; } = CellStyle.DefaultTitleCellStyle;
 


### PR DESCRIPTION
## Summary

Exposes `TableEntity.CellStyleOverride` (and `MergedCellRanges`) as public properties so external callers can populate table level overrides such as the flow direction. Also pre populates the default cell style instances with their canonical Id / HasData and adds a `DefaultTableCellStyle` referenced by the `TableStyle.TableCellStyle` initializer.

## Why

When writing a table to DWG R2010+, the per table flow direction (up/down) lives on `TableEntity.Content.CellStyleOverride` in the `FlowDirectionBottomToTop` bit of `PropertyOverrideFlags` and `TableCellStylePropertyFlags`. ODA reads it from there, not from the shared `TableStyle.FlowDirection`. Until now `Content` was `internal`, so external writers had no way to set that override and the only workaround was creating a separate `TableStyle` per direction, which then breaks the round trip through ODA.

This change is what lets a downstream DWG writer round trip the table flow direction correctly through ODA's reader.

## Changes

- `TableEntity.cs`
  - `public TableStyle.CellStyle CellStyleOverride { get; }` (delegates to `Content.CellStyleOverride`)
  - `public List<CellRange> MergedCellRanges { get; }`
  - Parameterless and `BlockRecord` based constructors
- `TableStyle.CellStyle.cs`
  - Default cell style factories now set the canonical `Id` (1 title, 2 header, 3 data) and `HasData = true`
  - New `DefaultTableCellStyle` (Id = 4, name 'Table')
- `TableStyle.cs`
  - `TableCellStyle` initializer uses `DefaultTableCellStyle`

3 files changed, +62 -1.

## Possibly related

This may or may not overlap with #995 (request to implement Dxf/Dwg writers for table entities). Linking it just in case it ends up being relevant.

## Test plan

- [x] Local build passes for all target frameworks
- [x] Round trip: write a `CadDocument` containing two tables (one with `FlowDirection.Down`, one with `FlowDirection.Up`) via an external writer that consumes `CellStyleOverride`, then read it back with ODA's reader. Table direction matches in both cases, which it didn't before this change.