### PR TITLE
Issue-1093 Refactor dimension handling and update submodule

### DIFF
--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>3.6.21</Version>
+		<Version>3.6.22</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>../ACadSharp.snk</AssemblyOriginatorKeyFile>

--- a/src/ACadSharp/Entities/DimensionLinear.cs
+++ b/src/ACadSharp/Entities/DimensionLinear.cs
@@ -4,132 +4,131 @@ using CSMath;
 using CSMath.Geometry;
 using System;
 
-namespace ACadSharp.Entities
+namespace ACadSharp.Entities;
+
+/// <summary>
+/// Represents a <see cref="DimensionLinear"/> entity.
+/// </summary>
+/// <remarks>
+/// Object name <see cref="DxfFileToken.EntityDimension"/> <br/>
+/// Dxf class name <see cref="DxfSubclassMarker.LinearDimension"/>
+/// </remarks>
+[DxfName(DxfFileToken.EntityDimension)]
+[DxfSubClass(DxfSubclassMarker.LinearDimension)]
+public class DimensionLinear : DimensionAligned
 {
-	/// <summary>
-	/// Represents a <see cref="DimensionLinear"/> entity.
-	/// </summary>
-	/// <remarks>
-	/// Object name <see cref="DxfFileToken.EntityDimension"/> <br/>
-	/// Dxf class name <see cref="DxfSubclassMarker.LinearDimension"/>
-	/// </remarks>
-	[DxfName(DxfFileToken.EntityDimension)]
-	[DxfSubClass(DxfSubclassMarker.LinearDimension)]
-	public class DimensionLinear : DimensionAligned
+	/// <inheritdoc/>
+	public override double Measurement
 	{
-		/// <inheritdoc/>
-		public override double Measurement
+		get
 		{
-			get
-			{
-				var angle = new XYZ(System.Math.Cos(this.Rotation), System.Math.Sin(this.Rotation), 0.0);
-				double dot = Math.Abs(angle.Dot((this.SecondPoint - this.FirstPoint).Normalize()));
-				return base.Measurement * dot;
-			}
+			var angle = new XYZ(System.Math.Cos(this.Rotation), System.Math.Sin(this.Rotation), 0.0);
+			double dot = Math.Abs(angle.Dot((this.SecondPoint - this.FirstPoint).Normalize()));
+			return base.Measurement * dot;
 		}
+	}
 
-		/// <inheritdoc/>
-		public override string ObjectName => DxfFileToken.EntityDimension;
+	/// <inheritdoc/>
+	public override string ObjectName => DxfFileToken.EntityDimension;
 
-		/// <inheritdoc/>
-		public override ObjectType ObjectType => ObjectType.DIMENSION_LINEAR;
+	/// <inheritdoc/>
+	public override ObjectType ObjectType => ObjectType.DIMENSION_LINEAR;
 
-		/// <inheritdoc/>
-		public override double Offset
+	/// <inheritdoc/>
+	public override double Offset
+	{
+		get
 		{
-			get
-			{
-				return base.Offset;
-			}
-			set
-			{
-				var transform = Transform.CreateRotation(this.Normal, this.Rotation);
-				XYZ axisY = transform.ApplyTransform(XYZ.AxisY).Normalize();
-
-				this.DefinitionPoint = this.SecondPoint + axisY * value;
-			}
+			return base.Offset;
 		}
-
-		/// <summary>
-		/// Angle of rotated, horizontal, or vertical dimensions.
-		/// </summary>
-		/// <value>
-		/// Value in radians.
-		/// </value>
-		[DxfCodeValue(DxfReferenceType.IsAngle, 50)]
-		public double Rotation { get; set; }
-
-		/// <inheritdoc/>
-		public override string SubclassMarker => DxfSubclassMarker.LinearDimension;
-
-		/// <inheritdoc/>
-		public DimensionLinear() : base(DimensionType.Linear)
+		set
 		{
-		}
-
-		/// <inheritdoc/>
-		public override void UpdateBlock()
-		{
-			this.createBlock();	//Should use base, needs to be optimized
-
 			var transform = Transform.CreateRotation(this.Normal, this.Rotation);
-			XYZ yVec = transform.ApplyTransform(XYZ.AxisY).Normalize();
-			XYZ xVec = transform.ApplyTransform(XYZ.AxisX).Normalize();
+			XYZ axisY = transform.ApplyTransform(XYZ.AxisY).Normalize();
 
-			Line3D line1 = new Line3D(this.FirstPoint, yVec);
-			Line3D line2 = new Line3D(this.DefinitionPoint, xVec);
-
-			var dimRef1 = line1.FindIntersection(line2);
-			var dimRef2 = this.DefinitionPoint;
-			XYZ dir = (dimRef2 - dimRef1).Normalize();
-
-			// reference points
-			this._block.Entities.Add(new Point(this.FirstPoint) { Layer = Layer.Defpoints });
-			this._block.Entities.Add(new Point(this.SecondPoint) { Layer = Layer.Defpoints });
-			this._block.Entities.Add(new Point(dimRef1) { Layer = Layer.Defpoints });
-			this._block.Entities.Add(new Point(dimRef2) { Layer = Layer.Defpoints });
-
-			if (!this.Style.SuppressFirstDimensionLine && !this.Style.SuppressSecondDimensionLine)
-			{
-				// dimension line
-				this._block.Entities.Add(dimensionLine(dimRef1, dimRef2, this.Style));
-				this._block.Entities.Add(dimensionArrow(dimRef1, -dir, this.Style, this.Style.DimArrow1));
-				this._block.Entities.Add(dimensionArrow(dimRef2, dir, this.Style, this.Style.DimArrow2));
-			}
-
-			// extension lines
-			var dirRef1 = (dimRef1 - this.FirstPoint).Normalize();
-			var dirRef2 = (dimRef2 - this.SecondPoint).Normalize();
-			double dimexo = this.Style.ExtensionLineOffset * this.Style.ScaleFactor;
-			double dimexe = this.Style.ExtensionLineExtension * this.Style.ScaleFactor;
-			if (!this.Style.SuppressFirstExtensionLine)
-			{
-				this._block.Entities.Add(extensionLine(this.FirstPoint + dimexo * dirRef1, dimRef1 + dimexe * dirRef1, this.Style, this.Style.LineTypeExt1));
-			}
-
-			if (!this.Style.SuppressSecondExtensionLine)
-			{
-				this._block.Entities.Add(extensionLine(this.SecondPoint + dimexo * dirRef2, dimRef2 + dimexe * dirRef2, this.Style, this.Style.LineTypeExt2));
-			}
-
-			// dimension text
-			var textRef = dimRef1.Mid(dimRef2);
-			double gap = this.Style.DimensionLineGap * this.Style.ScaleFactor;
-			double textRot = (double)this.Rotation;
-			if (textRot > MathHelper.HalfPI && textRot <= MathHelper.ThreeHalfPI)
-			{
-				gap = -gap;
-				textRot += Math.PI;
-			}
-
-			string text = this.GetMeasurementText();
-			if (!this.IsTextUserDefinedLocation)
-			{
-				this.TextMiddlePoint = (textRef + gap * yVec).Convert<XYZ>();
-			}
-
-			MText mText = this.createTextEntity(this.TextMiddlePoint, text);
-			this._block.Entities.Add(mText);
+			this.DefinitionPoint = this.SecondPoint + axisY * value;
 		}
+	}
+
+	/// <summary>
+	/// Angle of rotated, horizontal, or vertical dimensions.
+	/// </summary>
+	/// <value>
+	/// Value in radians.
+	/// </value>
+	[DxfCodeValue(DxfReferenceType.IsAngle, 50)]
+	public double Rotation { get; set; }
+
+	/// <inheritdoc/>
+	public override string SubclassMarker => DxfSubclassMarker.LinearDimension;
+
+	/// <inheritdoc/>
+	public DimensionLinear() : base(DimensionType.Linear)
+	{
+	}
+
+	/// <inheritdoc/>
+	public override void UpdateBlock()
+	{
+		this.createBlock(); //Should use base, needs to be optimized
+
+		var transform = Transform.CreateRotation(this.Normal, this.Rotation);
+		XYZ yVec = transform.ApplyTransform(XYZ.AxisY).Normalize();
+		XYZ xVec = transform.ApplyTransform(XYZ.AxisX).Normalize();
+
+		Line3D line1 = new Line3D(this.FirstPoint, yVec);
+		Line3D line2 = new Line3D(this.DefinitionPoint, xVec);
+
+		var dimRef1 = line1.FindIntersection(line2);
+		var dimRef2 = this.DefinitionPoint;
+		XYZ dir = (dimRef2 - dimRef1).Normalize();
+
+		// reference points
+		this._block.Entities.Add(new Point(this.FirstPoint) { Layer = Layer.Defpoints });
+		this._block.Entities.Add(new Point(this.SecondPoint) { Layer = Layer.Defpoints });
+		this._block.Entities.Add(new Point(dimRef1) { Layer = Layer.Defpoints });
+		this._block.Entities.Add(new Point(dimRef2) { Layer = Layer.Defpoints });
+
+		if (!this.Style.SuppressFirstDimensionLine && !this.Style.SuppressSecondDimensionLine)
+		{
+			// dimension line
+			this._block.Entities.Add(dimensionLine(dimRef1, dimRef2, this.Style));
+			this._block.Entities.Add(dimensionArrow(dimRef1, -dir, this.Style, this.Style.DimArrow1));
+			this._block.Entities.Add(dimensionArrow(dimRef2, dir, this.Style, this.Style.DimArrow2));
+		}
+
+		// extension lines
+		var dirRef1 = (dimRef1 - this.FirstPoint).Normalize();
+		var dirRef2 = (dimRef2 - this.SecondPoint).Normalize();
+		double dimexo = this.Style.ExtensionLineOffset * this.Style.ScaleFactor;
+		double dimexe = this.Style.ExtensionLineExtension * this.Style.ScaleFactor;
+		if (!this.Style.SuppressFirstExtensionLine)
+		{
+			this._block.Entities.Add(extensionLine(this.FirstPoint + dimexo * dirRef1, dimRef1 + dimexe * dirRef1, this.Style, this.Style.LineTypeExt1));
+		}
+
+		if (!this.Style.SuppressSecondExtensionLine)
+		{
+			this._block.Entities.Add(extensionLine(this.SecondPoint + dimexo * dirRef2, dimRef2 + dimexe * dirRef2, this.Style, this.Style.LineTypeExt2));
+		}
+
+		// dimension text
+		var textRef = dimRef1.Mid(dimRef2);
+		double gap = this.Style.DimensionLineGap * this.Style.ScaleFactor;
+		double textRot = (double)this.Rotation;
+		if (textRot > MathHelper.HalfPI && textRot <= MathHelper.ThreeHalfPI)
+		{
+			gap = -gap;
+			textRot += Math.PI;
+		}
+
+		string text = this.GetMeasurementText();
+		if (!this.IsTextUserDefinedLocation)
+		{
+			this.TextMiddlePoint = (textRef + gap * yVec).Convert<XYZ>();
+		}
+
+		MText mText = this.createTextEntity(this.TextMiddlePoint, text);
+		this._block.Entities.Add(mText);
 	}
 }

