### PR TITLE
Fix DXF color writing for dimension overrides and layer true color

### DIFF
--- a/src/ACadSharp/DxfPropertyBase.cs
+++ b/src/ACadSharp/DxfPropertyBase.cs
@@ -444,6 +444,9 @@ namespace ACadSharp
 				{
 					case 62:
 					case 70:
+					case 176:
+					case 177:
+					case 178:
 						return color.Index;
 					case 420:
 						// true color

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfTablesSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfTablesSectionWriter.cs
@@ -229,7 +229,7 @@ namespace ACadSharp.IO.DXF
 
 			if (layer.Color.IsTrueColor)
 			{
-				this._writer.Write(420, (uint)layer.Color.TrueColor, map);
+				this._writer.WriteTrueColor(420, layer.Color, map);
 			}
 
 			this._writer.Write(6, layer.LineType.Name, map);


### PR DESCRIPTION
# Description
1) Added cases `176`, `177`, `178` returning `color.Index`
2) Replaced the call with the existing `WriteTrueColor(420, layer.Color, map)` helper, which rebuilds the int from clean `B|G|R|00` bytes

# Tasks done in this PR
* [ ] Something awesome.
* [ ] An evil bug have been defeated.
* [x] Code cleanup and maintenance has been done.

# Related Issues / Pull Requests
- Add the links of issues or PR related to this one.
# Notes for reviewer
 - Things to consider during the review of this PR.