### PR TITLE
Add TableEntity DXF round-trip (cells, alignment, merges, flow direction)

### DIFF
--- a/src/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
@@ -543,7 +543,18 @@ namespace ACadSharp.IO.DXF
 					tmp.CurrentCell.Rotation = this._reader.ValueAsDouble;
 					return true;
 				case 170:
-					//Has data flag
+					// Per-cell alignment (set when the cell flag at code 91 has the
+					// CellAlignment override bit). Capture it on the cell-level
+					// StyleOverride so callers reading the table back via DXF can
+					// resolve alignment exactly like they do through DWG.
+					if (tmp.CurrentCell != null)
+					{
+						tmp.CurrentCell.StyleOverride.HasData = true;
+						tmp.CurrentCell.StyleOverride.CellAlignment =
+							(ACadSharp.Objects.TableStyle.CellAlignmentType)this._reader.ValueAsShort;
+						tmp.CurrentCell.StyleOverride.PropertyOverrideFlags |=
+							ACadSharp.Objects.TableStyle.CellStylePropertyFlags.Alignment;
+					}
 					return true;
 				case 171:
 					tmp.CreateCell((TableEntity.CellType)this._reader.ValueAsInt);
@@ -568,6 +579,18 @@ namespace ACadSharp.IO.DXF
 					return true;
 				case 179:
 					//Unknown value
+					return true;
+				case 70:
+					// Table-level flow direction (0 = top to bottom, 1 = bottom to top).
+					// Stored on the table-level CellStyleOverride so callers can read it
+					// through the same API used for round-tripping the rest of the
+					// override flags.
+					if (this._reader.ValueAsShort == 1)
+					{
+						table.CellStyleOverride.HasData = true;
+						table.CellStyleOverride.TableCellStylePropertyFlags |=
+							ACadSharp.Objects.TableStyle.CellStylePropertyFlags.FlowDirectionBottomToTop;
+					}
 					return true;
 				case 301:
 					content = new TableEntity.CellContent();

--- a/src/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
@@ -544,7 +544,18 @@ internal abstract class DxfSectionReaderBase
 				tmp.CurrentCell.Rotation = this._reader.ValueAsDouble;
 				return true;
 			case 170:
-				//Has data flag
+				// Per-cell alignment (set when the cell flag at code 91 has the
+				// CellAlignment override bit). Capture it on the cell-level
+				// StyleOverride so callers reading the table back via DXF can
+				// resolve alignment exactly like they do through DWG.
+				if (tmp.CurrentCell != null)
+				{
+					tmp.CurrentCell.StyleOverride.HasData = true;
+					tmp.CurrentCell.StyleOverride.CellAlignment =
+						(ACadSharp.Objects.TableStyle.CellAlignmentType)this._reader.ValueAsShort;
+					tmp.CurrentCell.StyleOverride.PropertyOverrideFlags |=
+						ACadSharp.Objects.TableStyle.CellStylePropertyFlags.Alignment;
+				}
 				return true;
 			case 171:
 				tmp.CreateCell((TableEntity.CellType)this._reader.ValueAsInt);
@@ -569,6 +580,18 @@ internal abstract class DxfSectionReaderBase
 				return true;
 			case 179:
 				//Unknown value
