### PR TITLE
Fix/dimension leader style override

### DIFF
--- a/src/ACadSharp/Entities/Dimension.cs
+++ b/src/ACadSharp/Entities/Dimension.cs
@@ -485,12 +485,16 @@ namespace ACadSharp.Entities
 				var curr = item.Value.GetRawValue(this.Style);
 				var over = item.Value.GetRawValue(styleOverride);
 
-				if (curr == null || over == null)
+				// Skip only when both values are null (no change to detect).
+				// When exactly one is null the property value has changed
+				// (e.g. a handle property going from null/default to a BlockRecord,
+				// or being explicitly cleared), so it must be included in the override.
+				if (curr == null && over == null)
 				{
 					continue;
 				}
 
-				if (!curr.Equals(over))
+				if (curr == null || over == null || !curr.Equals(over))
 				{
 					item.Value.StoredValue = over;
 					overrideMap.DxfProperties.Add(item.Key, item.Value);

--- a/src/ACadSharp/Entities/Dimension.cs
+++ b/src/ACadSharp/Entities/Dimension.cs
@@ -485,12 +485,19 @@ namespace ACadSharp.Entities
 				var curr = item.Value.GetRawValue(this.Style);
 				var over = item.Value.GetRawValue(styleOverride);
 
-				if (curr == null || over == null)
-				{
+				// Both null → no change, nothing to override.
+				if (curr == null && over == null)
 					continue;
-				}
 
-				if (!curr.Equals(over))
+				// over=null means "reset to default": ToXDataRecords would emit nothing
+				// (StoredValue=null → empty list), so skip to avoid a useless map entry.
+				if (over == null)
+					continue;
+
+				// curr=null and over!=null → property changed from default to a value (e.g.
+				// a handle going from null to a BlockRecord): include in the override.
+				// curr!=null and over!=null → include only if the values differ.
+				if (curr == null || !curr.Equals(over))
 				{
 					item.Value.StoredValue = over;
 					overrideMap.DxfProperties.Add(item.Key, item.Value);

--- a/src/ACadSharp/Entities/Leader.cs
+++ b/src/ACadSharp/Entities/Leader.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Attributes;
 using ACadSharp.Tables;
+using ACadSharp.XData;
 using CSMath;
 using System;
 using System.Collections.Generic;
@@ -209,6 +210,72 @@ namespace ACadSharp.Entities
 			{
 				this.Style = this.Document.DimensionStyles[DimensionStyle.DefaultName];
 			}
+		}
+
+		/// <summary>
+		/// Applies the specified dimension style override to the current leader, updating its extended data
+		/// to reflect the overridden properties (e.g. arrowhead block, DIMLDRBLK = code 341).
+		/// </summary>
+		/// <remarks>
+		/// Only properties that differ between the leader's current style and <paramref name="styleOverride"/>
+		/// are serialised into the DSTYLE XDATA block, mirroring the behaviour of
+		/// <see cref="Dimension.SetDimensionOverride"/>.
+		/// </remarks>
+		/// <param name="styleOverride">
+		/// The dimension style whose values should override the leader's current style.
+		/// Only properties with values different from the current style are applied.
+		/// </param>
+		public void SetDimensionOverride(DimensionStyle styleOverride)
+		{
+			DxfClassMap styleMap = DxfClassMap.Create<DimensionStyle>();
+			styleMap.DxfProperties.Remove(2);   // name — not an override
+			styleMap.DxfProperties.Remove(70);  // flags — not an override
+
+			DxfClassMap overrideMap = new DxfClassMap();
+			foreach (KeyValuePair<int, DxfProperty> item in styleMap.DxfProperties)
+			{
+				var curr = item.Value.GetRawValue(this.Style);
+				var over = item.Value.GetRawValue(styleOverride);
+
+				// Both null → no change, nothing to override.
+				if (curr == null && over == null)
+					continue;
+
+				// over=null means "reset to default": ToXDataRecords would emit nothing
+				// (StoredValue=null → empty list), so skip to avoid a useless map entry.
+				if (over == null)
+					continue;
+
+				// curr=null and over!=null → property changed from default to a value (e.g.
+				// a handle going from null to a BlockRecord): include in the override.
+				// curr!=null and over!=null → include only if the values differ.
+				if (curr == null || !curr.Equals(over))
+				{
+					item.Value.StoredValue = over;
+					overrideMap.DxfProperties.Add(item.Key, item.Value);
+				}
+			}
+
+			this.SetStyleOverrideMap(overrideMap);
+		}
+
+		/// <summary>
+		/// Sets the style override mapping for the current leader using the specified DXF class map,
+		/// writing the entries as <c>ACAD / DSTYLE / { … }</c> extended data.
+		/// </summary>
+		/// <param name="map">A DXF class map containing the property overrides to apply.</param>
+		public void SetStyleOverrideMap(DxfClassMap map)
+		{
+			ExtendedData edata = this.ExtendedData.TryAdd(AppId.DefaultName, new ExtendedData());
+			edata.Records.Clear();
+
+			edata.Records.Add(new ExtendedDataString(DimensionStyle.StyleOverrideEntryName));
+			edata.Records.Add(new ExtendedDataControlString(false));
+			foreach (DxfProperty p in map.DxfProperties.Values)
+			{
+				edata.Records.AddRange(p.ToXDataRecords());
+			}
+			edata.Records.Add(new ExtendedDataControlString(true));
 		}
 	}
 }

