### PR TITLE
Updated check on default layouts removing

### DIFF
--- a/src/ACadSharp/Objects/Collections/LayoutCollection.cs
+++ b/src/ACadSharp/Objects/Collections/LayoutCollection.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 namespace ACadSharp.Objects.Collections;
 
@@ -18,13 +19,17 @@ public class LayoutCollection : ObjectDictionaryCollection<Layout>
 		this._dictionary = dictionary;
 	}
 
-	/// <inheritdoc/>
 	public override bool Remove(string name, out Layout entry)
 	{
-		if (name.Equals(Layout.ModelLayoutName, StringComparison.InvariantCultureIgnoreCase)
-			|| name.Equals(Layout.PaperLayoutName, StringComparison.InvariantCultureIgnoreCase))
+		if (name.Equals(Layout.ModelLayoutName, StringComparison.InvariantCultureIgnoreCase))
 		{
 			throw new ArgumentException($"The Layout {name} cannot be removed.");
+		}
+
+		if (this.ContainsKey(name) && this.Count() <= 2)
+		{
+			throw new ArgumentException(
+				$"The Layout {name} cannot be removed: a DWG/DXF document must contain at least one paper layout.");
 		}
 
 		return base.Remove(name, out entry);


### PR DESCRIPTION
# Description

`LayoutCollection.Remove` blocked "Layout1" by name, but the name has no structural meaning in DWG/DXF. Only the count of paper layouts matters. Replaced the name check with a count check.

An alternative would be to remove the layout and recreate a default 'Layout1' if it is the last one. Let me know If you prefer this solution.