+				return true;
+			case 70:
+				// Table-level flow direction (0 = top to bottom, 1 = bottom to top).
+				// Stored on the table-level CellStyleOverride so callers can read it
+				// through the same API used for round-tripping the rest of the
+				// override flags.
+				if (this._reader.ValueAsShort == 1)
+				{
+					table.CellStyleOverride.HasData = true;
+					table.CellStyleOverride.TableCellStylePropertyFlags |=
+						ACadSharp.Objects.TableStyle.CellStylePropertyFlags.FlowDirectionBottomToTop;
+				}
 				return true;
 			case 301:
 				content = new TableEntity.CellContent();

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
@@ -599,8 +599,7 @@ internal abstract partial class DxfSectionWriterBase
 	{
 		// Emit the AcDbBlockReference (Insert) layer first. AutoCAD reads the block
 		// reference to instantiate the anonymous BlockRecord that holds the rendered
-		// table geometry, so even before the AcDbTable cells are populated the viewer
-		// has something to draw.
+		// table geometry, so it always has something to draw.
 		this._writer.Write(DxfCode.Subclass, DxfSubclassMarker.Insert);
 		if (table.Block != null)
 		{
@@ -613,42 +612,18 @@ internal abstract partial class DxfSectionWriterBase
 		this._writer.Write(50, table.Rotation);
 		this._writer.Write(210, table.Normal);
 
-		// AcDbTable subclass with the table-level header. Rows/columns/cells are
-		// intentionally not emitted in this minimal pass: when both AcDbBlockReference
-		// and a fully populated AcDbTable describe the same entity, AutoCAD ends up
-		// rendering the table twice (once from the anonymous BlockRecord pointed to
-		// by code 2, once from the AcDbTable cells), and the two renderings are
-		// usually offset because the AcDbTable renderer does not pick up the Insert's
-		// transform. Emitting only the header lets AutoCAD treat the entity as an
-		// Insert visually while keeping it tagged as ACAD_TABLE for tooling that
-		// inspects the class.
+		// AcDbTable subclass with the full cell data so the table round-trips through
+		// a DxfReader without losing rows, columns or text content. AutoCAD prefers a
+		// proxy graphic preview (codes 160/310 in AcDbEntity) when one is present and
+		// ignores the cell data for layout; without a preview, AutoCAD also renders
+		// the cells on top of the BlockReference, producing a second offset copy of
+		// the table. That visual artifact is the cost of keeping the data
+		// round-trippable: callers that need a single rendering should provide a
+		// proxy graphic via Entity.PreviewGraphic.
+		//
+		// Field order mirrors what AutoCAD emits so the strict ODA-based reader does
+		// not bail with "Invalid index" partway through the entity.
 		this._writer.Write(DxfCode.Subclass, DxfSubclassMarker.TableEntity);
-		this._writer.Write(280, table.Version);
-
-		this._writer.Write(11, table.HorizontalDirection);
-
-		int flag = table.ValueFlag;
-		if (table.OverrideFlag)
-		{
-			flag |= 1;
-		}
-		this._writer.Write(90, flag);
-
-		this._writer.Write(91, 0); // row count placeholder
-		this._writer.Write(92, 0); // column count placeholder
-
-		if (table.OverrideBorderColor)
-		{
-			this._writer.Write(94, 1);
-		}
-		if (table.OverrideBorderLineWeight)
-		{
-			this._writer.Write(95, 1);
-		}
-		if (table.OverrideBorderVisibility)
-		{
-			this._writer.Write(96, 1);
-		}
 
 		if (table.Style != null)
 		{
@@ -659,7 +634,201 @@ internal abstract partial class DxfSectionWriterBase
 			this._writer.Write(343, table.Block.Handle);
 		}
 
-		this.notify("TableEntity DXF writer emits the entity as a block reference; cell data is not round-tripped.", NotificationType.Warning);
+		this._writer.Write(11, table.HorizontalDirection);
+
+		int flag = table.ValueFlag;
+		if (table.OverrideFlag)
+		{
+			flag |= 1;
+		}
+		this._writer.Write(90, flag);
+
+		this._writer.Write(91, table.Rows.Count);
+		this._writer.Write(92, table.Columns.Count);
+
+		// Override count placeholder. The exact semantics of code 93 at the table
+		// level are not documented in OpenDesign but AutoCAD-produced files always
+		// emit it. Emit 0 here; the reader does not error out on it.
+		this._writer.Write(93, 0);
+
+		this._writer.Write(94, table.OverrideBorderColor ? 1 : 0);
+		this._writer.Write(95, table.OverrideBorderLineWeight ? 1 : 0);
+		this._writer.Write(96, table.OverrideBorderVisibility ? 1 : 0);
+
+		// Flow direction is emitted only when set to bottom-to-top. Down-direction
+		// tables in AutoCAD-produced files omit the code entirely.
+		bool isFlowUp = table.CellStyleOverride != null
+			&& table.CellStyleOverride.TableCellStylePropertyFlags.HasFlag(ACadSharp.Objects.TableStyle.CellStylePropertyFlags.FlowDirectionBottomToTop);
+		if (isFlowUp)
+		{
+			this._writer.Write(70, (short)1);
+		}
+
+		// Table-level cell margins. AutoCAD reads these here even when the per-cell
+		// style override carries the same values; omitting them causes the strict
+		// ODA-based reader to abort with "Invalid index".
+		double horMargin = 0.06;
+		double verMargin = 0.06;
+		if (table.CellStyleOverride != null
+			&& table.CellStyleOverride.MarginOverrideFlags.HasFlag(ACadSharp.Objects.TableStyle.MarginFlags.Override))
+		{
+			horMargin = table.CellStyleOverride.HorizontalMargin;
+			verMargin = table.CellStyleOverride.VerticalMargin;
+		}
+		else if (table.Style != null)
+		{
+			horMargin = table.Style.HorizontalCellMargin;
+			verMargin = table.Style.VerticalCellMargin;
+		}
+		this._writer.Write(40, horMargin);
+		this._writer.Write(41, verMargin);
+
+		this.notify("TableEntity DXF writer emits cell data without a proxy graphic preview; AutoCAD may draw the table twice (once from the block reference, once from the cells with no transform applied).", NotificationType.Warning);
+
+		foreach (var row in table.Rows)
+		{
+			this._writer.Write(141, row.Height);
+		}
+
+		foreach (var col in table.Columns)
+		{
+			this._writer.Write(142, col.Width);
+		}
+
+		// Translate table-level MergedCellRanges into the per-cell flags AutoCAD reads:
+		// the top-left cell of each range carries the column/row span in BorderWidth and
+		// BorderHeight while the remaining cells in the range have MergedValue = 1.
+		int rowCount = table.Rows.Count;
+		int colCount = table.Columns.Count;
+		short[,] mergeBorderWidth = new short[rowCount, colCount];
+		short[,] mergeBorderHeight = new short[rowCount, colCount];
+		short[,] mergeFlag = new short[rowCount, colCount];
+		for (int i = 0; i < rowCount; i++)
+		{
+			for (int j = 0; j < colCount; j++)
+			{
+				mergeBorderWidth[i, j] = 1;
+				mergeBorderHeight[i, j] = 1;
+			}
+		}
+		foreach (var range in table.MergedCellRanges)
+		{
+			int top = System.Math.Max(0, range.TopRowIndex);
+			int bottom = System.Math.Min(rowCount - 1, range.BottomRowIndex);
+			int left = System.Math.Max(0, range.LeftColumnIndex);
+			int right = System.Math.Min(colCount - 1, range.RightColumnIndex);
+			int rowSpan = bottom - top + 1;
+			int colSpan = right - left + 1;
+			if (rowSpan < 1 || colSpan < 1)
+			{
+				continue;
+			}
+			mergeBorderWidth[top, left] = (short)colSpan;
+			mergeBorderHeight[top, left] = (short)rowSpan;
+			for (int i = top; i <= bottom; i++)
+			{
+				for (int j = left; j <= right; j++)
+				{
+					if (i == top && j == left)
+					{
+						continue;
+					}
+					mergeFlag[i, j] = 1;
+				}
+			}
+		}
+
+		for (int i = 0; i < rowCount; i++)
+		{
+			var row = table.Rows[i];
+			for (int j = 0; j < row.Cells.Count; j++)
+			{
+				var cell = row.Cells[j];
+				short borderWidth = j < colCount ? mergeBorderWidth[i, j] : (short)1;
+				short borderHeight = j < colCount ? mergeBorderHeight[i, j] : (short)1;
+				short mergedValue = j < colCount ? mergeFlag[i, j] : (short)cell.MergedValue;
+				this._writer.Write(171, (short)cell.Type);
+				this._writer.Write(172, (short)cell.EdgeFlags);
+				this._writer.Write(173, mergedValue);
+				this._writer.Write(174, cell.AutoFit);
+				this._writer.Write(175, (int)borderWidth);
+				this._writer.Write(176, (int)borderHeight);
+
+				// Cell flag (state + override bits). AutoCAD-produced files always emit
+				// 262192 baseline and set bit 0x01 when the cell-level CellAlignment
+				// override is present; code 170 with the alignment value follows when
+				// that bit is set. Without bit 0x01 the strict ODA-based reader falls
+				// back to the TableStyle default and per-cell alignments leak away.
+				const int baseCellFlag = 262192;
+				bool hasAlignmentOverride = cell.StyleOverride != null
+					&& cell.StyleOverride.HasData
+					&& cell.StyleOverride.CellAlignment != default(ACadSharp.Objects.TableStyle.CellAlignmentType);
+				int cellFlag = baseCellFlag;
+				if (hasAlignmentOverride)
+				{
+					cellFlag |= 0x01;
+				}
+				this._writer.Write(91, cellFlag);
+				this._writer.Write(178, (short)cell.VirtualEdgeFlag);
+
+				this._writer.Write(145, cell.Rotation);
+
+				if (hasAlignmentOverride)
+				{
+					this._writer.Write(170, (short)cell.StyleOverride.CellAlignment);
+				}
+
+				ACadSharp.Tables.TextStyle textStyle = cell.StyleOverride?.TextStyle
+					?? (cell.Contents.Count > 0 ? cell.Contents[0].Format?.TextStyle : null);
+				if (textStyle != null)
+				{
+					this._writer.Write(7, textStyle.Name);
+				}
+
+				double textHeight = 0.0;
+				if (cell.StyleOverride != null && cell.StyleOverride.TextHeight > 0)
+				{
+					textHeight = cell.StyleOverride.TextHeight;
+				}
+				else if (cell.Contents.Count > 0 && cell.Contents[0].Format != null && cell.Contents[0].Format.TextHeight > 0)
+				{
+					textHeight = cell.Contents[0].Format.TextHeight;
+				}
+				if (textHeight > 0)
+				{
+					this._writer.Write(140, textHeight);
+				}
+
+				// Cell value state flag. AutoCAD-produced files always emit this before the
+				// CELL_VALUE block; omitting it causes the strict ODA-based reader to bail
+				// with "Invalid index".
+				this._writer.Write(92, 0);
+
+				// Cell text content wrapped in the CELL_VALUE block. The reader keys on
+				// code 301 to enter readCadValue and exits at 304.
+				string textValue = null;
+				if (cell.Content != null && cell.Content.CadValue.Value is string s)
+				{
+					textValue = s;
+				}
+				else if (cell.Contents.Count > 0 && cell.Contents[0].CadValue.Value is string s2)
+				{
+					textValue = s2;
+				}
+
+				if (!string.IsNullOrEmpty(textValue))
+				{
+					this._writer.Write(301, "CELL_VALUE");
+					this._writer.Write(93, 6);
+					this._writer.Write(90, (int)ACadSharp.CadValueType.String);
+					this._writer.Write(1, textValue);
+					this._writer.Write(94, 0);
+					this._writer.Write(300, string.Empty);
+					this._writer.Write(302, textValue);
+					this._writer.Write(304, "ACVALUE_END");
+				}
+			}
+		}
 	}
 
 	private void writeInsert(Insert insert)

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
@@ -598,10 +598,15 @@ internal abstract partial class DxfSectionWriterBase
 		this._writer.Write(50, table.Rotation);
 		this._writer.Write(210, table.Normal);
 
-		// AcDbTable subclass with the table-level data. This is the minimal set of
-		// codes the DXF reader expects; advanced features (per-cell content beyond a
-		// single text run, custom data, borders, format runs, merged ranges) are not
-		// emitted yet and will be lost on round-trip.
+		// AcDbTable subclass with the table-level header. Rows/columns/cells are
+		// intentionally not emitted in this minimal pass: when both AcDbBlockReference
+		// and a fully populated AcDbTable describe the same entity, AutoCAD ends up
+		// rendering the table twice (once from the anonymous BlockRecord pointed to
+		// by code 2, once from the AcDbTable cells), and the two renderings are
+		// usually offset because the AcDbTable renderer does not pick up the Insert's
+		// transform. Emitting only the header lets AutoCAD treat the entity as an
+		// Insert visually while keeping it tagged as ACAD_TABLE for tooling that
+		// inspects the class.
 		this._writer.Write(DxfCode.Subclass, DxfSubclassMarker.TableEntity);
 		this._writer.Write(280, table.Version);
 
@@ -614,8 +619,8 @@ internal abstract partial class DxfSectionWriterBase
 		}
 		this._writer.Write(90, flag);
 
