### PR TITLE
Add Material write support and Mesh texture coordinates round-trip

### DIFF
--- a/src/ACadSharp.Tests/Entities/MeshTests.cs
+++ b/src/ACadSharp.Tests/Entities/MeshTests.cs
@@ -1,0 +1,122 @@
+using ACadSharp.Entities;
+using ACadSharp.Extensions;
+using ACadSharp.IO;
+using ACadSharp.Tests.Common;
+using CSMath;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace ACadSharp.Tests.Entities
+{
+	public class MeshTests : CommonEntityTests<Mesh>
+	{
+		[Fact]
+		public override void GetBoundingBoxTest()
+		{
+			Mesh mesh = new Mesh();
+			mesh.Vertices.Add(new XYZ(-2, -3, -4));
+			mesh.Vertices.Add(new XYZ(5, 6, 7));
+			mesh.Vertices.Add(new XYZ(1, 0, 2));
+
+			BoundingBox boundingBox = mesh.GetBoundingBox();
+
+			Assert.Equal(new XYZ(-2, -3, -4), boundingBox.Min);
+			Assert.Equal(new XYZ(5, 6, 7), boundingBox.Max);
+		}
+
+		[Fact]
+		public void TextureCoordinatesDefaultsToEmpty()
+		{
+			Mesh mesh = new Mesh();
+
+			Assert.NotNull(mesh.TextureCoordinates);
+			Assert.Empty(mesh.TextureCoordinates);
+		}
+
+		[Fact]
+		public void TextureCoordinatesClonedIndependently()
+		{
+			Mesh mesh = new Mesh();
+			mesh.TextureCoordinates.Add(new XYZ(0.25, 0.5, 0));
+
+			Mesh clone = mesh.CloneTyped();
+
+			Assert.Equal(mesh.TextureCoordinates.Count, clone.TextureCoordinates.Count);
+			Assert.Equal(mesh.TextureCoordinates[0], clone.TextureCoordinates[0]);
+
+			clone.TextureCoordinates.Add(new XYZ(1, 1, 0));
+			Assert.NotEqual(mesh.TextureCoordinates.Count, clone.TextureCoordinates.Count);
+		}
+
+		[Fact]
+		public void TextureCoordinatesDwgRoundTrip()
+		{
+			CadDocument doc = new CadDocument(ACadVersion.AC1027);
+
+			Mesh mesh = new Mesh();
+			mesh.Vertices.Add(new XYZ(0, 0, 0));
+			mesh.Vertices.Add(new XYZ(1, 0, 0));
+			mesh.Vertices.Add(new XYZ(1, 1, 0));
+			mesh.Vertices.Add(new XYZ(0, 0, 0));
+			mesh.Vertices.Add(new XYZ(1, 1, 0));
+			mesh.Vertices.Add(new XYZ(0, 1, 0));
+			mesh.Faces.Add(new[] { 0, 1, 2 });
+			mesh.Faces.Add(new[] { 3, 4, 5 });
+			mesh.TextureCoordinates.Add(new XYZ(0.1, 0.2, 0));
+			mesh.TextureCoordinates.Add(new XYZ(0.3, 0.4, 0));
+			mesh.TextureCoordinates.Add(new XYZ(0.5, 0.6, 0));
+			mesh.TextureCoordinates.Add(new XYZ(0.7, 0.8, 0));
+			mesh.TextureCoordinates.Add(new XYZ(0.9, 0.1, 0));
+			mesh.TextureCoordinates.Add(new XYZ(0.2, 0.3, 0));
+
+			doc.Entities.Add(mesh);
+
+			MemoryStream ms = new MemoryStream();
+			DwgWriter.Write(ms, doc);
+			using MemoryStream readStream = new MemoryStream(ms.ToArray());
+			CadDocument rt = DwgReader.Read(readStream);
+
+			Mesh roundTripped = rt.Entities.OfType<Mesh>().Single();
+
+			Assert.Equal(mesh.Vertices.Count, roundTripped.Vertices.Count);
+			Assert.Equal(mesh.Faces.Count, roundTripped.Faces.Count);
+			Assert.Equal(mesh.TextureCoordinates.Count, roundTripped.TextureCoordinates.Count);
+
+			for (int i = 0; i < mesh.TextureCoordinates.Count; i++)
+			{
+				Assert.Equal(mesh.TextureCoordinates[i].X, roundTripped.TextureCoordinates[i].X, 9);
+				Assert.Equal(mesh.TextureCoordinates[i].Y, roundTripped.TextureCoordinates[i].Y, 9);
+				Assert.Equal(mesh.TextureCoordinates[i].Z, roundTripped.TextureCoordinates[i].Z, 9);
+			}
+		}
+
+		[Fact]
+		public void TextureCoordinatesEmittedAsXRecord()
+		{
+			// Verify the writer materializes the AcDbSubDMesh-shaped XRecord on the mesh
+			// extension dictionary, not just on the in-memory property.
+			CadDocument doc = new CadDocument(ACadVersion.AC1027);
+
+			Mesh mesh = new Mesh();
+			mesh.Vertices.Add(new XYZ(0, 0, 0));
+			mesh.Vertices.Add(new XYZ(1, 0, 0));
+			mesh.Vertices.Add(new XYZ(0, 1, 0));
+			mesh.Faces.Add(new[] { 0, 1, 2 });
+			mesh.TextureCoordinates.Add(new XYZ(0, 0, 0));
+			mesh.TextureCoordinates.Add(new XYZ(1, 0, 0));
+			mesh.TextureCoordinates.Add(new XYZ(0, 1, 0));
+
+			doc.Entities.Add(mesh);
+
+			MemoryStream ms = new MemoryStream();
+			DwgWriter.Write(ms, doc);
+			using MemoryStream readStream = new MemoryStream(ms.ToArray());
+			CadDocument rt = DwgReader.Read(readStream);
+
+			Mesh roundTripped = rt.Entities.OfType<Mesh>().Single();
+			Assert.NotNull(roundTripped.XDictionary);
+			Assert.True(roundTripped.XDictionary.ContainsKey("ADSK_XREC_SUBDVERTEXTEXCOORDS"));
+		}
+	}
+}

