### PR TITLE
Fix #1074: default VPort.AmbientColor to color index 250

### DIFF
--- a/src/ACadSharp/Tables/VPort.cs
+++ b/src/ACadSharp/Tables/VPort.cs
@@ -285,7 +285,7 @@ namespace ACadSharp.Tables
 		/// Ambient color(only output when non-black)
 		/// </summary>
 		[DxfCodeValue(63, 421, 431)]
-		public Color AmbientColor { get; set; }
+		public Color AmbientColor { get; set; } = Color.Black;
 
 		private XYZ _direction = XYZ.AxisZ;
 


### PR DESCRIPTION
## Summary

Fixes #1074. Switching to Realistic or Conceptual on a DWG written by `DwgWriter` crashes DWG TrueView with `Unhandled Access Violation Reading 0x0010`.

## Root cause

`VPort.AmbientColor` is an auto-property with no initializer:

```csharp
public Color AmbientColor { get; set; }
```

`default(Color)` encodes as ByBlock. The `*Active` viewport has no block context, so the color cannot be resolved. When TrueView's Realistic or Conceptual render setup reads ambient color from the active VPORT it follows a null block pointer and aborts.

A reference AC1027 file produced by AutoCAD initializes `*Active.AmbientColor` to black. Reading that reference back through ACadSharp's own `DwgReader` and diffing the in-memory `VPort` against a fresh `new CadDocument(ACadVersion.AC1027)` pointed to this property as the only relevant difference.

## Fix

One line in `src/ACadSharp/Tables/VPort.cs`:

```csharp
public Color AmbientColor { get; set; } = Color.Black;
```

## Test plan

- [x] Built ACadSharp with the change.
- [x] Reproduced the issue from #1074 (single `Line`, AC1027) against the un-patched library; TrueView crashes on Realistic/Conceptual.
- [x] Same repro on the patched build; TrueView opens the file and switches visual style without crashing.
- [x] `DwgWriter` then `DwgReader` roundtrip of the patched output still succeeds.
- [x] Diff vs `master` is a single file, +1 / -1 lines.