-		this._writer.Write(91, table.Rows.Count);
-		this._writer.Write(92, table.Columns.Count);
+		this._writer.Write(91, 0); // row count placeholder
+		this._writer.Write(92, 0); // column count placeholder
 
 		if (table.OverrideBorderColor)
 		{
@@ -639,46 +644,7 @@ internal abstract partial class DxfSectionWriterBase
 			this._writer.Write(343, table.Block.Handle);
 		}
 
-		foreach (var col in table.Columns)
-		{
-			this._writer.Write(142, col.Width);
-		}
-
-		foreach (var row in table.Rows)
-		{
-			this._writer.Write(141, row.Height);
-
-			foreach (var cell in row.Cells)
-			{
-				this._writer.Write(171, (short)cell.Type);
-				this._writer.Write(172, (short)cell.EdgeFlags);
-				this._writer.Write(173, (short)cell.MergedValue);
-				this._writer.Write(174, cell.AutoFit);
-				this._writer.Write(175, cell.BorderWidth);
-				this._writer.Write(176, cell.BorderHeight);
-
-				// First text content if available. Block-cell payloads and multi-run
-				// content are intentionally skipped in this initial pass.
-				string textValue = null;
-				if (cell.Content != null && cell.Content.CadValue.Value is string s)
-				{
-					textValue = s;
-				}
-				else if (cell.Contents.Count > 0 && cell.Contents[0].CadValue.Value is string s2)
-				{
-					textValue = s2;
-				}
-
-				if (!string.IsNullOrEmpty(textValue))
-				{
-					this._writer.Write(1, textValue);
-				}
-
-				this._writer.Write(145, cell.Rotation);
-			}
-		}
-
-		this.notify("TableEntity DXF writer emits a minimal subset of cell data; advanced cell content, borders, and merged ranges are not yet round-tripped.", NotificationType.Warning);
+		this.notify("TableEntity DXF writer emits the entity as a block reference; cell data is not round-tripped.", NotificationType.Warning);
 	}
 
 	private void writeInsert(Insert insert)

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
@@ -43,6 +43,9 @@ internal abstract partial class DxfSectionWriterBase
 			case Hatch hatch:
 				this.writeHatch(hatch);
 				break;