--- a/src/ACadSharp.Tests/IO/WriterSingleObjectTests.cs
+++ b/src/ACadSharp.Tests/IO/WriterSingleObjectTests.cs
@@ -90,6 +90,8 @@ public abstract class WriterSingleObjectTests : IOTestsBase
 		Data.Add(new(nameof(SingleCaseGenerator.CreateXRecords)));
 		Data.Add(new(nameof(SingleCaseGenerator.SingleTableEntity)));
 		Data.Add(new(nameof(SingleCaseGenerator.SingleMesh)));
+		Data.Add(new(nameof(SingleCaseGenerator.SingleMeshWithTextureCoordinates)));
+		Data.Add(new(nameof(SingleCaseGenerator.SingleMaterial)));
 	}
 
 	public WriterSingleObjectTests(ITestOutputHelper output) : base(output)
@@ -1413,6 +1415,70 @@ public abstract class WriterSingleObjectTests : IOTestsBase
 			//mesh.Edges.Add(new Mesh.Edge { Start = 1, End = 2 });
 			//mesh.Edges.Add(new Mesh.Edge { Start = 2, End = 3 });
 			//mesh.Edges.Add(new Mesh.Edge { Start = 0, End = 3 });
+
+			this.Document.Entities.Add(mesh);
+		}
+
+		public void SingleMeshWithTextureCoordinates()
+		{
+			// Face-corner-duplicated vertices so each corner gets its own UV, matching
+			// the AcDbSubDMesh convention persisted via the ADSK_XREC_SUBDVERTEXTEXCOORDS XRecord.
+			Mesh mesh = new Mesh();
+			mesh.Vertices.Add(new XYZ(0, 0, 0));
+			mesh.Vertices.Add(new XYZ(1, 0, 0));
+			mesh.Vertices.Add(new XYZ(1, 1, 0));
+			mesh.Vertices.Add(new XYZ(0, 0, 0));
+			mesh.Vertices.Add(new XYZ(1, 1, 0));
+			mesh.Vertices.Add(new XYZ(0, 1, 0));
+
+			mesh.Faces.Add([0, 1, 2]);
+			mesh.Faces.Add([3, 4, 5]);
+
+			mesh.TextureCoordinates.Add(new XYZ(0, 0, 0));
+			mesh.TextureCoordinates.Add(new XYZ(1, 0, 0));
+			mesh.TextureCoordinates.Add(new XYZ(1, 1, 0));
+			mesh.TextureCoordinates.Add(new XYZ(0, 0, 0));
+			mesh.TextureCoordinates.Add(new XYZ(1, 1, 0));
+			mesh.TextureCoordinates.Add(new XYZ(0, 1, 0));
+
+			this.Document.Entities.Add(mesh);
+		}
+
+		public void SingleMaterial()
+		{
+			Material material = new Material("TestMaterial")
+			{
+				Description = "Round-trip test material",
+				AmbientColorMethod = ColorMethod.Override,
+				AmbientColor = new Color(10, 20, 30),
+				DiffuseColorMethod = ColorMethod.Override,
+				DiffuseColor = new Color(200, 100, 50),
+				SpecularColorMethod = ColorMethod.Override,
+				SpecularColor = new Color(255, 255, 255),
+				SpecularGlossFactor = 0.5,
+				Opacity = 0.8,
+				RefractionIndex = 1.2,
+				Translucence = 0.1,
+				Reflectivity = 0.3,
+				ChannelFlags = MaterialChannelFlags.UseDiffuse | MaterialChannelFlags.UseBump,
+				IlluminationModel = MaterialIlluminationModel.MetalShader,
+				Mode = MaterialMode.Advanced,
+				DiffuseMapSource = MapSource.UseImageFile,
+				DiffuseMapFileName = "diffuse.png",
+				DiffuseMapBlendFactor = 1.0,
+			};
+
+			this.Document.Materials.Add(material);
+
+			// Anchor the material to an entity so the on-disk handle reference is exercised too.
+			Mesh mesh = new Mesh
+			{
+				Material = material,
+			};
+			mesh.Vertices.Add(new XYZ(0, 0, 0));
+			mesh.Vertices.Add(new XYZ(1, 0, 0));
+			mesh.Vertices.Add(new XYZ(1, 1, 0));
+			mesh.Faces.Add([0, 1, 2]);
 
 			this.Document.Entities.Add(mesh);
 		}

