### PR TITLE
Improve DXF encoding handling for compatibility

### DIFF
--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>3.6.19</Version>
+		<Version>3.6.20</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>../ACadSharp.snk</AssemblyOriginatorKeyFile>

--- a/src/ACadSharp/IO/DxfWriter.cs
+++ b/src/ACadSharp/IO/DxfWriter.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.IO.DXF;
 using System.IO;
+using System.Text;
 
 namespace ACadSharp.IO;
 
@@ -115,15 +116,16 @@ public class DxfWriter : CadWriterBase<DxfWriterConfiguration>
 
 	private void createStreamWriter()
 	{
-		this._encoding ??= this.getListedEncoding(this._document.Header.CodePage);
+		var encoding = this._document.Header.Version < ACadVersion.AC1021 ?
+			this.getListedEncoding(this._document.Header.CodePage) : new UTF8Encoding(false);
 
 		if (this.IsBinary)
 		{
-			this._writer = new DxfBinaryWriter(new BinaryWriter(this._stream, this._encoding));
+			this._writer = new DxfBinaryWriter(new BinaryWriter(this._stream, encoding));
 		}
 		else
 		{
-			this._writer = new DxfAsciiWriter(new StreamWriter(this._stream, this._encoding));
+			this._writer = new DxfAsciiWriter(new StreamWriter(this._stream, encoding));
 		}
 
 		this._writer.WriteOptional = this.Configuration.WriteOptionalValues;


### PR DESCRIPTION
# Description

Refactored `createStreamWriter` to conditionally select encoding based on the document's header version. Added `UTF8Encoding(false)` for newer DXF versions to avoid issues.
Replaced `_encoding` with a local `encoding` variable for better clarity. 
Updated writer initialization to use the new encoding logic.