+			case TableEntity tableEntity:
+				this.writeTableEntity(tableEntity);
+				break;
 			case Insert insert:
 				this.writeInsert(insert);
 				break;
@@ -145,7 +148,6 @@ internal abstract partial class DxfSectionWriterBase
 			case Shape:
 				return this.Configuration.WriteShapes;
 			case ProxyEntity:
-			case TableEntity:
 			case Solid3D:
 			case CadBody:
 			case Region:
@@ -576,6 +578,107 @@ internal abstract partial class DxfSectionWriterBase
 				}
 			}
 		}
+	}
+
+	private void writeTableEntity(TableEntity table)
+	{
+		// Emit the AcDbBlockReference (Insert) layer first. AutoCAD reads the block
+		// reference to instantiate the anonymous BlockRecord that holds the rendered
+		// table geometry, so even before the AcDbTable cells are populated the viewer
+		// has something to draw.
+		this._writer.Write(DxfCode.Subclass, DxfSubclassMarker.Insert);
+		if (table.Block != null)
+		{
+			this._writer.Write(2, table.Block.Name);
+		}
+		this._writer.Write(10, table.InsertPoint);
+		this._writer.Write(41, table.XScale);
+		this._writer.Write(42, table.YScale);
+		this._writer.Write(43, table.ZScale);
+		this._writer.Write(50, table.Rotation);
+		this._writer.Write(210, table.Normal);
+
+		// AcDbTable subclass with the table-level data. This is the minimal set of
+		// codes the DXF reader expects; advanced features (per-cell content beyond a
+		// single text run, custom data, borders, format runs, merged ranges) are not
+		// emitted yet and will be lost on round-trip.
+		this._writer.Write(DxfCode.Subclass, DxfSubclassMarker.TableEntity);
+		this._writer.Write(280, table.Version);
+
+		this._writer.Write(11, table.HorizontalDirection);
+
+		int flag = table.ValueFlag;
+		if (table.OverrideFlag)
+		{
+			flag |= 1;
+		}
+		this._writer.Write(90, flag);
+
+		this._writer.Write(91, table.Rows.Count);
+		this._writer.Write(92, table.Columns.Count);
+
+		if (table.OverrideBorderColor)
+		{
+			this._writer.Write(94, 1);
+		}
+		if (table.OverrideBorderLineWeight)
+		{
+			this._writer.Write(95, 1);
+		}
+		if (table.OverrideBorderVisibility)
+		{
+			this._writer.Write(96, 1);
+		}
+
+		if (table.Style != null)
+		{
+			this._writer.Write(342, table.Style.Handle);
+		}
+		if (table.Block != null)
+		{
+			this._writer.Write(343, table.Block.Handle);
+		}
+
+		foreach (var col in table.Columns)
+		{
+			this._writer.Write(142, col.Width);
+		}
+
+		foreach (var row in table.Rows)
+		{
+			this._writer.Write(141, row.Height);
+
+			foreach (var cell in row.Cells)
+			{
+				this._writer.Write(171, (short)cell.Type);
+				this._writer.Write(172, (short)cell.EdgeFlags);
+				this._writer.Write(173, (short)cell.MergedValue);
+				this._writer.Write(174, cell.AutoFit);
+				this._writer.Write(175, cell.BorderWidth);
+				this._writer.Write(176, cell.BorderHeight);
+
+				// First text content if available. Block-cell payloads and multi-run
+				// content are intentionally skipped in this initial pass.
+				string textValue = null;
+				if (cell.Content != null && cell.Content.CadValue.Value is string s)
+				{
+					textValue = s;
+				}
+				else if (cell.Contents.Count > 0 && cell.Contents[0].CadValue.Value is string s2)
+				{
+					textValue = s2;
+				}
+
+				if (!string.IsNullOrEmpty(textValue))
+				{
+					this._writer.Write(1, textValue);
+				}
+
+				this._writer.Write(145, cell.Rotation);
+			}
+		}
+
+		this.notify("TableEntity DXF writer emits a minimal subset of cell data; advanced cell content, borders, and merged ranges are not yet round-tripped.", NotificationType.Warning);
 	}
 
 	private void writeInsert(Insert insert)

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
@@ -613,10 +613,15 @@ internal abstract partial class DxfSectionWriterBase
 		this._writer.Write(50, table.Rotation);
 		this._writer.Write(210, table.Normal);
 
