### PR TITLE
Improved Paper Space Layout management

### DIFF
--- a/src/ACadSharp.Tests/Objects/LayoutTests.cs
+++ b/src/ACadSharp.Tests/Objects/LayoutTests.cs
@@ -1,4 +1,5 @@
 ﻿using ACadSharp.Objects;
+using ACadSharp.Tables;
 using System;
 using System.Linq;
 using Xunit;
@@ -15,12 +16,12 @@ public class LayoutTests : NonGraphicalObjectTests<Layout>
 		CadDocument document = new CadDocument();
 
 		Layout layout = new Layout(_layoutName);
-
 		document.Layouts.Add(layout);
 
-		Assert.Equal(_layoutName, layout.AssociatedBlock.Name);
+		Assert.Equal($"{BlockRecord.PaperSpaceName}0", layout.AssociatedBlock.Name);
 		Assert.Equal(3, document.Layouts.Count());
-		Assert.True(document.BlockRecords.Contains(_layoutName));
+		Assert.True(document.BlockRecords.Contains($"{BlockRecord.PaperSpaceName}0"));
+		Assert.True(document.BlockRecords.Contains(BlockRecord.PaperSpaceName));
 	}
 
 	[Fact]
@@ -30,6 +31,24 @@ public class LayoutTests : NonGraphicalObjectTests<Layout>
 
 		Assert.Throws<ArgumentException>(() => document.Layouts.Remove(Layout.ModelLayoutName));
 		Assert.Throws<ArgumentException>(() => document.Layouts.Remove(Layout.PaperLayoutName));
+	}
+
+	[Fact]
+	public void AddMultipleLayoutsAssignsConsecutivePaperSpaceNames()
+	{
+		CadDocument document = new CadDocument();
+
+		Layout first = new Layout("first");
+		Layout second = new Layout("second");
+		Layout third = new Layout("third");
+
+		document.Layouts.Add(first);
+		document.Layouts.Add(second);
+		document.Layouts.Add(third);
+
+		Assert.Equal($"{BlockRecord.PaperSpaceName}0", first.AssociatedBlock.Name);
+		Assert.Equal($"{BlockRecord.PaperSpaceName}1", second.AssociatedBlock.Name);
+		Assert.Equal($"{BlockRecord.PaperSpaceName}2", third.AssociatedBlock.Name);
 	}
 
 	[Fact]
@@ -52,7 +71,7 @@ public class LayoutTests : NonGraphicalObjectTests<Layout>
 
 		document.Layouts.Add(layout);
 
-		document.BlockRecords.Remove(_layoutName);
+		document.BlockRecords.Remove(layout.AssociatedBlock.Name);
 
 		Assert.Equal(2, document.Layouts.Count());
 		Assert.False(document.Layouts.ContainsKey(_layoutName));
@@ -67,10 +86,10 @@ public class LayoutTests : NonGraphicalObjectTests<Layout>
 
 		document.Layouts.Add(layout);
 
+		string associatedBlockName = layout.AssociatedBlock.Name;
 		Assert.True(document.Layouts.Remove(_layoutName));
 		Assert.Equal(2, document.Layouts.Count());
-		Assert.True(document.BlockRecords.Contains(_layoutName));
-		Assert.NotEqual(document.BlockRecords[_layoutName], layout.AssociatedBlock);
+		Assert.False(document.BlockRecords.Contains(associatedBlockName));
 	}
 
 	[Fact]

--- a/src/ACadSharp/Objects/Collections/LayoutCollection.cs
+++ b/src/ACadSharp/Objects/Collections/LayoutCollection.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using ACadSharp.Tables;
 
 namespace ACadSharp.Objects.Collections;
 
@@ -19,19 +20,44 @@ public class LayoutCollection : ObjectDictionaryCollection<Layout>
 		this._dictionary = dictionary;
 	}
 
+	public override void Add(Layout entry)
+	{
+		if (!isDefaultLayout(entry))
+			entry.AssociatedBlock.Name = findSmallestFreePaperSpaceName(this._dictionary.Document);
+
+		base.Add(entry);
+	}
+
 	public override bool Remove(string name, out Layout entry)
 	{
-		if (name.Equals(Layout.ModelLayoutName, StringComparison.InvariantCultureIgnoreCase))
+		if (!this.TryGet(name, out entry))
+			return false;
+
+		if (isDefaultLayout(entry))
 		{
 			throw new ArgumentException($"The Layout {name} cannot be removed.");
 		}
 
-		if (this.ContainsKey(name) && this.Count() <= 2)
-		{
-			throw new ArgumentException(
-				$"The Layout {name} cannot be removed: a DWG/DXF document must contain at least one paper layout.");
-		}
-
 		return base.Remove(name, out entry);
+	}
+
+	private static bool isDefaultLayout(Layout layout)
+	{
+		return layout.AssociatedBlock.Name.Equals(BlockRecord.PaperSpaceName, StringComparison.InvariantCultureIgnoreCase) ||
+		       layout.AssociatedBlock.Name.Equals(BlockRecord.ModelSpaceName, StringComparison.InvariantCultureIgnoreCase);
+	}
+
+	private static string findSmallestFreePaperSpaceName(CadDocument doc)
+	{
+		int n = 0;
+		while (true)
+		{
+			string candidate = Tables.BlockRecord.PaperSpaceName + n.ToString(System.Globalization.CultureInfo.InvariantCulture);
+			if (!doc.BlockRecords.Contains(candidate))
+			{
+				return candidate;
+			}
+			n++;
+		}
 	}
 }

--- a/src/ACadSharp/Objects/Collections/LayoutCollection.cs
+++ b/src/ACadSharp/Objects/Collections/LayoutCollection.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 namespace ACadSharp.Objects.Collections;
 
@@ -18,13 +19,17 @@ public class LayoutCollection : ObjectDictionaryCollection<Layout>
 		this._dictionary = dictionary;
 	}
 
-	/// <inheritdoc/>
 	public override bool Remove(string name, out Layout entry)
 	{
-		if (name.Equals(Layout.ModelLayoutName, StringComparison.InvariantCultureIgnoreCase)
-			|| name.Equals(Layout.PaperLayoutName, StringComparison.InvariantCultureIgnoreCase))
+		if (name.Equals(Layout.ModelLayoutName, StringComparison.InvariantCultureIgnoreCase))
 		{
 			throw new ArgumentException($"The Layout {name} cannot be removed.");
+		}
+
+		if (this.ContainsKey(name) && this.Count() <= 2)
+		{
+			throw new ArgumentException(
+				$"The Layout {name} cannot be removed: a DWG/DXF document must contain at least one paper layout.");
 		}
 
 		return base.Remove(name, out entry);

--- a/src/ACadSharp/Objects/Layout.cs
+++ b/src/ACadSharp/Objects/Layout.cs
@@ -311,9 +311,8 @@ public class Layout : PlotSettings
 
 		if (this.AssociatedBlock != null)
 		{
+			this.Document.BlockRecords.Remove(this.AssociatedBlock.Name);
 			this.AssociatedBlock.Layout = null;
-			this.Document.BlockRecords.OnRemove -= this.onRemoveBlockRecord;
-			this._blockRecord = (BlockRecord)this._blockRecord?.Clone();
 		}
 
 		base.UnassignDocument();


### PR DESCRIPTION
# Description

Follow-up of PR #1086

- When removing a layout, the check on default layout is based on the BlockRecord name and the AssociatedBlock is removed from the Document.BlockRecords collection.
- When adding a layout, the default _*Paper_SpaceN_ block name is assigned to the AssociatedBlock.