### PR TITLE
Refactor DwgLZ77AC21Decompressor to instance-based

### DIFF
--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>3.6.17</Version>
+		<Version>3.6.18</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>../ACadSharp.snk</AssemblyOriginatorKeyFile>

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgLZ77AC21Decompressor.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgLZ77AC21Decompressor.cs
@@ -1,193 +1,22 @@
-﻿namespace ACadSharp.IO.DWG
+﻿namespace ACadSharp.IO.DWG;
+
+internal class DwgLZ77AC21Decompressor
 {
-	internal static class DwgLZ77AC21Decompressor
-	{
-		private delegate void copyDelegate(byte[] src, uint srcIndex, byte[] dst, uint dstIndex);
+	private delegate void copyDelegate(byte[] src, uint srcIndex, byte[] dst, uint dstIndex);
 
-		private static uint m_sourceOffset = 0;
-		private static uint m_length = 0;
-		private static uint m_sourceIndex;
-		private static uint m_opCode = 0;
-
-		/// <summary>
-		/// Decompress a compressed source buffer.
-		/// </summary>
-		/// <param name="source"></param>
-		/// <param name="initialOffset"></param>
-		/// <param name="length"></param>
-		/// <param name="buffer"></param>
-		public static void Decompress(byte[] source, uint initialOffset, uint length, byte[] buffer)
-		{
-			m_sourceOffset = 0;
-			m_length = 0;
-			m_sourceIndex = initialOffset;
-			m_opCode = source[m_sourceIndex];
-
-			uint destIndex = 0;
-			uint endIndex = m_sourceIndex + length;
-
-			++m_sourceIndex;
-
-			if (m_sourceIndex >= endIndex)
-				return;
-
-			if (((int)m_opCode & 240) == 32)
-			{
-				m_sourceIndex += 3U;
-				m_length = source[m_sourceIndex - 1];
-				m_length &= 7U;
-			}
-
-			while (m_sourceIndex < endIndex)
-			{
-				nextIndex(source, buffer, ref destIndex);
-
-				if (m_sourceIndex >= endIndex)
-					break;
-
-				destIndex = copyDecompressedChunks(source, endIndex, buffer, destIndex);
-			}
-		}
-		private static void nextIndex(byte[] source, byte[] dest, ref uint index)
-		{
-			if (m_length == 0U)
-				readLiteralLength(source);
-
-			copy(source, m_sourceIndex, dest, index, m_length);
-
-			m_sourceIndex += m_length;
-
-			index += m_length;
-		}
-		private static uint copyDecompressedChunks(byte[] src, uint endIndex, byte[] dst, uint destIndex)
-		{
-			m_length = 0U;
-			m_opCode = src[m_sourceIndex];
-			++m_sourceIndex;
-
-			readInstructions(src);
-
-			while (true)
-			{
-				copyBytes(dst, destIndex, m_length, m_sourceOffset);
-
-				destIndex += m_length;
-
-				m_length = m_opCode & 0x07;
-
-				if (m_length != 0U || m_sourceIndex >= endIndex)
-					break;
-
-				m_opCode = src[m_sourceIndex];
-				++m_sourceIndex;
-
-				if (m_opCode >> 4 == 0)
-					break;
-
-				if (m_opCode >> 4 == 15)
-					m_opCode &= 15;
-
-				readInstructions(src);
-			}
-			return destIndex;
-		}
-		private static void readInstructions(byte[] buffer)
-		{
-			switch (m_opCode >> 4)
-			{
-				case 0:
-					m_length = (m_opCode & 0xF) + 0x13;
-					m_sourceOffset = buffer[m_sourceIndex];
-					++m_sourceIndex;
-					m_opCode = buffer[m_sourceIndex];
-					++m_sourceIndex;
-					m_length = (m_opCode >> 3 & 0x10) + m_length;
-					m_sourceOffset = ((m_opCode & 0x78) << 5) + 1 + m_sourceOffset;
-					break;
-				case 1:
-					m_length = (m_opCode & 0xF) + 3;
-					m_sourceOffset = buffer[m_sourceIndex];
-					++m_sourceIndex;
-					m_opCode = buffer[m_sourceIndex];
-					++m_sourceIndex;
-					m_sourceOffset = ((m_opCode & 248) << 5) + 1 + m_sourceOffset;
-					break;
-				case 2:
-					m_sourceOffset = buffer[m_sourceIndex];
-					++m_sourceIndex;
-					m_sourceOffset = (uint)(buffer[m_sourceIndex] << 8 & 0xFF00) | m_sourceOffset;
-					++m_sourceIndex;
-					m_length = m_opCode & 7U;
-					if ((m_opCode & 8) == 0)
-					{
-						m_opCode = buffer[m_sourceIndex];
-						++m_sourceIndex;
-						m_length = (m_opCode & 0xF8) + m_length;
-
-					}
-					else
-					{
-						++m_sourceOffset;
-						m_length = (uint)((buffer[m_sourceIndex] << 3) + m_length);
-						++m_sourceIndex;
-						m_opCode = buffer[m_sourceIndex];
-						++m_sourceIndex;
-						m_length = ((m_opCode & 0xF8) << 8) + m_length + 0x100;
-					}
-					break;
-				default:
-					m_length = m_opCode >> 4;
-					m_sourceOffset = m_opCode & 15U;
-					m_opCode = buffer[m_sourceIndex];
-					++m_sourceIndex;
-					m_sourceOffset = ((m_opCode & 0xF8) << 1) + m_sourceOffset + 1;
-					break;
-			}
-		}
-		private static void readLiteralLength(byte[] buffer)
-		{
-			m_length = m_opCode + 8;
-			if (m_length == 0x17)
-			{
-				uint n = buffer[m_sourceIndex];
-				++m_sourceIndex;
-				m_length += n;
-
-				if (n == 0xFF)
-				{
-					do
-					{
-						n = buffer[m_sourceIndex];
-						++m_sourceIndex;
-						n |= (uint)buffer[m_sourceIndex] << 8;
-						++m_sourceIndex;
-						m_length += n;
-
-					} while (n == 0xFFFF);
-				}
-			}
-		}
-		private static void copyBytes(byte[] dst, uint dstIndex, uint length, uint srcOffset)
-		{
-			uint initialIndex = dstIndex - srcOffset;
-			uint maxIndex = initialIndex + length;
-
-			while (initialIndex < maxIndex)
-				dst[(int)dstIndex++] = dst[(int)initialIndex++];
-		}
-		/*
-				 * The copying happens in chunks of 32 bytes, 
-				 * and the remainder is copied using a specific copy function for each number of bytes 
-				 * (so 31 separate copy functions). For copying 1-32 bytes, a combination of sub byte blocks is made:
-				 */
-		private static readonly copyDelegate[] m_copyMethods = new copyDelegate[32]
+	/// <summary>
+	/// The copying happens in chunks of 32 bytes,
+	/// and the remainder is copied using a specific copy function for each number of bytes
+	/// (so 31 separate copy functions). For copying 1-32 bytes, a combination of sub byte blocks is made:
+	/// </summary>
+	private readonly copyDelegate[] _copyMethods = new copyDelegate[32]
 {
-		null,
-		(src, srcIndex, dst, dstIndex) =>{copy1b(src, srcIndex, dst, dstIndex); },
-		(src, srcIndex, dst, dstIndex) =>{copy2b(src, srcIndex, dst, dstIndex); },
-		(src, srcIndex, dst, dstIndex) =>{copy3b(src, srcIndex, dst, dstIndex); },
-		(src, srcIndex, dst, dstIndex) =>{copy4b(src, srcIndex, dst, dstIndex); },
-	 (src, srcIndex, dst, dstIndex) =>
+	null,
+	(src, srcIndex, dst, dstIndex) =>{copy1b(src, srcIndex, dst, dstIndex); },
+	(src, srcIndex, dst, dstIndex) =>{copy2b(src, srcIndex, dst, dstIndex); },
+	(src, srcIndex, dst, dstIndex) =>{copy3b(src, srcIndex, dst, dstIndex); },
+	(src, srcIndex, dst, dstIndex) =>{copy4b(src, srcIndex, dst, dstIndex); },
+	(src, srcIndex, dst, dstIndex) =>
 	{
 	  copy1b(src, srcIndex + 4U, dst, dstIndex);
 	  copy4b(src, srcIndex, dst, dstIndex + 1U);
@@ -349,59 +178,243 @@
 	  copy8b(src, srcIndex + 2U, dst, dstIndex + 21U);
 	  copy2b(src, srcIndex, dst, dstIndex + 29U);
 	}
-};
-		private static void copy(byte[] src, uint srcIndex, byte[] dst, uint dstIndex, uint length)
+	};
+
+	private uint _length = 0;
+
+	private uint _opCode = 0;
+
+	private uint _sourceIndex;
+
+	private uint _sourceOffset = 0;
+
+	/// <summary>
+	/// Decompress a compressed source buffer.
+	/// </summary>
+	/// <param name="source"></param>
+	/// <param name="initialOffset"></param>
+	/// <param name="length"></param>
+	/// <param name="buffer"></param>
+	public void Decompress(byte[] source, uint initialOffset, uint length, byte[] buffer)
+	{
+		_sourceOffset = 0;
+		_length = 0;
+		_sourceIndex = initialOffset;
+		_opCode = source[_sourceIndex];
+
+		uint destIndex = 0;
+		uint endIndex = _sourceIndex + length;
+
+		++_sourceIndex;
+
+		if (_sourceIndex >= endIndex)
+			return;
+
+		if (((int)_opCode & 240) == 32)
 		{
-			for (; length >= 32U; length -= 32U)
+			_sourceIndex += 3U;
+			_length = source[_sourceIndex - 1];
+			_length &= 7U;
+		}
+
+		while (_sourceIndex < endIndex)
+		{
+			nextIndex(source, buffer, ref destIndex);
+
+			if (_sourceIndex >= endIndex)
+				break;
+
+			destIndex = copyDecompressedChunks(source, endIndex, buffer, destIndex);
+		}
+	}
+
+	private static void copy16b(byte[] src, uint srcIndex, byte[] dst, uint dstIndex)
+	{
+		copy8b(src, srcIndex + 8U, dst, dstIndex);
+		copy8b(src, srcIndex, dst, dstIndex + 8U);
+	}
+
+	private static void copy1b(byte[] src, uint srcIndex, byte[] dst, uint dstIndex)
+	{
+		dst[(int)dstIndex] = src[(int)srcIndex];
+	}
+
+	private static void copy2b(byte[] src, uint srcIndex, byte[] dst, uint dstIndex)
+	{
+		dst[(int)dstIndex] = src[(int)srcIndex + 1];
+		dst[(int)dstIndex + 1] = src[(int)srcIndex];
+	}
+
+	private static void copy3b(byte[] src, uint srcIndex, byte[] dst, uint dstIndex)
+	{
+		dst[(int)dstIndex] = src[(int)srcIndex + 2];
+		dst[(int)dstIndex + 1] = src[(int)srcIndex + 1];
+		dst[(int)dstIndex + 2] = src[(int)srcIndex];
+	}
+
+	private static void copy4b(byte[] src, uint srcIndex, byte[] dst, uint dstIndex)
+	{
+		dst[(int)dstIndex] = src[(int)srcIndex];
+		dst[(int)dstIndex + 1] = src[(int)srcIndex + 1];
+		dst[(int)dstIndex + 2] = src[(int)srcIndex + 2];
+		dst[(int)dstIndex + 3] = src[(int)srcIndex + 3];
+	}
+
+	private static void copy8b(byte[] src, uint srcIndex, byte[] dst, uint dstIndex)
+	{
+		copy4b(src, srcIndex, dst, dstIndex);
+		copy4b(src, srcIndex + 4U, dst, dstIndex + 4U);
+	}
+
+	private void copy(byte[] src, uint srcIndex, byte[] dst, uint dstIndex, uint length)
+	{
+		for (; length >= 32U; length -= 32U)
+		{
+			copy4b(src, srcIndex + 24U, dst, dstIndex);
+			copy4b(src, srcIndex + 28U, dst, dstIndex + 4U);
+			copy4b(src, srcIndex + 16U, dst, dstIndex + 8U);
+			copy4b(src, srcIndex + 20U, dst, dstIndex + 12U);
+			copy4b(src, srcIndex + 8U, dst, dstIndex + 16U);
+			copy4b(src, srcIndex + 12U, dst, dstIndex + 20U);
+			copy4b(src, srcIndex, dst, dstIndex + 24U);
+			copy4b(src, srcIndex + 4U, dst, dstIndex + 28U);
+
+			srcIndex += 32U;
+			dstIndex += 32U;
+		}
+		if (length <= 0U)
+			return;
+
+		_copyMethods[(int)length](src, srcIndex, dst, dstIndex);
+	}
+
+	private void copyBytes(byte[] dst, uint dstIndex, uint length, uint srcOffset)
+	{
+		uint initialIndex = dstIndex - srcOffset;
+		uint maxIndex = initialIndex + length;
+
+		while (initialIndex < maxIndex)
+			dst[(int)dstIndex++] = dst[(int)initialIndex++];
+	}
+
+	private uint copyDecompressedChunks(byte[] src, uint endIndex, byte[] dst, uint destIndex)
+	{
+		_length = 0U;
+		_opCode = src[_sourceIndex];
+		++_sourceIndex;
+
+		readInstructions(src);
+
+		while (true)
+		{
+			copyBytes(dst, destIndex, _length, _sourceOffset);
+
+			destIndex += _length;
+
+			_length = _opCode & 0x07;
+
+			if (_length != 0U || _sourceIndex >= endIndex)
+				break;
+
+			_opCode = src[_sourceIndex];
+			++_sourceIndex;
+
+			if (_opCode >> 4 == 0)
+				break;
+
+			if (_opCode >> 4 == 15)
+				_opCode &= 15;
+
+			readInstructions(src);
+		}
+		return destIndex;
+	}
+
+	private void nextIndex(byte[] source, byte[] dest, ref uint index)
+	{
+		if (_length == 0U)
+			readLiteralLength(source);
+
+		copy(source, _sourceIndex, dest, index, _length);
+
+		_sourceIndex += _length;
+
+		index += _length;
+	}
+
+	private void readInstructions(byte[] buffer)
+	{
+		switch (_opCode >> 4)
+		{
+			case 0:
+				_length = (_opCode & 0xF) + 0x13;
+				_sourceOffset = buffer[_sourceIndex];
+				++_sourceIndex;
+				_opCode = buffer[_sourceIndex];
+				++_sourceIndex;
+				_length = (_opCode >> 3 & 0x10) + _length;
+				_sourceOffset = ((_opCode & 0x78) << 5) + 1 + _sourceOffset;
+				break;
+			case 1:
+				_length = (_opCode & 0xF) + 3;
+				_sourceOffset = buffer[_sourceIndex];
+				++_sourceIndex;
+				_opCode = buffer[_sourceIndex];
+				++_sourceIndex;
+				_sourceOffset = ((_opCode & 248) << 5) + 1 + _sourceOffset;
+				break;
+			case 2:
+				_sourceOffset = buffer[_sourceIndex];
+				++_sourceIndex;
+				_sourceOffset = (uint)(buffer[_sourceIndex] << 8 & 0xFF00) | _sourceOffset;
+				++_sourceIndex;
+				_length = _opCode & 7U;
+				if ((_opCode & 8) == 0)
+				{
+					_opCode = buffer[_sourceIndex];
+					++_sourceIndex;
+					_length = (_opCode & 0xF8) + _length;
+				}
+				else
+				{
+					++_sourceOffset;
+					_length = (uint)((buffer[_sourceIndex] << 3) + _length);
+					++_sourceIndex;
+					_opCode = buffer[_sourceIndex];
+					++_sourceIndex;
+					_length = ((_opCode & 0xF8) << 8) + _length + 0x100;
+				}
+				break;
+			default:
+				_length = _opCode >> 4;
+				_sourceOffset = _opCode & 15U;
+				_opCode = buffer[_sourceIndex];
+				++_sourceIndex;
+				_sourceOffset = ((_opCode & 0xF8) << 1) + _sourceOffset + 1;
+				break;
+		}
+	}
+
+	private void readLiteralLength(byte[] buffer)
+	{
+		_length = _opCode + 8;
+		if (_length == 0x17)
+		{
+			uint n = buffer[_sourceIndex];
+			++_sourceIndex;
+			_length += n;
+
+			if (n == 0xFF)
 			{
-				copy4b(src, srcIndex + 24U, dst, dstIndex);
-				copy4b(src, srcIndex + 28U, dst, dstIndex + 4U);
-				copy4b(src, srcIndex + 16U, dst, dstIndex + 8U);
-				copy4b(src, srcIndex + 20U, dst, dstIndex + 12U);
-				copy4b(src, srcIndex + 8U, dst, dstIndex + 16U);
-				copy4b(src, srcIndex + 12U, dst, dstIndex + 20U);
-				copy4b(src, srcIndex, dst, dstIndex + 24U);
-				copy4b(src, srcIndex + 4U, dst, dstIndex + 28U);
-
-				srcIndex += 32U;
-				dstIndex += 32U;
+				do
+				{
+					n = buffer[_sourceIndex];
+					++_sourceIndex;
+					n |= (uint)buffer[_sourceIndex] << 8;
+					++_sourceIndex;
+					_length += n;
+				} while (n == 0xFFFF);
 			}
-			if (length <= 0U)
-				return;
-
-			m_copyMethods[(int)length](src, srcIndex, dst, dstIndex);
-		}
-		private static void copy1b(byte[] src, uint srcIndex, byte[] dst, uint dstIndex)
-		{
-			dst[(int)dstIndex] = src[(int)srcIndex];
-		}
-		private static void copy2b(byte[] src, uint srcIndex, byte[] dst, uint dstIndex)
-		{
-			dst[(int)dstIndex] = src[(int)srcIndex + 1];
-			dst[(int)dstIndex + 1] = src[(int)srcIndex];
-		}
-		private static void copy3b(byte[] src, uint srcIndex, byte[] dst, uint dstIndex)
-		{
-			dst[(int)dstIndex] = src[(int)srcIndex + 2];
-			dst[(int)dstIndex + 1] = src[(int)srcIndex + 1];
-			dst[(int)dstIndex + 2] = src[(int)srcIndex];
-		}
-		private static void copy4b(byte[] src, uint srcIndex, byte[] dst, uint dstIndex)
-		{
-			dst[(int)dstIndex] = src[(int)srcIndex];
-			dst[(int)dstIndex + 1] = src[(int)srcIndex + 1];
-			dst[(int)dstIndex + 2] = src[(int)srcIndex + 2];
-			dst[(int)dstIndex + 3] = src[(int)srcIndex + 3];
-		}
-		private static void copy8b(byte[] src, uint srcIndex, byte[] dst, uint dstIndex)
-		{
-			copy4b(src, srcIndex, dst, dstIndex);
-			copy4b(src, srcIndex + 4U, dst, dstIndex + 4U);
-		}
-		private static void copy16b(byte[] src, uint srcIndex, byte[] dst, uint dstIndex)
-		{
-			copy8b(src, srcIndex + 8U, dst, dstIndex);
-			copy8b(src, srcIndex, dst, dstIndex + 8U);
 		}
 	}
 }