-		// AcDbTable subclass with the table-level data. This is the minimal set of
-		// codes the DXF reader expects; advanced features (per-cell content beyond a
-		// single text run, custom data, borders, format runs, merged ranges) are not
-		// emitted yet and will be lost on round-trip.
+		// AcDbTable subclass with the table-level header. Rows/columns/cells are
+		// intentionally not emitted in this minimal pass: when both AcDbBlockReference
+		// and a fully populated AcDbTable describe the same entity, AutoCAD ends up
+		// rendering the table twice (once from the anonymous BlockRecord pointed to
+		// by code 2, once from the AcDbTable cells), and the two renderings are
+		// usually offset because the AcDbTable renderer does not pick up the Insert's
+		// transform. Emitting only the header lets AutoCAD treat the entity as an
+		// Insert visually while keeping it tagged as ACAD_TABLE for tooling that
+		// inspects the class.
 		this._writer.Write(DxfCode.Subclass, DxfSubclassMarker.TableEntity);
 		this._writer.Write(280, table.Version);
 
@@ -629,8 +634,8 @@ internal abstract partial class DxfSectionWriterBase
 		}
 		this._writer.Write(90, flag);
 
-		this._writer.Write(91, table.Rows.Count);
-		this._writer.Write(92, table.Columns.Count);
+		this._writer.Write(91, 0); // row count placeholder
+		this._writer.Write(92, 0); // column count placeholder
 
 		if (table.OverrideBorderColor)
 		{
@@ -654,46 +659,7 @@ internal abstract partial class DxfSectionWriterBase
 			this._writer.Write(343, table.Block.Handle);
 		}
 
-		foreach (var col in table.Columns)
-		{
-			this._writer.Write(142, col.Width);
-		}
-
-		foreach (var row in table.Rows)
-		{
-			this._writer.Write(141, row.Height);
-
-			foreach (var cell in row.Cells)
-			{
-				this._writer.Write(171, (short)cell.Type);
-				this._writer.Write(172, (short)cell.EdgeFlags);
-				this._writer.Write(173, (short)cell.MergedValue);
-				this._writer.Write(174, cell.AutoFit);
-				this._writer.Write(175, cell.BorderWidth);
-				this._writer.Write(176, cell.BorderHeight);
-
-				// First text content if available. Block-cell payloads and multi-run
-				// content are intentionally skipped in this initial pass.
-				string textValue = null;
-				if (cell.Content != null && cell.Content.CadValue.Value is string s)
-				{
-					textValue = s;
-				}
-				else if (cell.Contents.Count > 0 && cell.Contents[0].CadValue.Value is string s2)
-				{
-					textValue = s2;
-				}
-
-				if (!string.IsNullOrEmpty(textValue))
-				{
-					this._writer.Write(1, textValue);
-				}
-
-				this._writer.Write(145, cell.Rotation);
-			}
-		}
-
-		this.notify("TableEntity DXF writer emits a minimal subset of cell data; advanced cell content, borders, and merged ranges are not yet round-tripped.", NotificationType.Warning);
+		this.notify("TableEntity DXF writer emits the entity as a block reference; cell data is not round-tripped.", NotificationType.Warning);
 	}
 
 	private void writeInsert(Insert insert)

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
@@ -43,6 +43,9 @@ internal abstract partial class DxfSectionWriterBase
 			case Hatch hatch:
 				this.writeHatch(hatch);
 				break;
+			case TableEntity tableEntity:
+				this.writeTableEntity(tableEntity);
+				break;
 			case Insert insert:
 				this.writeInsert(insert);
 				break;
@@ -145,7 +148,6 @@ internal abstract partial class DxfSectionWriterBase
 			case Shape:
 				return this.Configuration.WriteShapes;
 			case ProxyEntity:
-			case TableEntity:
 			case Solid3D:
 			case CadBody:
 			case Region:
@@ -591,6 +593,107 @@ internal abstract partial class DxfSectionWriterBase
 				}
 			}
 		}