--- a/src/ACadSharp.Tests/Objects/MaterialTests.cs
+++ b/src/ACadSharp.Tests/Objects/MaterialTests.cs
@@ -1,0 +1,112 @@
+using ACadSharp.Entities;
+using ACadSharp.IO;
+using ACadSharp.Objects;
+using CSMath;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace ACadSharp.Tests.Objects
+{
+	public class MaterialTests
+	{
+		[Fact]
+		public void DefaultsAreReasonable()
+		{
+			Material material = new Material("Default");
+
+			Assert.Equal("Default", material.Name);
+			Assert.Equal(MaterialChannelFlags.UseDiffuse, material.ChannelFlags);
+			Assert.Equal(MaterialIlluminationModel.BlinnShader, material.IlluminationModel);
+			Assert.Equal(MaterialMode.Realistic, material.Mode);
+		}
+
+		[Fact]
+		public void DwgRoundTripPreservesColorMethodsAndEnums()
+		{
+			CadDocument doc = new CadDocument(ACadVersion.AC1027);
+
+			Material material = new Material("RoundTripMaterial")
+			{
+				Description = "Round-trip test",
+				AmbientColorMethod = ColorMethod.Override,
+				AmbientColor = new Color(10, 20, 30),
+				DiffuseColorMethod = ColorMethod.Override,
+				DiffuseColor = new Color(200, 100, 50),
+				SpecularColorMethod = ColorMethod.Override,
+				SpecularColor = new Color(255, 255, 255),
+				SpecularGlossFactor = 0.5,
+				Opacity = 0.8,
+				RefractionIndex = 1.2,
+				Translucence = 0.1,
+				Reflectivity = 0.3,
+				ChannelFlags = MaterialChannelFlags.UseDiffuse | MaterialChannelFlags.UseBump,
+				IlluminationModel = MaterialIlluminationModel.MetalShader,
+				Mode = MaterialMode.Advanced,
+			};
+			doc.Materials.Add(material);
+
+			Mesh anchor = new Mesh
+			{
+				Material = material,
+			};
+			anchor.Vertices.Add(new XYZ(0, 0, 0));
+			anchor.Vertices.Add(new XYZ(1, 0, 0));
+			anchor.Vertices.Add(new XYZ(0, 1, 0));
+			anchor.Faces.Add(new[] { 0, 1, 2 });
+			doc.Entities.Add(anchor);
+
+			MemoryStream ms = new MemoryStream();
+			DwgWriter.Write(ms, doc);
+			using MemoryStream readStream = new MemoryStream(ms.ToArray());
+			CadDocument rt = DwgReader.Read(readStream);
+
+			Assert.True(rt.Materials.TryGet("RoundTripMaterial", out Material got));
+			Assert.Equal("Round-trip test", got.Description);
+			Assert.Equal(ColorMethod.Override, got.AmbientColorMethod);
+			Assert.Equal(new Color(10, 20, 30), got.AmbientColor);
+			Assert.Equal(ColorMethod.Override, got.DiffuseColorMethod);
+			Assert.Equal(new Color(200, 100, 50), got.DiffuseColor);
+			Assert.Equal(ColorMethod.Override, got.SpecularColorMethod);
+			Assert.Equal(new Color(255, 255, 255), got.SpecularColor);
+			Assert.Equal(0.5, got.SpecularGlossFactor, 9);
+			Assert.Equal(0.8, got.Opacity, 9);
+			Assert.Equal(1.2, got.RefractionIndex, 9);
+			Assert.Equal(0.1, got.Translucence, 9);
+			Assert.Equal(0.3, got.Reflectivity, 9);
+			Assert.Equal(MaterialChannelFlags.UseDiffuse | MaterialChannelFlags.UseBump, got.ChannelFlags);
+			Assert.Equal(MaterialIlluminationModel.MetalShader, got.IlluminationModel);
+			Assert.Equal(MaterialMode.Advanced, got.Mode);
+
+			Mesh rtAnchor = rt.Entities.OfType<Mesh>().Single();
+			Assert.NotNull(rtAnchor.Material);
+			Assert.Equal("RoundTripMaterial", rtAnchor.Material.Name);
+		}
+
+		[Fact]
+		public void DwgRoundTripPreservesDiffuseMapMetadata()
+		{
+			CadDocument doc = new CadDocument(ACadVersion.AC1027);
+
+			Material material = new Material("Textured")
+			{
+				DiffuseColorMethod = ColorMethod.Override,
+				DiffuseColor = new Color(128, 128, 128),
+				DiffuseMapSource = MapSource.UseImageFile,
+				DiffuseMapFileName = "diffuse.png",
+				DiffuseMapBlendFactor = 1.0,
+			};
+			doc.Materials.Add(material);
+
+			MemoryStream ms = new MemoryStream();
+			DwgWriter.Write(ms, doc);
+			using MemoryStream readStream = new MemoryStream(ms.ToArray());
+			CadDocument rt = DwgReader.Read(readStream);
+
+			Assert.True(rt.Materials.TryGet("Textured", out Material got));
+			Assert.Equal(MapSource.UseImageFile, got.DiffuseMapSource);
+			Assert.Equal("diffuse.png", got.DiffuseMapFileName);
+			Assert.Equal(1.0, got.DiffuseMapBlendFactor, 9);
+		}
+	}
+}

--- a/src/ACadSharp/Entities/Mesh.cs
+++ b/src/ACadSharp/Entities/Mesh.cs
@@ -63,6 +63,17 @@ public partial class Mesh : Entity
 	[DxfCollectionCodeValue(10, 20, 30)]
 	public List<XYZ> Vertices { get; private set; } = new();
 
+	/// <summary>
+	/// Per-vertex texture coordinates (U, V, W). Empty if the mesh has no UV mapping.
+	/// </summary>
+	/// <remarks>
+	/// Persisted as an <c>ADSK_XREC_SUBDVERTEXTEXCOORDS</c> XRecord on the mesh extension dictionary,
+	/// matching the AutoCAD/AcDbSubDMesh convention. The list must have the same length as <see cref="Vertices"/>.
+	/// </remarks>
+	public List<XYZ> TextureCoordinates { get; private set; } = new();
+
+	internal const string TextureCoordsXRecordName = "ADSK_XREC_SUBDVERTEXTEXCOORDS";
+
 	//90	Count of sub-entity which property has been overridden
 
 	//91	Sub-entity marker