--- a/src/ACadSharp/Entities/Leader.cs
+++ b/src/ACadSharp/Entities/Leader.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Attributes;
 using ACadSharp.Tables;
+using ACadSharp.XData;
 using CSMath;
 using System;
 using System.Collections.Generic;
@@ -209,6 +210,69 @@ namespace ACadSharp.Entities
 			{
 				this.Style = this.Document.DimensionStyles[DimensionStyle.DefaultName];
 			}
+		}
+
+		/// <summary>
+		/// Applies the specified dimension style override to the current leader, updating its extended data
+		/// to reflect the overridden properties (e.g. arrowhead block, DIMLDRBLK = code 341).
+		/// </summary>
+		/// <remarks>
+		/// Only properties that differ between the leader's current style and <paramref name="styleOverride"/>
+		/// are serialised into the DSTYLE XDATA block, mirroring the behaviour of
+		/// <see cref="Dimension.SetDimensionOverride"/>.
+		/// </remarks>
+		/// <param name="styleOverride">
+		/// The dimension style whose values should override the leader's current style.
+		/// Only properties with values different from the current style are applied.
+		/// </param>
+		public void SetDimensionOverride(DimensionStyle styleOverride)
+		{
+			DxfClassMap styleMap = DxfClassMap.Create<DimensionStyle>();
+			styleMap.DxfProperties.Remove(2);   // name — not an override
+			styleMap.DxfProperties.Remove(70);  // flags — not an override
+
+			DxfClassMap overrideMap = new DxfClassMap();
+			foreach (KeyValuePair<int, DxfProperty> item in styleMap.DxfProperties)
+			{
+				var curr = item.Value.GetRawValue(this.Style);
+				var over = item.Value.GetRawValue(styleOverride);
+
+				// Skip only when both values are null (no change to detect).
+				// When exactly one is null the property value has changed
+				// (e.g. a handle property going from null/default to a BlockRecord),
+				// so it must be included in the override.
+				if (curr == null && over == null)
+				{
+					continue;
+				}
+
+				if (curr == null || over == null || !curr.Equals(over))
+				{
+					item.Value.StoredValue = over;
+					overrideMap.DxfProperties.Add(item.Key, item.Value);
+				}
+			}
+
+			this.SetStyleOverrideMap(overrideMap);
+		}
+
+		/// <summary>
+		/// Sets the style override mapping for the current leader using the specified DXF class map,
+		/// writing the entries as <c>ACAD / DSTYLE / { … }</c> extended data.
+		/// </summary>
+		/// <param name="map">A DXF class map containing the property overrides to apply.</param>
+		public void SetStyleOverrideMap(DxfClassMap map)
+		{
+			ExtendedData edata = this.ExtendedData.TryAdd(AppId.DefaultName, new ExtendedData());
+			edata.Records.Clear();
+
+			edata.Records.Add(new ExtendedDataString(DimensionStyle.StyleOverrideEntryName));
+			edata.Records.Add(new ExtendedDataControlString(false));
+			foreach (DxfProperty p in map.DxfProperties.Values)
+			{
+				edata.Records.AddRange(p.ToXDataRecords());
+			}
+			edata.Records.Add(new ExtendedDataControlString(true));
 		}
 	}
 }

--- a/src/ACadSharp/Tables/DimensionStyle.cs
+++ b/src/ACadSharp/Tables/DimensionStyle.cs
@@ -737,7 +737,7 @@ namespace ACadSharp.Tables
 		/// <b>false</b> if arrowhead block set by <see cref="ArrowBlock"/> shall be used.
 		/// </value>
 		[DxfCodeValue(173)]
-		public bool SeparateArrowBlocks { get; set; } = true;
+		public bool SeparateArrowBlocks { get; set; }
 
 		/// <summary>
 		/// Specifies the text style of the dimension


### PR DESCRIPTION
# Description

Three related fixes to make arrowhead style overrides work correctly in DXF output:

1. DimensionStyle.cs — SeparateArrowBlocks (code 173) defaulted to `true`, but the DXF standard default is 0 (false).

2. Dimension.cs — SetDimensionOverride skipped a property whenever *either* curr or over was null (`curr == null || over == null → continue`).  Handle-reference properties (ArrowBlock/DimArrow1/DimArrow2, codes 342-344) default to null, so assigning a BlockRecord in the override was silently ignored.

3. Leader.cs — Leader has a DimensionStyle Style property and uses the same ACAD/DSTYLE XDATA mechanism as Dimension, but had no SetDimensionOverride method.  The method (plus the supporting SetStyleOverrideMap) is added with identical diff-detection logic, using the same null-guard fix from point 2.  This allows callers to set e.g. overrideStyle.LeaderArrow = block and have DIMLDRBLK (code 341) written correctly.
This maybe could be refactored considering that is equal to the one for the Dimensions.

# Tasks done in this PR
* [ ] Something awesome.
* [ ] An evil bug have been defeated.
* [ ] Code cleanup and maintenance has been done.

# Related Issues / Pull Requests
- Add the links of issues or PR related to this one.
# Notes for reviewer
 - Things to consider during the review of this PR.