+	}
+
+	private void writeTableEntity(TableEntity table)
+	{
+		// Emit the AcDbBlockReference (Insert) layer first. AutoCAD reads the block
+		// reference to instantiate the anonymous BlockRecord that holds the rendered
+		// table geometry, so even before the AcDbTable cells are populated the viewer
+		// has something to draw.
+		this._writer.Write(DxfCode.Subclass, DxfSubclassMarker.Insert);
+		if (table.Block != null)
+		{
+			this._writer.Write(2, table.Block.Name);
+		}
+		this._writer.Write(10, table.InsertPoint);
+		this._writer.Write(41, table.XScale);
+		this._writer.Write(42, table.YScale);
+		this._writer.Write(43, table.ZScale);
+		this._writer.Write(50, table.Rotation);
+		this._writer.Write(210, table.Normal);
+
+		// AcDbTable subclass with the table-level data. This is the minimal set of
+		// codes the DXF reader expects; advanced features (per-cell content beyond a
+		// single text run, custom data, borders, format runs, merged ranges) are not
+		// emitted yet and will be lost on round-trip.
+		this._writer.Write(DxfCode.Subclass, DxfSubclassMarker.TableEntity);
+		this._writer.Write(280, table.Version);
+
+		this._writer.Write(11, table.HorizontalDirection);
+
+		int flag = table.ValueFlag;
+		if (table.OverrideFlag)
+		{
+			flag |= 1;
+		}
+		this._writer.Write(90, flag);
+
+		this._writer.Write(91, table.Rows.Count);
+		this._writer.Write(92, table.Columns.Count);
+
+		if (table.OverrideBorderColor)
+		{
+			this._writer.Write(94, 1);
+		}
+		if (table.OverrideBorderLineWeight)
+		{
+			this._writer.Write(95, 1);
+		}
+		if (table.OverrideBorderVisibility)
+		{
+			this._writer.Write(96, 1);
+		}
+
+		if (table.Style != null)
+		{
+			this._writer.Write(342, table.Style.Handle);
+		}
+		if (table.Block != null)
+		{
+			this._writer.Write(343, table.Block.Handle);
+		}
+
+		foreach (var col in table.Columns)
+		{
+			this._writer.Write(142, col.Width);
+		}
+
+		foreach (var row in table.Rows)
+		{
+			this._writer.Write(141, row.Height);
+
+			foreach (var cell in row.Cells)
+			{
+				this._writer.Write(171, (short)cell.Type);
+				this._writer.Write(172, (short)cell.EdgeFlags);
+				this._writer.Write(173, (short)cell.MergedValue);
+				this._writer.Write(174, cell.AutoFit);
+				this._writer.Write(175, cell.BorderWidth);
+				this._writer.Write(176, cell.BorderHeight);
+
+				// First text content if available. Block-cell payloads and multi-run
+				// content are intentionally skipped in this initial pass.
+				string textValue = null;
+				if (cell.Content != null && cell.Content.CadValue.Value is string s)
+				{
+					textValue = s;
+				}
+				else if (cell.Contents.Count > 0 && cell.Contents[0].CadValue.Value is string s2)
+				{
+					textValue = s2;
+				}
+
+				if (!string.IsNullOrEmpty(textValue))
+				{
+					this._writer.Write(1, textValue);
+				}
+
+				this._writer.Write(145, cell.Rotation);
+			}
+		}
+
+		this.notify("TableEntity DXF writer emits a minimal subset of cell data; advanced cell content, borders, and merged ranges are not yet round-tripped.", NotificationType.Warning);
 	}
 
 	private void writeInsert(Insert insert)

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
@@ -584,8 +584,7 @@ internal abstract partial class DxfSectionWriterBase
 	{
 		// Emit the AcDbBlockReference (Insert) layer first. AutoCAD reads the block
 		// reference to instantiate the anonymous BlockRecord that holds the rendered
-		// table geometry, so even before the AcDbTable cells are populated the viewer
-		// has something to draw.
+		// table geometry, so it always has something to draw.
 		this._writer.Write(DxfCode.Subclass, DxfSubclassMarker.Insert);
 		if (table.Block != null)
 		{
@@ -598,42 +597,18 @@ internal abstract partial class DxfSectionWriterBase
 		this._writer.Write(50, table.Rotation);
 		this._writer.Write(210, table.Normal);
 
-		// AcDbTable subclass with the table-level header. Rows/columns/cells are
-		// intentionally not emitted in this minimal pass: when both AcDbBlockReference
-		// and a fully populated AcDbTable describe the same entity, AutoCAD ends up
-		// rendering the table twice (once from the anonymous BlockRecord pointed to
-		// by code 2, once from the AcDbTable cells), and the two renderings are
-		// usually offset because the AcDbTable renderer does not pick up the Insert's
-		// transform. Emitting only the header lets AutoCAD treat the entity as an
-		// Insert visually while keeping it tagged as ACAD_TABLE for tooling that
-		// inspects the class.
+		// AcDbTable subclass with the full cell data so the table round-trips through
+		// a DxfReader without losing rows, columns or text content. AutoCAD prefers a
+		// proxy graphic preview (codes 160/310 in AcDbEntity) when one is present and
+		// ignores the cell data for layout; without a preview, AutoCAD also renders
+		// the cells on top of the BlockReference, producing a second offset copy of
+		// the table. That visual artifact is the cost of keeping the data
+		// round-trippable: callers that need a single rendering should provide a
+		// proxy graphic via Entity.PreviewGraphic.
+		//
+		// Field order mirrors what AutoCAD emits so the strict ODA-based reader does
+		// not bail with "Invalid index" partway through the entity.
 		this._writer.Write(DxfCode.Subclass, DxfSubclassMarker.TableEntity);
-		this._writer.Write(280, table.Version);
-
-		this._writer.Write(11, table.HorizontalDirection);
-
-		int flag = table.ValueFlag;
-		if (table.OverrideFlag)
-		{
-			flag |= 1;
-		}
-		this._writer.Write(90, flag);
-
-		this._writer.Write(91, 0); // row count placeholder
-		this._writer.Write(92, 0); // column count placeholder
-
-		if (table.OverrideBorderColor)
-		{
-			this._writer.Write(94, 1);
-		}
-		if (table.OverrideBorderLineWeight)
-		{
-			this._writer.Write(95, 1);
-		}
-		if (table.OverrideBorderVisibility)
-		{
-			this._writer.Write(96, 1);
-		}
 
 		if (table.Style != null)
 		{
@@ -644,7 +619,201 @@ internal abstract partial class DxfSectionWriterBase
 			this._writer.Write(343, table.Block.Handle);
 		}
 
-		this.notify("TableEntity DXF writer emits the entity as a block reference; cell data is not round-tripped.", NotificationType.Warning);
+		this._writer.Write(11, table.HorizontalDirection);
+
+		int flag = table.ValueFlag;
+		if (table.OverrideFlag)
+		{
+			flag |= 1;
+		}
+		this._writer.Write(90, flag);
+
+		this._writer.Write(91, table.Rows.Count);
+		this._writer.Write(92, table.Columns.Count);
+
+		// Override count placeholder. The exact semantics of code 93 at the table
+		// level are not documented in OpenDesign but AutoCAD-produced files always
+		// emit it. Emit 0 here; the reader does not error out on it.
+		this._writer.Write(93, 0);
+
+		this._writer.Write(94, table.OverrideBorderColor ? 1 : 0);
+		this._writer.Write(95, table.OverrideBorderLineWeight ? 1 : 0);
+		this._writer.Write(96, table.OverrideBorderVisibility ? 1 : 0);
+
+		// Flow direction is emitted only when set to bottom-to-top. Down-direction
+		// tables in AutoCAD-produced files omit the code entirely.
+		bool isFlowUp = table.CellStyleOverride != null
+			&& table.CellStyleOverride.TableCellStylePropertyFlags.HasFlag(ACadSharp.Objects.TableStyle.CellStylePropertyFlags.FlowDirectionBottomToTop);
+		if (isFlowUp)
+		{
+			this._writer.Write(70, (short)1);
+		}
+
+		// Table-level cell margins. AutoCAD reads these here even when the per-cell
+		// style override carries the same values; omitting them causes the strict
+		// ODA-based reader to abort with "Invalid index".
+		double horMargin = 0.06;
+		double verMargin = 0.06;
+		if (table.CellStyleOverride != null
+			&& table.CellStyleOverride.MarginOverrideFlags.HasFlag(ACadSharp.Objects.TableStyle.MarginFlags.Override))
+		{
+			horMargin = table.CellStyleOverride.HorizontalMargin;
+			verMargin = table.CellStyleOverride.VerticalMargin;
+		}
+		else if (table.Style != null)
+		{
+			horMargin = table.Style.HorizontalCellMargin;
+			verMargin = table.Style.VerticalCellMargin;
+		}
+		this._writer.Write(40, horMargin);
+		this._writer.Write(41, verMargin);
+
+		this.notify("TableEntity DXF writer emits cell data without a proxy graphic preview; AutoCAD may draw the table twice (once from the block reference, once from the cells with no transform applied).", NotificationType.Warning);
+
+		foreach (var row in table.Rows)
+		{
+			this._writer.Write(141, row.Height);
+		}
+
+		foreach (var col in table.Columns)
+		{
+			this._writer.Write(142, col.Width);
+		}
+
+		// Translate table-level MergedCellRanges into the per-cell flags AutoCAD reads:
+		// the top-left cell of each range carries the column/row span in BorderWidth and
+		// BorderHeight while the remaining cells in the range have MergedValue = 1.
+		int rowCount = table.Rows.Count;
+		int colCount = table.Columns.Count;
+		short[,] mergeBorderWidth = new short[rowCount, colCount];
+		short[,] mergeBorderHeight = new short[rowCount, colCount];
+		short[,] mergeFlag = new short[rowCount, colCount];
+		for (int i = 0; i < rowCount; i++)
+		{
+			for (int j = 0; j < colCount; j++)
+			{
+				mergeBorderWidth[i, j] = 1;
+				mergeBorderHeight[i, j] = 1;
+			}
+		}
+		foreach (var range in table.MergedCellRanges)
+		{
+			int top = System.Math.Max(0, range.TopRowIndex);
+			int bottom = System.Math.Min(rowCount - 1, range.BottomRowIndex);
+			int left = System.Math.Max(0, range.LeftColumnIndex);
+			int right = System.Math.Min(colCount - 1, range.RightColumnIndex);
+			int rowSpan = bottom - top + 1;
+			int colSpan = right - left + 1;
+			if (rowSpan < 1 || colSpan < 1)
+			{
+				continue;
+			}
+			mergeBorderWidth[top, left] = (short)colSpan;
+			mergeBorderHeight[top, left] = (short)rowSpan;
+			for (int i = top; i <= bottom; i++)
+			{
+				for (int j = left; j <= right; j++)
+				{
+					if (i == top && j == left)
+					{
+						continue;
+					}
+					mergeFlag[i, j] = 1;
+				}
+			}
+		}
+
+		for (int i = 0; i < rowCount; i++)
+		{
+			var row = table.Rows[i];
+			for (int j = 0; j < row.Cells.Count; j++)
+			{
+				var cell = row.Cells[j];
+				short borderWidth = j < colCount ? mergeBorderWidth[i, j] : (short)1;
+				short borderHeight = j < colCount ? mergeBorderHeight[i, j] : (short)1;
+				short mergedValue = j < colCount ? mergeFlag[i, j] : (short)cell.MergedValue;
+				this._writer.Write(171, (short)cell.Type);
+				this._writer.Write(172, (short)cell.EdgeFlags);
+				this._writer.Write(173, mergedValue);
+				this._writer.Write(174, cell.AutoFit);
+				this._writer.Write(175, (int)borderWidth);
+				this._writer.Write(176, (int)borderHeight);
+
+				// Cell flag (state + override bits). AutoCAD-produced files always emit
+				// 262192 baseline and set bit 0x01 when the cell-level CellAlignment
+				// override is present; code 170 with the alignment value follows when
+				// that bit is set. Without bit 0x01 the strict ODA-based reader falls
+				// back to the TableStyle default and per-cell alignments leak away.
+				const int baseCellFlag = 262192;
+				bool hasAlignmentOverride = cell.StyleOverride != null
+					&& cell.StyleOverride.HasData
+					&& cell.StyleOverride.CellAlignment != default(ACadSharp.Objects.TableStyle.CellAlignmentType);
+				int cellFlag = baseCellFlag;
+				if (hasAlignmentOverride)
+				{
+					cellFlag |= 0x01;
+				}
+				this._writer.Write(91, cellFlag);
+				this._writer.Write(178, (short)cell.VirtualEdgeFlag);
+
+				this._writer.Write(145, cell.Rotation);
+
+				if (hasAlignmentOverride)
+				{
+					this._writer.Write(170, (short)cell.StyleOverride.CellAlignment);
+				}
+
+				ACadSharp.Tables.TextStyle textStyle = cell.StyleOverride?.TextStyle
+					?? (cell.Contents.Count > 0 ? cell.Contents[0].Format?.TextStyle : null);
+				if (textStyle != null)
+				{
+					this._writer.Write(7, textStyle.Name);
+				}
+
+				double textHeight = 0.0;
+				if (cell.StyleOverride != null && cell.StyleOverride.TextHeight > 0)
+				{
+					textHeight = cell.StyleOverride.TextHeight;
+				}
+				else if (cell.Contents.Count > 0 && cell.Contents[0].Format != null && cell.Contents[0].Format.TextHeight > 0)
+				{
+					textHeight = cell.Contents[0].Format.TextHeight;
+				}
+				if (textHeight > 0)
+				{
+					this._writer.Write(140, textHeight);
+				}
+
+				// Cell value state flag. AutoCAD-produced files always emit this before the
+				// CELL_VALUE block; omitting it causes the strict ODA-based reader to bail
+				// with "Invalid index".
+				this._writer.Write(92, 0);
+
+				// Cell text content wrapped in the CELL_VALUE block. The reader keys on
+				// code 301 to enter readCadValue and exits at 304.
+				string textValue = null;
+				if (cell.Content != null && cell.Content.CadValue.Value is string s)
+				{
+					textValue = s;
+				}
+				else if (cell.Contents.Count > 0 && cell.Contents[0].CadValue.Value is string s2)
+				{
+					textValue = s2;
+				}
+
+				if (!string.IsNullOrEmpty(textValue))
+				{
+					this._writer.Write(301, "CELL_VALUE");
+					this._writer.Write(93, 6);
+					this._writer.Write(90, (int)ACadSharp.CadValueType.String);
+					this._writer.Write(1, textValue);
+					this._writer.Write(94, 0);
+					this._writer.Write(300, string.Empty);
+					this._writer.Write(302, textValue);
+					this._writer.Write(304, "ACVALUE_END");
+				}
+			}
+		}
 	}
 
 	private void writeInsert(Insert insert)

--- a/src/ACadSharp/IO/Templates/CadTableEntityTemplate.CadTableCellTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadTableEntityTemplate.CadTableCellTemplate.cs
@@ -42,6 +42,28 @@ internal partial class CadTableEntityTemplate
 			{
 				contentTemplate.Build(builder);
 			}
+
+			// Apply the cell-level text height read from group code 140 (or 144) so
+			// consumers can reach it through the regular cell content/format API
+			// rather than poking at the template. Without this the value parsed by
+			// readTableEntity is silently dropped.
+			if (this.FormatTextHeight.HasValue && this.FormatTextHeight.Value > 0)
+			{
+				double height = this.FormatTextHeight.Value;
+				if (this.Cell.StyleOverride != null && this.Cell.StyleOverride.TextHeight <= 0)
+				{
+					this.Cell.StyleOverride.TextHeight = height;
+					this.Cell.StyleOverride.HasData = true;
+				}
+				foreach (var content in this.Cell.Contents)
+				{
+					if (content.Format != null && content.Format.TextHeight <= 0)
+					{
+						content.Format.TextHeight = height;
+						content.Format.HasData = true;
+					}
+				}
+			}
 		}
 	}
 }