@@ -92,6 +103,7 @@ public partial class Mesh : Entity
 		clone.Edges = new List<Edge>(this.Edges);
 		clone.Vertices = new List<XYZ>(this.Vertices);
 		clone.Faces = new List<int[]>(this.Faces);
+		clone.TextureCoordinates = new List<XYZ>(this.TextureCoordinates);
 
 		return clone;
 	}

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -3240,6 +3240,18 @@ namespace ACadSharp.IO.DWG
 
 			#endregion Refraction
 
+			// SINCE R_2007a tail block. AutoCAD writes these every time, even
+			// when the values are default; consuming them keeps the in-memory
+			// model in sync with the file and lets ACadSharp round-trip a
+			// non-default material (e.g. one with kMetalShader or a custom
+			// channel-flag mask) without losing the choice.
+			material.Translucence = this._mergedReaders.ReadBitDouble();
+			this._mergedReaders.ReadBitDouble();                                   // self_illumination (not modeled)
+			material.Reflectivity = this._mergedReaders.ReadBitDouble();
+			material.IlluminationModel = (MaterialIlluminationModel)this._mergedReaders.ReadBitLong();
+			material.ChannelFlags = (MaterialChannelFlags)this._mergedReaders.ReadBitLong();
+			material.Mode = (MaterialMode)this._mergedReaders.ReadBitLong();
+
 #if TEST
 			var obj = DwgStreamReaderBase.Explore(this._objectReader);
 			var text = DwgStreamReaderBase.Explore(this._textReader);

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -3240,17 +3240,23 @@ namespace ACadSharp.IO.DWG
 
 			#endregion Refraction
 
-			// SINCE R_2007a tail block. AutoCAD writes these every time, even
-			// when the values are default; consuming them keeps the in-memory
-			// model in sync with the file and lets ACadSharp round-trip a
-			// non-default material (e.g. one with kMetalShader or a custom
-			// channel-flag mask) without losing the choice.
-			material.Translucence = this._mergedReaders.ReadBitDouble();
-			this._mergedReaders.ReadBitDouble();                                   // self_illumination (not modeled)
-			material.Reflectivity = this._mergedReaders.ReadBitDouble();
-			material.IlluminationModel = (MaterialIlluminationModel)this._mergedReaders.ReadBitLong();
-			material.ChannelFlags = (MaterialChannelFlags)this._mergedReaders.ReadBitLong();
-			material.Mode = (MaterialMode)this._mergedReaders.ReadBitLong();
+			// Since R2007a there is a tail block with the render-mode hints.
+			// AutoCAD writes these every time, even when the values are default;
+			// consuming them keeps the in-memory model in sync with the file and
+			// lets ACadSharp round-trip a non-default material (e.g. one with
+			// kMetalShader or a custom channel-flag mask) without losing the choice.
+			// Pre-R2007 MATERIAL objects end after the refraction block, so reading
+			// the tail there would run past the end of the object and corrupt the
+			// stream position for every subsequent object.
+			if (this.R2007Plus)
+			{
+				material.Translucence = this._mergedReaders.ReadBitDouble();
+				this._mergedReaders.ReadBitDouble();                                   // self_illumination (not modeled)
+				material.Reflectivity = this._mergedReaders.ReadBitDouble();
+				material.IlluminationModel = (MaterialIlluminationModel)this._mergedReaders.ReadBitLong();
+				material.ChannelFlags = (MaterialChannelFlags)this._mergedReaders.ReadBitLong();
+				material.Mode = (MaterialMode)this._mergedReaders.ReadBitLong();
+			}
 
 #if TEST
 			var obj = DwgStreamReaderBase.Explore(this._objectReader);

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Common.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Common.cs
@@ -293,8 +293,16 @@ namespace ACadSharp.IO.DWG
 			//R2007+:
 			if (this.R2007Plus)
 			{
-				//Material flags BB 00 = bylayer, 01 = byblock, 11 = material handle present at end of object
-				this._writer.Write2Bits(0b00);
+				//Material flags BB 00 = bylayer, 01 = byblock, 11 = material handle present
+				if (entity.Material == null)
+				{
+					this._writer.Write2Bits(0b00);
+				}
+				else
+				{
+					this._writer.Write2Bits(0b11);
+					this._writer.HandleReference(DwgReferenceType.HardPointer, entity.Material);
+				}
 
 				//Shadow flags RC
 				this._writer.WriteByte(0);

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Material.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Material.cs
@@ -90,15 +90,19 @@ internal partial class DwgObjectWriter : DwgSectionIO
 			(byte)material.RefractionMapSource,
 			material.RefractionMapFileName);
 
-		// Tail block (R2007a+): values not read by readMaterial but emitted by
-		// AutoCAD so the declared body size matches. Defaults sampled from an
-		// AutoCAD-produced AC1027 reference: channel_flags = 0x7F, rest = 0.
-		this._writer.WriteBitDouble(material.Translucence);
-		this._writer.WriteBitDouble(0.0);                   // self_illumination
-		this._writer.WriteBitDouble(material.Reflectivity);
-		this._writer.WriteBitLong((int)material.IlluminationModel);
-		this._writer.WriteBitLong((int)material.ChannelFlags);
-		this._writer.WriteBitLong((int)material.Mode);
+		// Tail block (R2007a+): render-mode hints AutoCAD always emits so the
+		// declared body size matches. Defaults sampled from an AutoCAD-produced
+		// AC1027 reference: channel_flags = UseDiffuse, rest = 0. Pre-R2007
+		// MATERIAL objects end after the refraction block.
+		if (this.R2007Plus)
+		{
+			this._writer.WriteBitDouble(material.Translucence);
+			this._writer.WriteBitDouble(0.0);                   // self_illumination
+			this._writer.WriteBitDouble(material.Reflectivity);
+			this._writer.WriteBitLong((int)material.IlluminationModel);
+			this._writer.WriteBitLong((int)material.ChannelFlags);
+			this._writer.WriteBitLong((int)material.Mode);
+		}
 	}
 
 	private void writeMaterialColor(ColorMethod method, double factor, Color rgb)

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Material.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Material.cs
@@ -96,9 +96,9 @@ internal partial class DwgObjectWriter : DwgSectionIO
 		this._writer.WriteBitDouble(material.Translucence);
 		this._writer.WriteBitDouble(0.0);                   // self_illumination
 		this._writer.WriteBitDouble(material.Reflectivity);