--- a/src/ACadSharp/IO/DwgReader.cs
+++ b/src/ACadSharp/IO/DwgReader.cs
@@ -318,7 +318,7 @@ public class DwgReader : CadReaderBase<DwgReaderConfiguration>
 
 		byte[] decompressedData = new byte[uncompressedSize];
 
-		DwgLZ77AC21Decompressor.Decompress(compressedData, 0U, (uint)compressedSize, decompressedData);
+		new DwgLZ77AC21Decompressor().Decompress(compressedData, 0U, (uint)compressedSize, decompressedData);
 
 		return decompressedData;
 	}
@@ -443,7 +443,7 @@ public class DwgReader : CadReaderBase<DwgReaderConfiguration>
 				{
 					//Page is compressed
 					byte[] arr = new byte[page.DecompressedSize];
-					DwgLZ77AC21Decompressor.Decompress(pageBytes, 0U, (uint)page.CompressedSize, arr);
+					new DwgLZ77AC21Decompressor().Decompress(pageBytes, 0U, (uint)page.CompressedSize, arr);
 					pageBytes = arr;
 				}
 
@@ -982,7 +982,7 @@ public class DwgReader : CadReaderBase<DwgReaderConfiguration>
 		//If ComprLen is positive, the ComprLen bytes of data are compressed
 		else
 		{
-			DwgLZ77AC21Decompressor.Decompress(decodedData, 32U, (uint)comprLen, buffer);
+			new DwgLZ77AC21Decompressor().Decompress(decodedData, 32U, (uint)comprLen, buffer);
 		}
 
 		//Get the descompressed stream to read the records


### PR DESCRIPTION
# Description

Refactored `DwgLZ77AC21Decompressor` from a static class to an instance-based class to improve encapsulation, testability, and thread safety. Updated all static fields and methods to instance fields and methods. Corrected namespace declaration syntax.

Updated `DwgReader` to use the new instance-based
`DwgLZ77AC21Decompressor` by creating instances for decompression operations. Improved maintainability and reduced shared state across threads.