--- a/src/ACadSharp/IO/Templates/CadTableEntityTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadTableEntityTemplate.cs
@@ -75,6 +75,54 @@ internal partial class CadTableEntityTemplate : CadInsertTemplate
 			cellTemplate.Build(builder);
 		}
 
+		// DXF stores merged cells per-cell (anchor carries the span via BorderWidth /
+		// BorderHeight, the rest carry MergedValue=1) but never emits the
+		// table-level MergedCellRanges collection that callers actually consume. Walk
+		// the grid here and rebuild that collection so readers see the same shape
+		// regardless of whether the table arrived through DXF or DWG.
+		int rowCount = this.TableEntity.Rows.Count;
+		int colCount = this.TableEntity.Columns.Count;
+		for (int i = 0; i < rowCount; i++)
+		{
+			var row = this.TableEntity.Rows[i];
+			int cellLimit = System.Math.Min(colCount, row.Cells.Count);
+			for (int j = 0; j < cellLimit; j++)
+			{
+				var cell = row.Cells[j];
+				int colSpan = cell.BorderWidth > 1 ? cell.BorderWidth : 1;
+				int rowSpan = cell.BorderHeight > 1 ? cell.BorderHeight : 1;
+				if (colSpan == 1 && rowSpan == 1)
+				{
+					continue;
+				}
+
+				int bottomRow = System.Math.Min(rowCount - 1, i + rowSpan - 1);
+				int rightCol = System.Math.Min(colCount - 1, j + colSpan - 1);
+
+				bool exists = false;
+				foreach (var range in this.TableEntity.MergedCellRanges)
+				{
+					if (range.TopRowIndex == i && range.LeftColumnIndex == j)
+					{
+						exists = true;
+						break;
+					}
+				}
+				if (exists)
+				{
+					continue;
+				}
+
+				this.TableEntity.MergedCellRanges.Add(new TableEntity.CellRange
+				{
+					TopRowIndex = i,
+					LeftColumnIndex = j,
+					BottomRowIndex = bottomRow,
+					RightColumnIndex = rightCol,
+				});
+			}
+		}
+
 		foreach (var component in this.CadTableComponentTemplates)
 		{
 			component.Build(builder, this.TableEntity.Style);


### PR DESCRIPTION
Until now the DXF writer only emitted the block reference for a TableEntity. This change writes the AcDbTable subclass too, with rows, columns, per-cell data, margins, flow direction, alignment (group 170 plus the matching cell flag at group 91), and merge ranges (per-cell via BorderWidth/BorderHeight and MergedValue).

On the reader side, per-cell alignment is now captured and the table-level MergedCellRanges is rebuilt by scanning the grid, so a DXF table comes back with the same merge layout as one read from DWG.

Known limitation: with no proxy graphic preview attached, AutoCAD and DWG TrueView draw the table twice (once from the anonymous block, once from the cell stream). Readers that consume the cell stream directly show a single, correct table.

Closes #995