-		this._writer.WriteBitLong(material.IlluminationModel);
-		this._writer.WriteBitLong(material.ChannelFlags == 0 ? 127 : material.ChannelFlags);
-		this._writer.WriteBitLong(0);                       // mode
+		this._writer.WriteBitLong((int)material.IlluminationModel);
+		this._writer.WriteBitLong((int)material.ChannelFlags);
+		this._writer.WriteBitLong((int)material.Mode);
 	}
 
 	private void writeMaterialColor(ColorMethod method, double factor, Color rgb)

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Material.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Material.cs
@@ -1,0 +1,163 @@
+using ACadSharp.Objects;
+using CSMath;
+
+namespace ACadSharp.IO.DWG;
+
+internal partial class DwgObjectWriter : DwgSectionIO
+{
+	// Mirror of DwgObjectReader.readMaterial. Field order and binary types are
+	// kept symmetric with the reader so a Material round-tripped through
+	// ACadSharp ends up with the same in-memory state.
+	//
+	// The reader stops at the end of the Refraction block; the writer emits the
+	// same six "tail" fields AutoCAD writes after Refraction (translucence,
+	// self_illumination, reflectivity, illumination_model, channel_flags, mode)
+	// so the body length in the resulting DWG matches what AutoCAD and DWG
+	// TrueView expect. The reader will still ignore those bytes because each
+	// object knows its own size from the object map.
+
+	private void writeMaterial(Material material)
+	{
+		// 1, 2 -- name + description as bit-text.
+		this._writer.WriteVariableText(material.Name);
+		this._writer.WriteVariableText(material.Description ?? string.Empty);
+
+		// Ambient color block: method (RC byte), factor (BD), optional RGB (BL).
+		this.writeMaterialColor(material.AmbientColorMethod, material.AmbientColorFactor, material.AmbientColor);
+
+		// Diffuse color + diffuse map.
+		this.writeMaterialColor(material.DiffuseColorMethod, material.DiffuseColorFactor, material.DiffuseColor);
+		this.writeMaterialMap(
+			material.DiffuseMapBlendFactor,
+			(byte)material.DiffuseProjectionMethod,
+			(byte)material.DiffuseTilingMethod,
+			(byte)material.DiffuseAutoTransform,
+			material.DiffuseMatrix,
+			(byte)material.DiffuseMapSource,
+			material.DiffuseMapFileName);
+
+		// Specular color + specular map + gloss.
+		this.writeMaterialColor(material.SpecularColorMethod, material.SpecularColorFactor, material.SpecularColor);
+		this.writeMaterialMap(
+			material.SpecularMapBlendFactor,
+			(byte)material.SpecularProjectionMethod,
+			(byte)material.SpecularTilingMethod,
+			(byte)material.SpecularAutoTransform,
+			material.SpecularMatrix,
+			(byte)material.SpecularMapSource,
+			material.SpecularMapFileName);
+		this._writer.WriteBitDouble(material.SpecularGlossFactor);
+
+		// Reflection map + opacity scalar.
+		this.writeMaterialMap(
+			material.ReflectionMapBlendFactor,
+			(byte)material.ReflectionProjectionMethod,
+			(byte)material.ReflectionTilingMethod,
+			(byte)material.ReflectionAutoTransform,
+			material.ReflectionMatrix,
+			(byte)material.ReflectionMapSource,
+			material.ReflectionMapFileName);
+		this._writer.WriteBitDouble(material.Opacity);
+
+		// Opacity map.
+		this.writeMaterialMap(
+			material.OpacityMapBlendFactor,
+			(byte)material.OpacityProjectionMethod,
+			(byte)material.OpacityTilingMethod,
+			(byte)material.OpacityAutoTransform,
+			material.OpacityMatrix,
+			(byte)material.OpacityMapSource,
+			material.OpacityMapFileName);
+
+		// Bump map + refraction index scalar.
+		this.writeMaterialMap(
+			material.BumpMapBlendFactor,
+			(byte)material.BumpProjectionMethod,
+			(byte)material.BumpTilingMethod,
+			(byte)material.BumpAutoTransform,
+			material.BumpMatrix,
+			(byte)material.BumpMapSource,
+			material.BumpMapFileName);
+		this._writer.WriteBitDouble(material.RefractionIndex);
+
+		// Refraction map.
+		this.writeMaterialMap(
+			material.RefractionMapBlendFactor,
+			(byte)material.RefractionProjectionMethod,
+			(byte)material.RefractionTilingMethod,
+			(byte)material.RefractionAutoTransform,
+			material.RefractionMatrix,
+			(byte)material.RefractionMapSource,
+			material.RefractionMapFileName);
+
+		// Tail block (R2007a+): values not read by readMaterial but emitted by
+		// AutoCAD so the declared body size matches. Defaults sampled from an
+		// AutoCAD-produced AC1027 reference: channel_flags = 0x7F, rest = 0.
+		this._writer.WriteBitDouble(material.Translucence);
+		this._writer.WriteBitDouble(0.0);                   // self_illumination
+		this._writer.WriteBitDouble(material.Reflectivity);
+		this._writer.WriteBitLong(material.IlluminationModel);
+		this._writer.WriteBitLong(material.ChannelFlags == 0 ? 127 : material.ChannelFlags);
+		this._writer.WriteBitLong(0);                       // mode
+	}
+
+	private void writeMaterialColor(ColorMethod method, double factor, Color rgb)
+	{
+		// readMaterial reads a single byte for method, then BD factor, then a
+		// BL rgb only when method == Override. Encoder mirrors that.
+		this._writer.WriteByte((byte)method);
+		this._writer.WriteBitDouble(factor);
+		if (method == ColorMethod.Override)
+		{
+			byte[] arr = new byte[]
+			{
+				rgb.B,
+				rgb.G,
+				rgb.R,
+				0
+			};
+			uint packed = CSUtilities.Converters.LittleEndianConverter.Instance.ToUInt32(arr);
+			this._writer.WriteBitLong((int)packed);
+		}
+	}
+
+	private void writeMaterialMap(double blendFactor, byte projection, byte tiling, byte autoTransform,
+		Matrix4 transform, byte source, string fileName)
+	{
+		// readMaterial sequence: BD blendFactor, RC projection, RC tiling, RC
+		// autoTransform, 16 BD matrix entries, RC source, optional T filename.
+		this._writer.WriteBitDouble(blendFactor);
+		this._writer.WriteByte(projection);
+		this._writer.WriteByte(tiling);
+		this._writer.WriteByte(autoTransform);
+		this.writeMaterialMatrix(transform);
+		this._writer.WriteByte(source);
+
+		// Source enum: 0 = scene, 1 = file, 2 = procedural. Only the "file"
+		// branch carries a follow-up text token in the binary stream.
+		if (source == (byte)MapSource.UseImageFile)
+		{
+			this._writer.WriteVariableText(fileName ?? string.Empty);
+		}
+	}
+
+	private void writeMaterialMatrix(Matrix4 m)
+	{
+		this._writer.WriteBitDouble(m.M00);
+		this._writer.WriteBitDouble(m.M01);
+		this._writer.WriteBitDouble(m.M02);
+		this._writer.WriteBitDouble(m.M03);
+		this._writer.WriteBitDouble(m.M10);
+		this._writer.WriteBitDouble(m.M11);
+		this._writer.WriteBitDouble(m.M12);
+		this._writer.WriteBitDouble(m.M13);
+		this._writer.WriteBitDouble(m.M20);
+		this._writer.WriteBitDouble(m.M21);
+		this._writer.WriteBitDouble(m.M22);
+		this._writer.WriteBitDouble(m.M23);
+		this._writer.WriteBitDouble(m.M30);
+		this._writer.WriteBitDouble(m.M31);
+		this._writer.WriteBitDouble(m.M32);
+		this._writer.WriteBitDouble(m.M33);
+	}
+}

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Material.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Material.cs
@@ -109,12 +109,18 @@ internal partial class DwgObjectWriter : DwgSectionIO
 		this._writer.WriteBitDouble(factor);
 		if (method == ColorMethod.Override)
 		{
+			// True-color tag 0xc2 in the high byte marks the BL as a 24-bit
+			// RGB true color instead of an index. ACadSharp's reader strips
+			// this byte before constructing the Color so the round-trip works
+			// either way; AutoCAD and DWG TrueView actually inspect the tag
+			// when rendering. Writing 0 here was making materials come out
+			// black under Realistic / Conceptual.
 			byte[] arr = new byte[]
 			{
 				rgb.B,
 				rgb.G,
 				rgb.R,
-				0
+				0b11000010
 			};
 			uint packed = CSUtilities.Converters.LittleEndianConverter.Instance.ToUInt32(arr);
 			this._writer.WriteBitLong((int)packed);

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
@@ -41,7 +41,6 @@ internal partial class DwgObjectWriter : DwgSectionIO
 			case AecBinRecord:
 			case DimensionAssociation:
 			case EvaluationGraph:
-			case Material:
 			case UnknownNonGraphicalObject:
 			case VisualStyle:
 			case ProxyObject:
@@ -1050,6 +1049,9 @@ internal partial class DwgObjectWriter : DwgSectionIO
 				break;
 			case Layout layout:
 				this.writeLayout(layout);
+				break;
+			case Material material:
+				this.writeMaterial(material);
 				break;
 			case MLineStyle style:
 				this.writeMLineStyle(style);

--- a/src/ACadSharp/IO/DwgWriter.cs
+++ b/src/ACadSharp/IO/DwgWriter.cs
@@ -56,6 +56,12 @@ namespace ACadSharp.IO
 
 			this.getFileHeaderWriter();
 
+			// Allocate handles for any synthetic objects that the writer materializes during entity
+			// serialization (Mesh.TextureCoordinates -> ADSK_XREC_SUBDVERTEXTEXCOORDS XRecord, etc.)
+			// before writeHeader emits the HandleSeed. Otherwise the header reports a stale seed and
+			// the resulting file opens in recovery mode.
+			this.prepareDocument();
+
 			this.writeHeader();
 			this.writeClasses();
 			//this.writeEmptySection();
@@ -176,6 +182,46 @@ namespace ACadSharp.IO
 			writer.Write();
 
 			this._fileHeaderWriter.AddSection(DwgSectionDefinition.Header, stream, true);
+		}
+
+		private void prepareDocument()
+		{
+			foreach (var record in this._document.BlockRecords)
+			{
+				foreach (var entity in record.Entities)
+				{
+					if (entity is Entities.Mesh mesh)
+					{
+						syncMeshTextureCoordinates(mesh);
+					}
+				}
+			}
+		}
+
+		private static void syncMeshTextureCoordinates(Entities.Mesh mesh)
+		{
+			bool hasCoords = mesh.TextureCoordinates != null && mesh.TextureCoordinates.Count > 0;
+
+			if (!hasCoords)
+			{
+				return;
+			}
+
+			var xdict = mesh.CreateExtendedDictionary();
+			if (xdict.ContainsKey(Entities.Mesh.TextureCoordsXRecordName))
+			{
+				xdict.Remove(Entities.Mesh.TextureCoordsXRecordName, out _);
+			}
+
+			var xrec = new Objects.XRecord(Entities.Mesh.TextureCoordsXRecordName);
+			foreach (var uv in mesh.TextureCoordinates)
+			{
+				xrec.CreateEntry(43, uv.X);
+				xrec.CreateEntry(44, uv.Y);
+				xrec.CreateEntry(45, uv.Z);
+			}
+
+			xdict.Add(xrec);
 		}
 
 		private void writeClasses()