--- a/src/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
@@ -4,6 +4,7 @@ using ACadSharp.Objects;
 using ACadSharp.Tables;
 using ACadSharp.XData;
 using CSMath;
+using CSUtilities.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -782,34 +783,34 @@ internal abstract class DxfSectionReaderBase
 					{
 						case DimensionType.Linear:
 							tmp.SetDimensionObject(new DimensionLinear());
-							map.SubClasses.Add(DxfSubclassMarker.AlignedDimension, DxfClassMap.Create<DimensionAligned>());
-							map.SubClasses.Add(DxfSubclassMarker.LinearDimension, DxfClassMap.Create<DimensionLinear>());
+							map.SubClasses.TryAdd(DxfSubclassMarker.AlignedDimension, DxfClassMap.Create<DimensionAligned>());
+							map.SubClasses.TryAdd(DxfSubclassMarker.LinearDimension, DxfClassMap.Create<DimensionLinear>());
 							break;
 						case DimensionType.Aligned:
 							tmp.SetDimensionObject(new DimensionAligned());
-							map.SubClasses.Add(DxfSubclassMarker.AlignedDimension, DxfClassMap.Create<DimensionAligned>());
+							map.SubClasses.TryAdd(DxfSubclassMarker.AlignedDimension, DxfClassMap.Create<DimensionAligned>());
 							break;
 						case DimensionType.Angular:
 							tmp.SetDimensionObject(new DimensionAngular2Line());
-							map.SubClasses.Add(DxfSubclassMarker.Angular2LineDimension, DxfClassMap.Create<DimensionAngular2Line>());
+							map.SubClasses.TryAdd(DxfSubclassMarker.Angular2LineDimension, DxfClassMap.Create<DimensionAngular2Line>());
 							break;
 						case DimensionType.Diameter:
 							tmp.SetDimensionObject(new DimensionDiameter());
-							map.SubClasses.Add(DxfSubclassMarker.DiametricDimension, DxfClassMap.Create<DimensionDiameter>());
+							map.SubClasses.TryAdd(DxfSubclassMarker.DiametricDimension, DxfClassMap.Create<DimensionDiameter>());
 							break;
 						case DimensionType.Radius:
 							tmp.SetDimensionObject(new DimensionRadius());
-							map.SubClasses.Add(DxfSubclassMarker.RadialDimension, DxfClassMap.Create<DimensionRadius>());
+							map.SubClasses.TryAdd(DxfSubclassMarker.RadialDimension, DxfClassMap.Create<DimensionRadius>());
 							break;
 						case DimensionType.Angular3Point:
 							tmp.SetDimensionObject(new DimensionAngular3Pt());
-							map.SubClasses.Add(DxfSubclassMarker.Angular3PointDimension, DxfClassMap.Create<DimensionAngular3Pt>());
+							map.SubClasses.TryAdd(DxfSubclassMarker.Angular3PointDimension, DxfClassMap.Create<DimensionAngular3Pt>());
 							break;
 						case DimensionType.Ordinate:
 						case DimensionType.OrdinateTypeX:
 						case DimensionType.Ordinate | DimensionType.OrdinateTypeX:
 							tmp.SetDimensionObject(new DimensionOrdinate());
-							map.SubClasses.Add(DxfSubclassMarker.OrdinateDimension, DxfClassMap.Create<DimensionOrdinate>());
+							map.SubClasses.TryAdd(DxfSubclassMarker.OrdinateDimension, DxfClassMap.Create<DimensionOrdinate>());
 							break;
 						case DimensionType.BlockReference:
 						case DimensionType.TextUserDefinedLocation:
@@ -832,32 +833,34 @@ internal abstract class DxfSectionReaderBase
 				switch (this._reader.ValueAsString)
 				{
 					case DxfSubclassMarker.Dimension:
-						return this.tryAssignCurrentValue(template.CadObject, map.SubClasses[DxfSubclassMarker.Dimension]);
+						return true;
 					case DxfSubclassMarker.AlignedDimension:
 						tmp.SetDimensionObject(new DimensionAligned());
-						map.SubClasses.Add(this._reader.ValueAsString, DxfClassMap.Create<DimensionAligned>());
+						map.SubClasses.TryAdd(this._reader.ValueAsString, DxfClassMap.Create<DimensionAligned>());
 						return true;
 					case DxfSubclassMarker.DiametricDimension:
 						tmp.SetDimensionObject(new DimensionDiameter());
-						map.SubClasses.Add(this._reader.ValueAsString, DxfClassMap.Create<DimensionDiameter>());
+						map.SubClasses.TryAdd(this._reader.ValueAsString, DxfClassMap.Create<DimensionDiameter>());
 						return true;
 					case DxfSubclassMarker.Angular2LineDimension:
 						tmp.SetDimensionObject(new DimensionAngular2Line());
-						map.SubClasses.Add(this._reader.ValueAsString, DxfClassMap.Create<DimensionAngular2Line>());
+						map.SubClasses.TryAdd(this._reader.ValueAsString, DxfClassMap.Create<DimensionAngular2Line>());
 						return true;
 					case DxfSubclassMarker.Angular3PointDimension:
 						tmp.SetDimensionObject(new DimensionAngular3Pt());
-						map.SubClasses.Add(this._reader.ValueAsString, DxfClassMap.Create<DimensionAngular3Pt>());
+						map.SubClasses.TryAdd(this._reader.ValueAsString, DxfClassMap.Create<DimensionAngular3Pt>());
 						return true;
 					case DxfSubclassMarker.RadialDimension:
 						tmp.SetDimensionObject(new DimensionRadius());
-						map.SubClasses.Add(this._reader.ValueAsString, DxfClassMap.Create<DimensionRadius>());
+						map.SubClasses.TryAdd(this._reader.ValueAsString, DxfClassMap.Create<DimensionRadius>());
 						return true;
 					case DxfSubclassMarker.OrdinateDimension:
 						tmp.SetDimensionObject(new DimensionOrdinate());
-						map.SubClasses.Add(this._reader.ValueAsString, DxfClassMap.Create<DimensionOrdinate>());
+						map.SubClasses.TryAdd(this._reader.ValueAsString, DxfClassMap.Create<DimensionOrdinate>());
 						return true;
 					case DxfSubclassMarker.LinearDimension:
+						tmp.SetDimensionObject(new DimensionLinear());
+						map.SubClasses.TryAdd(DxfSubclassMarker.LinearDimension, DxfClassMap.Create<DimensionLinear>());
 						return true;
 					default:
 						return false;

--- a/src/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
@@ -765,13 +765,13 @@ internal abstract class DxfSectionReaderBase
 				tmp.StyleName = this._reader.ValueAsString;
 				return true;
 			case 50:
-				var dim = new DimensionLinear();
-				tmp.SetDimensionObject(dim);
-				dim.Rotation = this._reader.ValueAsAngle;
-				if (!map.SubClasses.ContainsKey(DxfSubclassMarker.LinearDimension))
+				if (tmp.CadObject is not DimensionLinear dim)
 				{
-					map.SubClasses.Add(DxfSubclassMarker.LinearDimension, DxfClassMap.Create<DimensionLinear>());
+					dim = new DimensionLinear();
+					tmp.SetDimensionObject(dim);
 				}
+				dim.Rotation = this._reader.ValueAsAngle;
+				map.SubClasses.TryAdd(DxfSubclassMarker.LinearDimension, DxfClassMap.Create<DimensionLinear>());
 				return true;
 			case 70:
 				//Flags do not have set

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
@@ -468,7 +468,7 @@ internal abstract partial class DxfSectionWriterBase
 
 		this.writeHatchPattern(hatch, hatch.Pattern);
 
-		if (hatch.PixelSize != 0)
+		if (!hatch.IsSolid || hatch.Paths.Any(p => p.Flags.HasFlag(BoundaryPathFlags.Derived)) || hatch.PixelSize != 0)
 		{
 			this._writer.Write(47, hatch.PixelSize, map);
 		}
@@ -777,11 +777,11 @@ internal abstract partial class DxfSectionWriterBase
 			this._writer.Write(90, edge.End);
 		}
 
-			this._writer.Write(95, mesh.Edges.Count, map);
-			foreach (Mesh.Edge edge in mesh.Edges)
-			{
-				this._writer.Write(140, edge.Crease.HasValue ? edge.Crease.Value : 0.0d);
-			}
+		this._writer.Write(95, mesh.Edges.Count, map);
+		foreach (Mesh.Edge edge in mesh.Edges)
+		{
+			this._writer.Write(140, edge.Crease.HasValue ? edge.Crease.Value : 0.0d);
+		}
 
 		this._writer.Write(90, 0);
 	}

--- a/src/ACadSharp/IO/Templates/CadDimensionTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadDimensionTemplate.cs
@@ -67,6 +67,11 @@ internal class CadDimensionTemplate : CadEntityTemplate
 
 	public void SetDimensionObject(Dimension dimension)
 	{
+		if (this.CadObject.GetType() == dimension.GetType())
+		{
+			return;
+		}
+
 		dimension.Handle = this.CadObject.Handle;
 		dimension.Owner = this.CadObject.Owner;
 


### PR DESCRIPTION
# Description

Replaced `Add` with `TryAdd` for safer subclass marker handling in `DxfSectionReaderBase.cs`. 
Improved `tryAssignCurrentValue` logic and added support for `DxfSubclassMarker.LinearDimension`. 
Updated `hatch.PixelSize` condition and refactored `writeHatch` method in `DxfSectionWriterBase.Entities.cs`. 
Updated `CSUtilities` submodule to a new commit.