--- a/src/ACadSharp/IO/Templates/CadEntityTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadEntityTemplate.cs
@@ -102,6 +102,11 @@ internal class CadEntityTemplate : CadTemplate<Entity>
 		{
 			this.CadObject.BookColor = color;
 		}
+
+		if (builder.TryGetCadObject(this.MaterialHandle, out Material material))
+		{
+			this.CadObject.Material = material;
+		}
 	}
 }
 

--- a/src/ACadSharp/IO/Templates/CadMeshTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadMeshTemplate.cs
@@ -1,4 +1,6 @@
-﻿using ACadSharp.Entities;
+using ACadSharp.Entities;
+using ACadSharp.Objects;
+using CSMath;
 
 namespace ACadSharp.IO.Templates
 {
@@ -9,5 +11,53 @@ namespace ACadSharp.IO.Templates
 		public CadMeshTemplate() { }
 
 		public CadMeshTemplate(Mesh mesh) : base(mesh) { }
-}
+
+		protected override void build(CadDocumentBuilder builder)
+		{
+			base.build(builder);
+
+			// Pull per-vertex texture coordinates from the ADSK_XREC_SUBDVERTEXTEXCOORDS
+			// XRecord that AutoCAD/AcDbSubDMesh stores on the mesh's extension dictionary.
+			// Coordinates are written as repeated 43/44/45 triplets (U/V/W).
+			if (this.CadObject.XDictionary == null
+				|| !this.CadObject.XDictionary.TryGetEntry(Mesh.TextureCoordsXRecordName, out XRecord xrec)
+				|| xrec == null)
+			{
+				return;
+			}
+
+			double? u = null, v = null;
+			foreach (var entry in xrec.Entries)
+			{
+				switch (entry.Code)
+				{
+					case 43:
+						u = toDouble(entry.Value);
+						break;
+					case 44:
+						v = toDouble(entry.Value);
+						break;
+					case 45:
+						double w = toDouble(entry.Value) ?? 0.0;
+						if (u.HasValue && v.HasValue)
+						{
+							this.CadObject.TextureCoordinates.Add(new XYZ(u.Value, v.Value, w));
+						}
+						u = null;
+						v = null;
+						break;
+				}
+			}
+		}
+
+		private static double? toDouble(object value)
+		{
+			if (value == null)
+			{
+				return null;
+			}
+
+			return System.Convert.ToDouble(value, System.Globalization.CultureInfo.InvariantCulture);
+		}
+	}
 }

--- a/src/ACadSharp/Objects/CadDictionary.cs
+++ b/src/ACadSharp/Objects/CadDictionary.cs
@@ -225,6 +225,14 @@ namespace ACadSharp.Objects
 				throw new ArgumentNullException(nameof(value), $"NonGraphicalObject [{this.GetType().FullName}] must have a name");
 			}
 
+			// Keep the value's Name in sync with the dictionary key so that writers (which serialize
+			// item.Name as the dictionary entry name) emit the correct key. Without this, calling
+			// Add("MY_KEY", new XRecord()) would persist with an empty entry name.
+			if (string.IsNullOrEmpty(value.Name))
+			{
+				value.Name = key;
+			}
+
 			this._entries.Add(key, value);
 			value.Owner = this;
 

--- a/src/ACadSharp/Objects/Material.cs
+++ b/src/ACadSharp/Objects/Material.cs
@@ -95,8 +95,13 @@ namespace ACadSharp.Objects
 		/// <summary>
 		/// Channel Flags.
 		/// </summary>
+		/// <summary>
+		/// Bit flags telling the renderer which Material channels to evaluate.
+		/// Defaults to <see cref="MaterialChannelFlags.UseAll"/> to match what
+		/// AutoCAD writes for every material it emits.
+		/// </summary>
 		[DxfCodeValue(94)]
-		public int ChannelFlags { get; set; }
+		public MaterialChannelFlags ChannelFlags { get; set; } = MaterialChannelFlags.UseAll;
 
 		/// <summary>
 		/// Material description.
@@ -178,8 +183,20 @@ namespace ACadSharp.Objects
 		[DxfCodeValue(74)]
 		public TilingMethod DiffuseTilingMethod { get; set; } = TilingMethod.Tile;
 
+		/// <summary>
+		/// Shader chosen to evaluate the Material's illumination. Defaults to
+		/// <see cref="MaterialIlluminationModel.BlinnShader"/>, the ODA SDK
+		/// default for <c>OdGiMaterialTraits</c>.
+		/// </summary>
 		[DxfCodeValue(93)]
-		public int IlluminationModel { get; set; } = 0;
+		public MaterialIlluminationModel IlluminationModel { get; set; } = MaterialIlluminationModel.BlinnShader;
+
+		/// <summary>
+		/// Render-pipeline mode hint. Defaults to
+		/// <see cref="MaterialMode.Realistic"/>, the ODA SDK default.
+		/// </summary>
+		[DxfCodeValue(282)]
+		public MaterialMode Mode { get; set; } = MaterialMode.Realistic;
 
 		/// <summary>
 		/// Material name.

--- a/src/ACadSharp/Objects/Material.cs
+++ b/src/ACadSharp/Objects/Material.cs
@@ -97,11 +97,15 @@ namespace ACadSharp.Objects
 		/// </summary>
 		/// <summary>
 		/// Bit flags telling the renderer which Material channels to evaluate.
-		/// Defaults to <see cref="MaterialChannelFlags.UseAll"/> to match what
-		/// AutoCAD writes for every material it emits.
+		/// Defaults to <see cref="MaterialChannelFlags.UseDiffuse"/> to match
+		/// what AutoCAD writes for a basic material. Setting
+		/// <see cref="MaterialChannelFlags.UseAll"/> here breaks texture
+		/// rendering in DWG TrueView because the renderer then tries to sample
+		/// channels (bump, reflection, refraction, normal) that the material
+		/// has no data for.
 		/// </summary>
 		[DxfCodeValue(94)]
-		public MaterialChannelFlags ChannelFlags { get; set; } = MaterialChannelFlags.UseAll;
+		public MaterialChannelFlags ChannelFlags { get; set; } = MaterialChannelFlags.UseDiffuse;
 
 		/// <summary>
 		/// Material description.

--- a/src/ACadSharp/Objects/MaterialChannelFlags.cs
+++ b/src/ACadSharp/Objects/MaterialChannelFlags.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace ACadSharp.Objects
+{
+	/// <summary>
+	/// Material channel-enable flags. Each bit toggles whether the renderer
+	/// considers the corresponding channel data on the <see cref="Material"/>.
+	/// Mirrors the ODA-side <c>OdGiMaterialTraits::ChannelFlags</c> enum.
+	/// </summary>
+	[Flags]
+	public enum MaterialChannelFlags
+	{
+		None = 0,
+		UseDiffuse = 0x01,
+		UseSpecular = 0x02,
+		UseReflection = 0x04,
+		UseOpacity = 0x08,
+		UseBump = 0x10,
+		UseRefraction = 0x20,
+		UseNormalMap = 0x40,
+		UseAll = UseDiffuse | UseSpecular | UseReflection | UseOpacity | UseBump | UseRefraction | UseNormalMap,
+	}
+}

--- a/src/ACadSharp/Objects/MaterialIlluminationModel.cs
+++ b/src/ACadSharp/Objects/MaterialIlluminationModel.cs
@@ -1,0 +1,12 @@
+namespace ACadSharp.Objects
+{
+	/// <summary>
+	/// Shader chosen to evaluate the illumination of a <see cref="Material"/>.
+	/// Mirrors the ODA-side <c>OdGiMaterialTraits::IlluminationModel</c> enum.
+	/// </summary>
+	public enum MaterialIlluminationModel
+	{
+		BlinnShader = 0,
+		MetalShader = 1,
+	}
+}

--- a/src/ACadSharp/Objects/MaterialMode.cs
+++ b/src/ACadSharp/Objects/MaterialMode.cs
@@ -1,0 +1,12 @@
+namespace ACadSharp.Objects
+{
+	/// <summary>
+	/// Render-pipeline mode hint for a <see cref="Material"/>. Mirrors the
+	/// ODA-side <c>OdGiMaterialTraits::Mode</c> enum.
+	/// </summary>
+	public enum MaterialMode
+	{
+		Realistic = 0,
+		Advanced = 1,
+	}
+}


### PR DESCRIPTION
## Summary

Adds Material write support and Mesh texture coordinate round-trip in DWG.

- DwgWriter emits Material objects (writeMaterial body, dispatch, dropped from skipEntry).
- Entities persist their Material reference via the common entity data material flag bits, and CadEntityTemplate binds the handle on read.
- The override-color RGB packing in writeMaterial uses the 0xC2 tag in the high byte so AutoCAD reads it as a true-color override instead of falling back to ByLayer.
- Material render-mode hints are now strongly-typed enums: MaterialChannelFlags, MaterialIlluminationModel, MaterialMode replace the raw int fields.
- New Mesh.TextureCoordinates property persists per-vertex UVs through the ADSK_XREC_SUBDVERTEXTEXCOORDS XRecord that AcDbSubDMesh stores on the mesh extension dictionary. DwgWriter materializes the XRecord in prepareDocument before writeHeader so HandleSeed stays accurate.
- CadDictionary.Add(string key, NonGraphicalObject value) syncs value.Name with the supplied key when the value has no name yet. Without this, callers using the 2-arg overload lost the entry key on write because writers serialize item.Name as the dictionary entry name.
- Material.ChannelFlags default lowered from UseAll to UseDiffuse. UseAll caused DWG TrueView to drop texture rendering on basic materials because the renderer sampled channels (bump, reflection, refraction, normal) the material had no data for.

## Test plan

- [x] Diagnostic project writes 3 cubes with distinct Materials and reads them back: 3 materials, 3 meshes with material references, identical color/method/factor fields on read.
- [x] DWG TrueView 2025 opens a mesh exported via this stack in Realistic mode with the diffuse texture rendered correctly (textured house from an OBJ import).
- [x] Existing read path still parses files produced by the reference writer (verified by re-reading the same TrueView-friendly file through DwgReader after each change).