### PR TITLE
Hatch explode

### DIFF
--- a/src/ACadSharp.Tests/Entities/HatchTests.cs
+++ b/src/ACadSharp.Tests/Entities/HatchTests.cs
@@ -109,11 +109,98 @@ public class HatchTests : CommonEntityTests<Hatch>
 	}
 
 	[Fact]
+	public void ExplodePatternArcBoundaryTest()
+	{
+		Hatch hatch = new Hatch();
+		hatch.Paths.Add(this.createArcBoundary());
+
+		this.applyHorizontalPattern(hatch);
+
+		List<Line> lines = hatch.ExplodePattern()
+			.OfType<Line>()
+			.OrderBy(l => l.StartPoint.Y)
+			.ToList();
+
+		Assert.Equal(3, lines.Count);
+
+		double[] expectedY = [-0.5, 0.0, 0.5];
+
+		for (int i = 0; i < lines.Count; i++)
+		{
+			double x = Math.Sqrt(1.0 - expectedY[i] * expectedY[i]);
+			AssertUtils.AreEqual(new XYZ(-x, expectedY[i], 0), lines[i].StartPoint, 2);
+			AssertUtils.AreEqual(new XYZ(x, expectedY[i], 0), lines[i].EndPoint, 2);
+		}
+	}
+
+	[Fact]
+	public void ExplodePatternEllipseBoundaryTest()
+	{
+		Hatch hatch = new Hatch();
+		hatch.Paths.Add(this.createEllipseBoundary());
+
+		this.applyHorizontalPattern(hatch);
+
+		List<Line> lines = hatch.ExplodePattern()
+			.OfType<Line>()
+			.OrderBy(l => l.StartPoint.Y)
+			.ToList();
+
+		Assert.Single(lines);
+		AssertUtils.AreEqual(new XYZ(-1, 0, 0), lines[0].StartPoint);
+		AssertUtils.AreEqual(new XYZ(1, 0, 0), lines[0].EndPoint);
+	}
+
+	[Fact]
+	public void ExplodePatternLineBoundaryTest()
+	{
+		Hatch hatch = new Hatch();
+		hatch.Paths.Add(this.createLineBoundary());
+
+		this.applyHorizontalPattern(hatch);
+
+		List<Line> lines = hatch.ExplodePattern()
+			.OfType<Line>()
+			.OrderBy(l => l.StartPoint.Y)
+			.ToList();
+
+		Assert.Equal(3, lines.Count);
+
+		double[] expectedY = [0.0, 0.5, 1.0];
+
+		for (int i = 0; i < lines.Count; i++)
+		{
+			AssertUtils.AreEqual(new XYZ(0, expectedY[i], 0), lines[i].StartPoint);
+			AssertUtils.AreEqual(new XYZ(1, expectedY[i], 0), lines[i].EndPoint);
+		}
+	}
+
+	[Fact]
 	public void ExplodePatternTest()
 	{
 		Hatch hatch = new Hatch();
+		Hatch.BoundaryPath path = new Hatch.BoundaryPath();
+		Hatch.BoundaryPath.Polyline pline = createPolylineBoundary();
 
-		var lines = hatch.ExplodePattern();
+		path.Edges.Add(pline);
+		hatch.Paths.Add(path);
+
+		this.applyHorizontalPattern(hatch);
+
+		List<Line> lines = hatch.ExplodePattern()
+			.OfType<Line>()
+			.OrderBy(l => l.StartPoint.Y)
+			.ToList();
+
+		Assert.Equal(3, lines.Count);
+
+		double[] expectedY = [0.0, 0.5, 1.0];
+
+		for (int i = 0; i < lines.Count; i++)
+		{
+			AssertUtils.AreEqual(new XYZ(0, expectedY[i], 0), lines[i].StartPoint);
+			AssertUtils.AreEqual(new XYZ(1, expectedY[i], 0), lines[i].EndPoint);
+		}
 	}
 
 	[Fact]
@@ -205,6 +292,60 @@ public class HatchTests : CommonEntityTests<Hatch>
 
 		hatch.PatternAngle = MathHelper.HalfPI;
 		Assert.Equal(MathHelper.HalfPI, line.Angle);
+	}
+
+	private void applyHorizontalPattern(Hatch hatch)
+	{
+		hatch.Pattern = new HatchPattern("custom");
+		hatch.Pattern.Lines.Add(new HatchPattern.Line
+		{
+			Angle = 0.0,
+			BasePoint = new XY(0, 0),
+			Offset = new XY(0, 0.5)
+		});
+	}
+
+	private Hatch.BoundaryPath createArcBoundary()
+	{
+		Hatch.BoundaryPath path = new Hatch.BoundaryPath();
+		path.Edges.Add(new Hatch.BoundaryPath.Arc
+		{
+			Center = new XY(0, 0),
+			Radius = 1.0,
+			StartAngle = 0.0,
+			EndAngle = MathHelper.TwoPI,
+			CounterClockWise = true
+		});
+
+		return path;
+	}
+
+	private Hatch.BoundaryPath createEllipseBoundary()
+	{
+		Hatch.BoundaryPath path = new Hatch.BoundaryPath();
+		path.Edges.Add(new Hatch.BoundaryPath.Ellipse
+		{
+			Center = new XY(0, 0),
+			MajorAxisEndPoint = new XY(1, 0),
+			RadiusRatio = 0.5,
+			StartAngle = 0.0,
+			EndAngle = MathHelper.TwoPI,
+			CounterClockWise = true
+		});
+
+		return path;
+	}
+
+	private Hatch.BoundaryPath createLineBoundary()
+	{
+		Hatch.BoundaryPath path = new Hatch.BoundaryPath();
+
+		path.Edges.Add(new Hatch.BoundaryPath.Line { Start = new XY(0, 0), End = new XY(1, 0) });
+		path.Edges.Add(new Hatch.BoundaryPath.Line { Start = new XY(1, 0), End = new XY(1, 1) });
+		path.Edges.Add(new Hatch.BoundaryPath.Line { Start = new XY(1, 1), End = new XY(0, 1) });
+		path.Edges.Add(new Hatch.BoundaryPath.Line { Start = new XY(0, 1), End = new XY(0, 0) });
+
+		return path;
 	}
 
 	private Hatch.BoundaryPath.Polyline createPolylineBoundary()

--- a/src/ACadSharp.Tests/Entities/HatchTests.cs
+++ b/src/ACadSharp.Tests/Entities/HatchTests.cs
@@ -6,230 +6,236 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
-namespace ACadSharp.Tests.Entities
+namespace ACadSharp.Tests.Entities;
+
+public class HatchTests : CommonEntityTests<Hatch>
 {
-	public class HatchTests : CommonEntityTests<Hatch>
+	[Fact]
+	public void BoundaryPathToEntityTest()
 	{
-		[Fact]
-		public void BoundaryPathToEntityTest()
+		var a = new Hatch.BoundaryPath.Arc
 		{
-			var a = new Hatch.BoundaryPath.Arc
-			{
-				Center = new XY(25, 0),
-				StartAngle = 0,
-				EndAngle = MathHelper.HalfPI,
-				Radius = 10,
-				CounterClockWise = true
-			};
+			Center = new XY(25, 0),
+			StartAngle = 0,
+			EndAngle = MathHelper.HalfPI,
+			Radius = 10,
+			CounterClockWise = true
+		};
 
-			ACadSharp.Entities.Arc arc = (Arc)a.ToEntity();
+		ACadSharp.Entities.Arc arc = (Arc)a.ToEntity();
 
-			Assert.NotNull(arc);
-			Assert.Equal(a.Center.Convert<XYZ>(), arc.Center);
-			Assert.Equal(a.StartAngle, arc.StartAngle);
-			Assert.Equal(a.EndAngle, arc.EndAngle);
-			Assert.Equal(a.Radius, arc.Radius);
+		Assert.NotNull(arc);
+		Assert.Equal(a.Center.Convert<XYZ>(), arc.Center);
+		Assert.Equal(a.StartAngle, arc.StartAngle);
+		Assert.Equal(a.EndAngle, arc.EndAngle);
+		Assert.Equal(a.Radius, arc.Radius);
 
-			var l = new Hatch.BoundaryPath.Line
-			{
-				Start = new XY(25, 0),
-				End = new XY(25, 0)
-			};
+		var l = new Hatch.BoundaryPath.Line
+		{
+			Start = new XY(25, 0),
+			End = new XY(25, 0)
+		};
 
-			ACadSharp.Entities.Line line = (Line)l.ToEntity();
+		ACadSharp.Entities.Line line = (Line)l.ToEntity();
 
-			Assert.NotNull(line);
-			Assert.Equal(l.Start.Convert<XYZ>(), line.StartPoint);
-			Assert.Equal(l.End.Convert<XYZ>(), line.EndPoint);
+		Assert.NotNull(line);
+		Assert.Equal(l.Start.Convert<XYZ>(), line.StartPoint);
+		Assert.Equal(l.End.Convert<XYZ>(), line.EndPoint);
+	}
+
+	[Fact]
+	public void CreateHatch()
+	{
+		Hatch hatch = new Hatch();
+		hatch.IsSolid = true;
+
+		hatch.SeedPoints.Add(new XY());
+
+		List<Hatch.BoundaryPath.Line> edges = new List<Hatch.BoundaryPath.Line>();
+
+		//edges
+		Hatch.BoundaryPath.Line edge1 = new Hatch.BoundaryPath.Line
+		{
+			Start = new CSMath.XY(0, 0),
+			End = new CSMath.XY(1, 0)
+		};
+		edges.Add(edge1);
+
+		Hatch.BoundaryPath.Line edge2 = new Hatch.BoundaryPath.Line
+		{
+			Start = new CSMath.XY(1, 0),
+			End = new CSMath.XY(1, 1)
+		};
+		edges.Add(edge2);
+
+		Hatch.BoundaryPath.Line edge3 = new Hatch.BoundaryPath.Line
+		{
+			Start = new CSMath.XY(1, 1),
+			End = new CSMath.XY(0, 1)
+		};
+		edges.Add(edge3);
+
+		Hatch.BoundaryPath.Line edge4 = new Hatch.BoundaryPath.Line
+		{
+			Start = new CSMath.XY(0, 1),
+			End = new CSMath.XY(0, 0)
+		};
+		edges.Add(edge4);
+
+		Hatch.BoundaryPath path = new Hatch.BoundaryPath();
+		foreach (var item in edges)
+		{
+			path.Edges.Add(item);
 		}
 
-		[Fact]
-		public void CreateHatch()
+		hatch.Paths.Add(path);
+
+		Assert.NotEmpty(hatch.Paths);
+		Assert.NotEmpty(path.Edges);
+		Assert.False(path.IsPolyline);
+	}
+
+	[Fact]
+	public void CreatePolylineHatch()
+	{
+		Hatch hatch = new Hatch();
+		Hatch.BoundaryPath path = new Hatch.BoundaryPath();
+		Hatch.BoundaryPath.Polyline pline = createPolylineBoundary();
+
+		path.Edges.Add(pline);
+		hatch.Paths.Add(path);
+
+		Assert.True(path.IsPolyline);
+	}
+
+	[Fact]
+	public void ExplodePatternTest()
+	{
+		Hatch hatch = new Hatch();
+
+		var lines = hatch.ExplodePattern();
+	}
+
+	[Fact]
+	public void ExplodeTest()
+	{
+		Hatch hatch = new Hatch();
+		Hatch.BoundaryPath path = new Hatch.BoundaryPath();
+		Hatch.BoundaryPath.Polyline pline = createPolylineBoundary();
+
+		path.Edges.Add(pline);
+		hatch.Paths.Add(path);
+
+		var entities = hatch.Explode();
+
+		Assert.NotEmpty(entities);
+
+		Polyline2D result = entities.OfType<Polyline2D>().FirstOrDefault();
+		Assert.NotNull(result);
+		Assert.NotEmpty(result.Vertices);
+
+		for (int i = 0; i < result.Vertices.Count; i++)
 		{
-			Hatch hatch = new Hatch();
-			hatch.IsSolid = true;
+			AssertUtils.AreEqual(pline.Vertices[i], result.Vertices[i].Location);
+		}
+	}
 
-			hatch.SeedPoints.Add(new XY());
+	[Fact]
+	public override void GetBoundingBoxTest()
+	{
+		Hatch hatch = this.createPolylineHatch();
 
-			List<Hatch.BoundaryPath.Line> edges = new List<Hatch.BoundaryPath.Line>();
+		var box = hatch.GetBoundingBox();
 
-			//edges
-			Hatch.BoundaryPath.Line edge1 = new Hatch.BoundaryPath.Line
-			{
-				Start = new CSMath.XY(0, 0),
-				End = new CSMath.XY(1, 0)
-			};
-			edges.Add(edge1);
+		Assert.Equal(new XYZ(0, 0, 0), box.Min);
+		Assert.Equal(new XYZ(1, 1, 0), box.Max);
+	}
 
-			Hatch.BoundaryPath.Line edge2 = new Hatch.BoundaryPath.Line
-			{
-				Start = new CSMath.XY(1, 0),
-				End = new CSMath.XY(1, 1)
-			};
-			edges.Add(edge2);
+	[Fact]
+	public void PolylineHatchNotAllowMoreEdges()
+	{
+		Hatch.BoundaryPath path = new Hatch.BoundaryPath();
+		Hatch.BoundaryPath.Polyline pline = createPolylineBoundary();
+		path.Edges.Add(pline);
 
-			Hatch.BoundaryPath.Line edge3 = new Hatch.BoundaryPath.Line
-			{
-				Start = new CSMath.XY(1, 1),
-				End = new CSMath.XY(0, 1)
-			};
-			edges.Add(edge3);
+		Assert.Throws<InvalidOperationException>(() =>
+		{
+			path.Edges.Add(new Hatch.BoundaryPath.Line());
+		}
+		);
 
-			Hatch.BoundaryPath.Line edge4 = new Hatch.BoundaryPath.Line
-			{
-				Start = new CSMath.XY(0, 1),
-				End = new CSMath.XY(0, 0)
-			};
-			edges.Add(edge4);
+		Assert.Throws<InvalidOperationException>(() =>
+		{
+			path.Edges.Add(new Hatch.BoundaryPath.Polyline());
+		}
+		);
+	}
 
-			Hatch.BoundaryPath path = new Hatch.BoundaryPath();
-			foreach (var item in edges)
-			{
-				path.Edges.Add(item);
-			}
+	[Fact]
+	public void TransformTest()
+	{
+		Hatch hatch = this.createPolylineHatch();
+		var translation = Transform.CreateTranslation(new XYZ(10, 10, 0));
 
-			hatch.Paths.Add(path);
+		hatch.ApplyTransform(translation);
+	}
 
-			Assert.NotEmpty(hatch.Paths);
-			Assert.NotEmpty(path.Edges);
-			Assert.False(path.IsPolyline);
+	[Fact]
+	public void UpdatePattern()
+	{
+		Hatch hatch = new Hatch();
+		var pattern = new HatchPattern("custom");
+		hatch.Pattern = pattern;
+
+		pattern.Lines.Add(new HatchPattern.Line
+		{
+			Angle = 0,
+			Offset = new XY(-1, 1),
+			DashLengths = { 0.5, 0.5 }
+		});
+
+		hatch.PatternScale = 2;
+
+		var line = pattern.Lines.First();
+		Assert.Equal(new XY(-2, 2), line.Offset);
+		foreach (var item in line.DashLengths)
+		{
+			Assert.Equal(1, item);
 		}
 
-		[Fact]
-		public void CreatePolylineHatch()
-		{
-			Hatch hatch = new Hatch();
-			Hatch.BoundaryPath path = new Hatch.BoundaryPath();
-			Hatch.BoundaryPath.Polyline pline = createPolylineBoundary();
+		hatch.PatternAngle = MathHelper.HalfPI;
+		Assert.Equal(MathHelper.HalfPI, line.Angle);
+	}
 
-			path.Edges.Add(pline);
-			hatch.Paths.Add(path);
+	private Hatch.BoundaryPath.Polyline createPolylineBoundary()
+	{
+		Hatch.BoundaryPath.Polyline pline = new Hatch.BoundaryPath.Polyline();
+		pline.Vertices.Add(new XYZ(0, 0, 0));
+		pline.Vertices.Add(new XYZ(1, 0, 0));
+		pline.Vertices.Add(new XYZ(1, 1, 0));
+		pline.Vertices.Add(new XYZ(0, 1, 0));
+		pline.Vertices.Add(new XYZ(0, 0, 0));
 
-			Assert.True(path.IsPolyline);
-		}
+		return pline;
+	}
 
-		[Fact]
-		public void ExplodeTest()
-		{
-			Hatch hatch = new Hatch();
-			Hatch.BoundaryPath path = new Hatch.BoundaryPath();
-			Hatch.BoundaryPath.Polyline pline = createPolylineBoundary();
+	private Hatch createPolylineHatch()
+	{
+		Hatch hatch = new Hatch();
 
-			path.Edges.Add(pline);
-			hatch.Paths.Add(path);
+		Hatch.BoundaryPath path = new Hatch.BoundaryPath();
 
-			var entities = hatch.Explode();
+		Hatch.BoundaryPath.Polyline pline = new Hatch.BoundaryPath.Polyline();
+		pline.Vertices.Add(new XYZ(0, 0, 0));
+		pline.Vertices.Add(new XYZ(1, 0, 0));
+		pline.Vertices.Add(new XYZ(1, 1, 0));
+		pline.Vertices.Add(new XYZ(0, 1, 0));
+		pline.Vertices.Add(new XYZ(0, 0, 0));
 
-			Assert.NotEmpty(entities);
+		path.Edges.Add(pline);
 
-			Polyline2D result = entities.OfType<Polyline2D>().FirstOrDefault();
-			Assert.NotNull(result);
-			Assert.NotEmpty(result.Vertices);
+		hatch.Paths.Add(path);
 
-			for (int i = 0; i < result.Vertices.Count; i++)
-			{
-				AssertUtils.AreEqual(pline.Vertices[i], result.Vertices[i].Location);
-			}
-
-		}
-
-		[Fact]
-		public void TransformTest()
-		{
-			Hatch hatch = this.createPolylineHatch();
-			var translation = Transform.CreateTranslation(new XYZ(10, 10, 0));
-
-			hatch.ApplyTransform(translation);
-		}
-
-		[Fact]
-		public override void GetBoundingBoxTest()
-		{
-			Hatch hatch = this.createPolylineHatch();
-
-			var box = hatch.GetBoundingBox();
-
-			Assert.Equal(new XYZ(0, 0, 0), box.Min);
-			Assert.Equal(new XYZ(1, 1, 0), box.Max);
-		}
-
-		[Fact]
-		public void PolylineHatchNotAllowMoreEdges()
-		{
-			Hatch.BoundaryPath path = new Hatch.BoundaryPath();
-			Hatch.BoundaryPath.Polyline pline = createPolylineBoundary();
-			path.Edges.Add(pline);
-
-			Assert.Throws<InvalidOperationException>(() =>
-			{
-				path.Edges.Add(new Hatch.BoundaryPath.Line());
-			}
-			);
-
-			Assert.Throws<InvalidOperationException>(() =>
-			{
-				path.Edges.Add(new Hatch.BoundaryPath.Polyline());
-			}
-			);
-		}
-
-		[Fact]
-		public void UpdatePattern()
-		{
-			Hatch hatch = new Hatch();
-			var pattern = new HatchPattern("custom");
-			hatch.Pattern = pattern;
-
-			pattern.Lines.Add(new HatchPattern.Line
-			{
-				Angle = 0,
-				Offset = new XY(-1, 1),
-				DashLengths = { 0.5, 0.5 }
-			});
-
-			hatch.PatternScale = 2;
-
-			var line = pattern.Lines.First();
-			Assert.Equal(new XY(-2, 2), line.Offset);
-			foreach (var item in line.DashLengths)
-			{
-				Assert.Equal(1, item);
-			}
-
-			hatch.PatternAngle = MathHelper.HalfPI;
-			Assert.Equal(MathHelper.HalfPI, line.Angle);
-		}
-
-		private Hatch createPolylineHatch()
-		{
-			Hatch hatch = new Hatch();
-
-			Hatch.BoundaryPath path = new Hatch.BoundaryPath();
-
-			Hatch.BoundaryPath.Polyline pline = new Hatch.BoundaryPath.Polyline();
-			pline.Vertices.Add(new XYZ(0, 0, 0));
-			pline.Vertices.Add(new XYZ(1, 0, 0));
-			pline.Vertices.Add(new XYZ(1, 1, 0));
-			pline.Vertices.Add(new XYZ(0, 1, 0));
-			pline.Vertices.Add(new XYZ(0, 0, 0));
-
-			path.Edges.Add(pline);
-
-			hatch.Paths.Add(path);
-
-			return hatch;
-		}
-
-		private Hatch.BoundaryPath.Polyline createPolylineBoundary()
-		{
-			Hatch.BoundaryPath.Polyline pline = new Hatch.BoundaryPath.Polyline();
-			pline.Vertices.Add(new XYZ(0, 0, 0));
-			pline.Vertices.Add(new XYZ(1, 0, 0));
-			pline.Vertices.Add(new XYZ(1, 1, 0));
-			pline.Vertices.Add(new XYZ(0, 1, 0));
-			pline.Vertices.Add(new XYZ(0, 0, 0));
-
-			return pline;
-		}
+		return hatch;
 	}
 }

--- a/src/ACadSharp.Tests/IO/LocalSampleTests.cs
+++ b/src/ACadSharp.Tests/IO/LocalSampleTests.cs
@@ -44,6 +44,7 @@ public class LocalSampleTests : IOTestsBase
 			toAdd.AddRange(item.ExplodePattern());
 		}
 
+		toAdd.ForEach(e => e.Color = Color.Red);
 		doc.Entities.AddRange(toAdd);
 
 		if (!TestVariables.SaveOutputInStream)

--- a/src/ACadSharp.Tests/IO/LocalSampleTests.cs
+++ b/src/ACadSharp.Tests/IO/LocalSampleTests.cs
@@ -1,6 +1,7 @@
 ﻿using ACadSharp.Entities;
 using ACadSharp.IO;
 using ACadSharp.Tests.TestModels;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -36,6 +37,15 @@ public class LocalSampleTests : IOTestsBase
 			return;
 
 		CadDocument doc = DwgReader.Read(test.Path, this._dwgConfiguration, this.onNotification);
+
+		var toAdd = new List<Entity>();
+		foreach (var item in doc.Entities.OfType<Hatch>())
+		{
+			toAdd.AddRange(item.ExplodePattern());
+		}
+
+		doc.Entities.AddRange(toAdd);
+
 		if (!TestVariables.SaveOutputInStream)
 		{
 			DwgWriter.Write(Path.Combine(TestVariables.DesktopFolder, "output", "test.dwg"), doc, notification: this.onNotification);

--- a/src/ACadSharp.Tests/IO/LocalSampleTests.cs
+++ b/src/ACadSharp.Tests/IO/LocalSampleTests.cs
@@ -37,16 +37,6 @@ public class LocalSampleTests : IOTestsBase
 			return;
 
 		CadDocument doc = DwgReader.Read(test.Path, this._dwgConfiguration, this.onNotification);
-
-		var toAdd = new List<Entity>();
-		foreach (var item in doc.Entities.OfType<Hatch>())
-		{
-			toAdd.AddRange(item.ExplodePattern());
-		}
-
-		toAdd.ForEach(e => e.Color = Color.Red);
-		doc.Entities.AddRange(toAdd);
-
 		if (!TestVariables.SaveOutputInStream)
 		{
 			DwgWriter.Write(Path.Combine(TestVariables.DesktopFolder, "output", "test.dwg"), doc, notification: this.onNotification);

--- a/src/ACadSharp.Tests/Internal/DwgObjectWriterTests.cs
+++ b/src/ACadSharp.Tests/Internal/DwgObjectWriterTests.cs
@@ -22,32 +22,6 @@ namespace ACadSharp.Tests.Internal
 
 		[Theory]
 		[MemberData(nameof(DwgVersions))]
-		public void WriteEmptyDocumentTest(ACadVersion version)
-		{
-			CadDocument document = new CadDocument();
-			document.Header.Version = version;
-			if (document.Header.Version < ACadVersion.AC1018)
-			{
-				document.VEntityControl ??= new ViewportEntityControl(document);
-			}
-
-			DwgDocumentBuilder builder = this.writeInfo(document);
-
-			builder.BuildDocument();
-
-			this.assertTable(document.AppIds, builder.AppIds);
-			this.assertTable(document.Layers, builder.Layers);
-			this.assertTable(document.LineTypes, builder.LineTypesTable);
-			this.assertTable(document.TextStyles, builder.TextStyles);
-			this.assertTable(document.UCSs, builder.UCSs);
-			this.assertTable(document.Views, builder.Views);
-			this.assertTable(document.DimensionStyles, builder.DimensionStyles);
-			this.assertTable(document.VPorts, builder.VPorts);
-			this.assertTable(document.BlockRecords, builder.BlockRecords);
-		}
-
-		[Theory]
-		[MemberData(nameof(DwgVersions))]
 		public void EntitiesTest(ACadVersion version)
 		{
 			CadDocument document = new CadDocument();
@@ -107,8 +81,41 @@ namespace ACadSharp.Tests.Internal
 			}
 		}
 
+		[Theory]
+		[MemberData(nameof(DwgVersions))]
+		public void WriteEmptyDocumentTest(ACadVersion version)
+		{
+			CadDocument document = new CadDocument();
+			document.Header.Version = version;
+			if (document.Header.Version < ACadVersion.AC1018)
+			{
+				document.VEntityControl ??= new ViewportEntityControl(document);
+			}
+
+			DwgDocumentBuilder builder = this.writeInfo(document);
+
+			builder.BuildDocument();
+
+			this.assertTable(document.AppIds, builder.AppIds);
+			this.assertTable(document.Layers, builder.Layers);
+			this.assertTable(document.LineTypes, builder.LineTypesTable);
+			this.assertTable(document.TextStyles, builder.TextStyles);
+			this.assertTable(document.UCSs, builder.UCSs);
+			this.assertTable(document.Views, builder.Views);
+			this.assertTable(document.DimensionStyles, builder.DimensionStyles);
+			this.assertTable(document.VPorts, builder.VPorts);
+			this.assertTable(document.BlockRecords, builder.BlockRecords);
+		}
+
+		protected override void onNotification(object sender, NotificationEventArgs e)
+		{
+			Assert.False(e.NotificationType == NotificationType.Error, e.Message);
+
+			base.onNotification(sender, e);
+		}
+
 		private void assertTable<T>(Table<T> expected, Table<T> actual)
-			where T : TableEntry
+					where T : TableEntry
 		{
 			Assert.NotNull(expected);
 			Assert.Equal(expected.Handle, actual.Handle);
@@ -155,13 +162,6 @@ namespace ACadSharp.Tests.Internal
 			reader.Read();
 
 			return builder;
-		}
-
-		protected override void onNotification(object sender, NotificationEventArgs e)
-		{
-			Assert.False(e.NotificationType == NotificationType.Error, e.Message);
-
-			base.onNotification(sender, e);
 		}
 	}
 }

--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>3.6.22</Version>
+		<Version>3.6.23</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>../ACadSharp.snk</AssemblyOriginatorKeyFile>

--- a/src/ACadSharp/Entities/Arc.cs
+++ b/src/ACadSharp/Entities/Arc.cs
@@ -4,313 +4,316 @@ using CSMath.Geometry;
 using System;
 using System.Collections.Generic;
 
-namespace ACadSharp.Entities
+namespace ACadSharp.Entities;
+
+/// <summary>
+/// Represents a <see cref="Arc"/> entity.
+/// </summary>
+/// <remarks>
+/// Object name <see cref="DxfFileToken.EntityArc"/> <br/>
+/// Dxf class name <see cref="DxfSubclassMarker.Arc"/>
+/// </remarks>
+[DxfName(DxfFileToken.EntityArc)]
+[DxfSubClass(DxfSubclassMarker.Arc)]
+public class Arc : Circle
 {
 	/// <summary>
-	/// Represents a <see cref="Arc"/> entity.
+	/// The end angle in radians.
 	/// </summary>
 	/// <remarks>
-	/// Object name <see cref="DxfFileToken.EntityArc"/> <br/>
-	/// Dxf class name <see cref="DxfSubclassMarker.Arc"/>
+	/// Use 6.28 radians to specify a closed circle or ellipse.
 	/// </remarks>
-	[DxfName(DxfFileToken.EntityArc)]
-	[DxfSubClass(DxfSubclassMarker.Arc)]
-	public class Arc : Circle
+	[DxfCodeValue(DxfReferenceType.IsAngle, 51)]
+	public double EndAngle { get; set; } = Math.PI;
+
+	/// <inheritdoc/>
+	public override string ObjectName => DxfFileToken.EntityArc;
+
+	/// <inheritdoc/>
+	public override ObjectType ObjectType => ObjectType.ARC;
+
+	/// <summary>
+	/// The start angle in radians.
+	/// </summary>
+	[DxfCodeValue(DxfReferenceType.IsAngle, 50)]
+	public double StartAngle { get; set; } = 0.0;
+
+	/// <inheritdoc/>
+	public override string SubclassMarker => DxfSubclassMarker.Arc;
+
+	/// <summary>
+	/// Sweep of the arc, in radians.
+	/// </summary>
+	public double Sweep
 	{
-		/// <summary>
-		/// The end angle in radians.
-		/// </summary>
-		/// <remarks>
-		/// Use 6.28 radians to specify a closed circle or ellipse.
-		/// </remarks>
-		[DxfCodeValue(DxfReferenceType.IsAngle, 51)]
-		public double EndAngle { get; set; } = Math.PI;
-
-		/// <inheritdoc/>
-		public override string ObjectName => DxfFileToken.EntityArc;
-
-		/// <inheritdoc/>
-		public override ObjectType ObjectType => ObjectType.ARC;
-
-		/// <summary>
-		/// The start angle in radians.
-		/// </summary>
-		[DxfCodeValue(DxfReferenceType.IsAngle, 50)]
-		public double StartAngle { get; set; } = 0.0;
-
-		/// <inheritdoc/>
-		public override string SubclassMarker => DxfSubclassMarker.Arc;
-
-		/// <summary>
-		/// Sweep of the arc, in radians.
-		/// </summary>
-		public double Sweep
+		get
 		{
-			get
+			double start = this.StartAngle;
+			double end = this.EndAngle;
+			if (end < start)
 			{
-				double start = this.StartAngle;
-				double end = this.EndAngle;
-				if (end < start)
-				{
-					end += MathHelper.TwoPI;
-				}
-
-				return start - end;
-			}
-		}
-
-		/// <inheritdoc/>
-		public Arc() : base() { }
-
-		/// <summary>
-		/// Initializes a new instance of the <see cref="Arc"/> class.
-		/// </summary>
-		/// <param name="center"></param>
-		/// <param name="radius"></param>
-		/// <param name="start"></param>
-		/// <param name="end"></param>
-		public Arc(XYZ center, double radius, double start, double end) : base()
-		{
-			this.Center = center;
-			this.Radius = radius;
-			this.StartAngle = start;
-			this.EndAngle = end;
-		}
-
-		/// <summary>
-		/// Initializes a new instance of the Arc class that passes through the specified start and end points, is centered at
-		/// the given point, and lies in the plane defined by the specified normal vector.
-		/// </summary>
-		/// <remarks>The arc is constructed in the plane defined by the normal vector, with its center at the
-		/// specified point. The start and end points determine the angular span of the arc. The direction from start to end
-		/// is determined by the order of the points and the orientation of the normal vector.</remarks>
-		/// <param name="center">The center point of the arc. Defines the origin of the arc's circle.</param>
-		/// <param name="start">The start point of the arc. Must lie on the circle defined by the center and radius.</param>
-		/// <param name="end">The end point of the arc. Must lie on the circle defined by the center and radius.</param>
-		/// <param name="normal">The normal vector defining the plane in which the arc lies. Must be a non-zero vector.</param>
-		public Arc(XYZ center, XYZ start, XYZ end, XYZ normal)
-		{
-			this.Normal = normal;
-			this.Center = center;
-			this.Radius = center.DistanceFrom(start);
-
-			this.StartAngle = XYZ.AxisX.GetAngle(start - center, Normal);
-			this.EndAngle = XYZ.AxisX.GetAngle(end - center, Normal);
-		}
-
-		/// <summary>
-		/// Initializes a new instance of the Arc class that passes through the specified center, start, and end points, using
-		/// the default axis of rotation.
-		/// </summary>
-		/// <remarks>This constructor creates an arc in the plane defined by the provided points, using the Z axis as
-		/// the default normal. To specify a different axis of rotation, use the constructor that accepts an axis
-		/// parameter.</remarks>
-		/// <param name="center">The center point of the arc.</param>
-		/// <param name="start">The start point of the arc.</param>
-		/// <param name="end">The end point of the arc.</param>
-		public Arc(XYZ center, XYZ start, XYZ end)
-			: this(center, start, end, XYZ.AxisZ)
-		{
-		}
-
-		/// <summary>
-		/// Creates an arc using 2 points and a bulge.
-		/// </summary>
-		/// <param name="p1"></param>
-		/// <param name="p2"></param>
-		/// <param name="bulge"></param>
-		/// <returns></returns>
-		public static Arc CreateFromBulge(XY p1, XY p2, double bulge)
-		{
-			XY center = GetCenter(p1, p2, bulge, out double r);
-
-			double startAngle;
-			double endAngle;
-			if (bulge < 0)
-			{
-				startAngle = p2.Subtract(center).GetAngle();
-				endAngle = p1.Subtract(center).GetAngle();
-			}
-			else
-			{
-				startAngle = p1.Subtract(center).GetAngle();
-				endAngle = p2.Subtract(center).GetAngle();
+				end += MathHelper.TwoPI;
 			}
 
-			return new Arc
-			{
-				Center = new XYZ(center.X, center.Y, 0),
-				Radius = r,
-				StartAngle = startAngle,
-				EndAngle = endAngle,
-			};
+			return start - end;
+		}
+	}
+
+	/// <inheritdoc/>
+	public Arc() : base() { }
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="Arc"/> class.
+	/// </summary>
+	/// <param name="center"></param>
+	/// <param name="radius"></param>
+	/// <param name="start"></param>
+	/// <param name="end"></param>
+	public Arc(XYZ center, double radius, double start, double end) : base()
+	{
+		this.Center = center;
+		this.Radius = radius;
+		this.StartAngle = start;
+		this.EndAngle = end;
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the Arc class that passes through the specified start and end points, is centered at
+	/// the given point, and lies in the plane defined by the specified normal vector.
+	/// </summary>
+	/// <remarks>The arc is constructed in the plane defined by the normal vector, with its center at the
+	/// specified point. The start and end points determine the angular span of the arc. The direction from start to end
+	/// is determined by the order of the points and the orientation of the normal vector.</remarks>
+	/// <param name="center">The center point of the arc. Defines the origin of the arc's circle.</param>
+	/// <param name="start">The start point of the arc. Must lie on the circle defined by the center and radius.</param>
+	/// <param name="end">The end point of the arc. Must lie on the circle defined by the center and radius.</param>
+	/// <param name="normal">The normal vector defining the plane in which the arc lies. Must be a non-zero vector.</param>
+	public Arc(XYZ center, XYZ start, XYZ end, XYZ normal)
+	{
+		this.Normal = normal;
+		this.Center = center;
+		this.Radius = center.DistanceFrom(start);
+
+		this.StartAngle = XYZ.AxisX.GetAngle(start - center, Normal);
+		this.EndAngle = XYZ.AxisX.GetAngle(end - center, Normal);
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the Arc class that passes through the specified center, start, and end points, using
+	/// the default axis of rotation.
+	/// </summary>
+	/// <remarks>This constructor creates an arc in the plane defined by the provided points, using the Z axis as
+	/// the default normal. To specify a different axis of rotation, use the constructor that accepts an axis
+	/// parameter.</remarks>
+	/// <param name="center">The center point of the arc.</param>
+	/// <param name="start">The start point of the arc.</param>
+	/// <param name="end">The end point of the arc.</param>
+	public Arc(XYZ center, XYZ start, XYZ end)
+		: this(center, start, end, XYZ.AxisZ)
+	{
+	}
+
+	/// <summary>
+	/// Creates an arc using 2 points and a bulge.
+	/// </summary>
+	/// <param name="p1"></param>
+	/// <param name="p2"></param>
+	/// <param name="bulge"></param>
+	/// <returns></returns>
+	public static Arc CreateFromBulge(XY p1, XY p2, double bulge)
+	{
+		XY center = GetCenter(p1, p2, bulge, out double r);
+
+		double startAngle;
+		double endAngle;
+		if (bulge < 0)
+		{
+			startAngle = p2.Subtract(center).GetAngle();
+			endAngle = p1.Subtract(center).GetAngle();
+		}
+		else
+		{
+			startAngle = p1.Subtract(center).GetAngle();
+			endAngle = p2.Subtract(center).GetAngle();
 		}
 
-		/// <summary>
-		/// Calculates the bulge factor for an arc defined by its center, start point, end point, and direction.
-		/// </summary>
-		/// <remarks>The bulge factor is commonly used in geometric and CAD applications to represent arcs in polyline
-		/// definitions.</remarks>
-		/// <param name="center">The center point of the arc.</param>
-		/// <param name="start">The starting point of the arc.</param>
-		/// <param name="end">The ending point of the arc.</param>
-		/// <param name="clockWise">A value indicating whether the arc is drawn in a clockwise direction. <see langword="true"/> if the arc is
-		/// clockwise; otherwise, <see langword="false"/>.</param>
-		/// <returns>The bulge factor of the arc, which represents the tangent of one-fourth of the included angle. A positive value
-		/// indicates a counterclockwise arc, while a negative value indicates a clockwise arc.</returns>
-		internal static double GetBulge(XY center, XY start, XY end, bool clockWise)
+		return new Arc
 		{
+			Center = new XYZ(center.X, center.Y, 0),
+			Radius = r,
+			StartAngle = startAngle,
+			EndAngle = endAngle,
+		};
+	}
 
-			//TODO: add normal //Needed??
+	/// <summary>
+	/// Get the center coordinate from a start, end an a bulge value.
+	/// </summary>
+	/// <param name="start">Start point.</param>
+	/// <param name="end">Ending point.</param>
+	/// <param name="bulge">Bulge.</param>
+	/// <returns>Center of the represented circle.</returns>
+	public static XY GetCenter(XY start, XY end, double bulge)
+	{
+		return GetCenter(start, end, bulge, out _);
+	}
 
-			XY u = start - center;
-			XY u2 = new XY(0.0 - u.Y, u.X);
-			XY v = end - center;
-			double angle = Math.Atan2(x: u.Dot(v), y: u2.Dot(v));
-			if (clockWise)
+	/// <summary>
+	/// Get the center coordinate from a start, end an a bulge value.
+	/// </summary>
+	/// <param name="start">Start point.</param>
+	/// <param name="end">Ending point.</param>
+	/// <param name="bulge">Bulge.</param>
+	/// <param name="radius">Radius of the circle.</param>
+	/// <returns>Center of the represented circle.</returns>
+	public static XY GetCenter(XY start, XY end, double bulge, out double radius)
+	{
+		double theta = 4 * Math.Atan(Math.Abs(bulge));
+		double c = start.DistanceFrom(end) / 2.0;
+		radius = c / Math.Sin(theta / 2.0);
+
+		double gamma = (Math.PI - theta) / 2;
+		double phi = (end - start).GetAngle() + Math.Sign(bulge) * gamma;
+		return new XY(start.X + radius * MathHelper.Cos(phi), start.Y + radius * MathHelper.Sin(phi));
+	}
+
+	/// <inheritdoc/>
+	public override void ApplyTransform(Transform transform)
+	{
+		var normal = this.Normal;
+
+		base.ApplyTransform(transform);
+
+		Matrix3 trans = this.getWorldMatrix(transform, normal, this.Normal, out Matrix3 transOW, out Matrix3 transWO);
+
+		XY start = XY.Rotate(new XY(this.Radius, 0.0), this.StartAngle);
+		XY end = XY.Rotate(new XY(this.Radius, 0.0), this.EndAngle);
+
+		XYZ vStart = transOW * new XYZ(start.X, start.Y, 0.0);
+		vStart = trans * vStart;
+		vStart = transWO * vStart;
+
+		XYZ vEnd = transOW * new XYZ(end.X, end.Y, 0.0);
+		vEnd = trans * vEnd;
+		vEnd = transWO * vEnd;
+
+		XY startPoint = new XY(vStart.X, vStart.Y);
+		XY endPoint = new XY(vEnd.X, vEnd.Y);
+
+		if (Math.Sign(trans.M00 * trans.M11 * trans.M22) < 0)
+		{
+			this.EndAngle = startPoint.GetAngle();
+			this.StartAngle = endPoint.GetAngle();
+		}
+		else
+		{
+			this.StartAngle = startPoint.GetAngle();
+			this.EndAngle = endPoint.GetAngle();
+		}
+
+		this.StartAngle = MathHelper.FixZero(this.StartAngle);
+		this.EndAngle = MathHelper.FixZero(this.EndAngle);
+	}
+
+	/// <inheritdoc/>
+	public override BoundingBox GetBoundingBox()
+	{
+		List<XYZ> vertices = this.PolygonalVertexes(256);
+
+		return BoundingBox.FromPoints(vertices);
+	}
+
+	/// <summary>
+	/// Process the 2 points limiting the arc segment
+	/// </summary>
+	/// <param name="start">Start point of the arc segment</param>
+	/// <param name="end">End point of the arc segment</param>
+	public void GetEndVertices(out XYZ start, out XYZ end)
+	{
+		//Start vector If normal = Z
+		start = new XYZ(MathHelper.Cos(this.StartAngle), MathHelper.Sin(this.StartAngle), 0.0);
+		start = this.Center + this.Radius * start;
+
+		//End vector if normal = Z
+		end = new XYZ(MathHelper.Cos(this.EndAngle), MathHelper.Sin(this.EndAngle), 0.0);
+		end = this.Center + this.Radius * end;
+
+		var t = Matrix4.GetArbitraryAxis(this.Normal);
+
+		start = t * start;
+		end = t * end;
+	}
+
+	/// <summary>
+	/// Converts the arc in a list of vertexes.
+	/// </summary>
+	/// <param name="precision">Number of vertexes generated.</param>
+	/// <returns>A list vertexes that represents the arc expressed in object coordinate system.</returns>
+	public override List<XYZ> PolygonalVertexes(int precision)
+	{
+		if (precision < 2)
+		{
+			throw new ArgumentOutOfRangeException(nameof(precision), precision, "The arc precision must be equal or greater than two.");
+		}
+
+		return CurveExtensions.PolygonalVertexes(
+			precision,
+			this.Center,
+			this.StartAngle,
+			this.EndAngle,
+			this.Radius,
+			this.Normal.Normalize()
+		);
+	}
+
+	public Arc2D ToArc2D()
+	{
+		return new Arc2D(this.Center.Convert<XY>(), this.Radius, this.StartAngle, this.EndAngle);
+	}
+
+	/// <summary>
+	/// Calculates the bulge factor for an arc defined by its center, start point, end point, and direction.
+	/// </summary>
+	/// <remarks>The bulge factor is commonly used in geometric and CAD applications to represent arcs in polyline
+	/// definitions.</remarks>
+	/// <param name="center">The center point of the arc.</param>
+	/// <param name="start">The starting point of the arc.</param>
+	/// <param name="end">The ending point of the arc.</param>
+	/// <param name="clockWise">A value indicating whether the arc is drawn in a clockwise direction. <see langword="true"/> if the arc is
+	/// clockwise; otherwise, <see langword="false"/>.</param>
+	/// <returns>The bulge factor of the arc, which represents the tangent of one-fourth of the included angle. A positive value
+	/// indicates a counterclockwise arc, while a negative value indicates a clockwise arc.</returns>
+	internal static double GetBulge(XY center, XY start, XY end, bool clockWise)
+	{
+		//TODO: add normal //Needed??
+
+		XY u = start - center;
+		XY u2 = new XY(0.0 - u.Y, u.X);
+		XY v = end - center;
+		double angle = Math.Atan2(x: u.Dot(v), y: u2.Dot(v));
+		if (clockWise)
+		{
+			if (angle > 0.0)
 			{
-				if (angle > 0.0)
-				{
-					angle -= MathHelper.PI * 2.0;
-				}
+				angle -= MathHelper.PI * 2.0;
 			}
-			else if (angle < 0.0)
-			{
-				angle += MathHelper.PI * 2.0;
-			}
-
-			return Math.Tan(angle / 4.0);
 		}
-
-		/// <summary>
-		/// Calculates the bulge value corresponding to a given angle.
-		/// </summary>
-		/// <param name="angle">The angle, in radians, for which to calculate the bulge. The angle must be a finite value.</param>
-		/// <returns>The bulge value, which is the tangent of half the angle.</returns>
-		internal static double GetBulgeFromAngle(double angle)
+		else if (angle < 0.0)
 		{
-			// TODO: NEEDED?
-			return Math.Tan(angle / 4);
+			angle += MathHelper.PI * 2.0;
 		}
 
-		/// <summary>
-		/// Get the center coordinate from a start, end an a bulge value.
-		/// </summary>
-		/// <param name="start">Start point.</param>
-		/// <param name="end">Ending point.</param>
-		/// <param name="bulge">Bulge.</param>
-		/// <returns>Center of the represented circle.</returns>
-		public static XY GetCenter(XY start, XY end, double bulge)
-		{
-			return GetCenter(start, end, bulge, out _);
-		}
+		return Math.Tan(angle / 4.0);
+	}
 
-		/// <summary>
-		/// Get the center coordinate from a start, end an a bulge value.
-		/// </summary>
-		/// <param name="start">Start point.</param>
-		/// <param name="end">Ending point.</param>
-		/// <param name="bulge">Bulge.</param>
-		/// <param name="radius">Radius of the circle.</param>
-		/// <returns>Center of the represented circle.</returns>
-		public static XY GetCenter(XY start, XY end, double bulge, out double radius)
-		{
-			double theta = 4 * Math.Atan(Math.Abs(bulge));
-			double c = start.DistanceFrom(end) / 2.0;
-			radius = c / Math.Sin(theta / 2.0);
-
-			double gamma = (Math.PI - theta) / 2;
-			double phi = (end - start).GetAngle() + Math.Sign(bulge) * gamma;
-			return new XY(start.X + radius * MathHelper.Cos(phi), start.Y + radius * MathHelper.Sin(phi));
-		}
-
-		/// <inheritdoc/>
-		public override void ApplyTransform(Transform transform)
-		{
-			var normal = this.Normal;
-
-			base.ApplyTransform(transform);
-
-			Matrix3 trans = this.getWorldMatrix(transform, normal, this.Normal, out Matrix3 transOW, out Matrix3 transWO);
-
-			XY start = XY.Rotate(new XY(this.Radius, 0.0), this.StartAngle);
-			XY end = XY.Rotate(new XY(this.Radius, 0.0), this.EndAngle);
-
-			XYZ vStart = transOW * new XYZ(start.X, start.Y, 0.0);
-			vStart = trans * vStart;
-			vStart = transWO * vStart;
-
-			XYZ vEnd = transOW * new XYZ(end.X, end.Y, 0.0);
-			vEnd = trans * vEnd;
-			vEnd = transWO * vEnd;
-
-			XY startPoint = new XY(vStart.X, vStart.Y);
-			XY endPoint = new XY(vEnd.X, vEnd.Y);
-
-			if (Math.Sign(trans.M00 * trans.M11 * trans.M22) < 0)
-			{
-				this.EndAngle = startPoint.GetAngle();
-				this.StartAngle = endPoint.GetAngle();
-			}
-			else
-			{
-				this.StartAngle = startPoint.GetAngle();
-				this.EndAngle = endPoint.GetAngle();
-			}
-
-			this.StartAngle = MathHelper.FixZero(this.StartAngle);
-			this.EndAngle = MathHelper.FixZero(this.EndAngle);
-		}
-
-		/// <inheritdoc/>
-		public override BoundingBox GetBoundingBox()
-		{
-			List<XYZ> vertices = this.PolygonalVertexes(256);
-
-			return BoundingBox.FromPoints(vertices);
-		}
-
-		/// <summary>
-		/// Process the 2 points limiting the arc segment
-		/// </summary>
-		/// <param name="start">Start point of the arc segment</param>
-		/// <param name="end">End point of the arc segment</param>
-		public void GetEndVertices(out XYZ start, out XYZ end)
-		{
-			//Start vector If normal = Z
-			start = new XYZ(MathHelper.Cos(this.StartAngle), MathHelper.Sin(this.StartAngle), 0.0);
-			start = this.Center + this.Radius * start;
-
-			//End vector if normal = Z
-			end = new XYZ(MathHelper.Cos(this.EndAngle), MathHelper.Sin(this.EndAngle), 0.0);
-			end = this.Center + this.Radius * end;
-
-			var t = Matrix4.GetArbitraryAxis(this.Normal);
-
-			start = t * start;
-			end = t * end;
-		}
-
-		/// <summary>
-		/// Converts the arc in a list of vertexes.
-		/// </summary>
-		/// <param name="precision">Number of vertexes generated.</param>
-		/// <returns>A list vertexes that represents the arc expressed in object coordinate system.</returns>
-		public override List<XYZ> PolygonalVertexes(int precision)
-		{
-			if (precision < 2)
-			{
-				throw new ArgumentOutOfRangeException(nameof(precision), precision, "The arc precision must be equal or greater than two.");
-			}
-
-			return CurveExtensions.PolygonalVertexes(
-				precision,
-				this.Center,
-				this.StartAngle,
-				this.EndAngle,
-				this.Radius,
-				this.Normal.Normalize()
-			);
-		}
+	/// <summary>
+	/// Calculates the bulge value corresponding to a given angle.
+	/// </summary>
+	/// <param name="angle">The angle, in radians, for which to calculate the bulge. The angle must be a finite value.</param>
+	/// <returns>The bulge value, which is the tangent of half the angle.</returns>
+	internal static double GetBulgeFromAngle(double angle)
+	{
+		// TODO: NEEDED?
+		return Math.Tan(angle / 4);
 	}
 }

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.Arc.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.Arc.cs
@@ -1,161 +1,181 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Geometry;
 using System;
 using System.Collections.Generic;
 
-namespace ACadSharp.Entities
+namespace ACadSharp.Entities;
+
+public partial class Hatch
 {
-	public partial class Hatch
+	public partial class BoundaryPath
 	{
-		public partial class BoundaryPath
+		public class Arc : Edge
 		{
-			public class Arc : Edge
+			/// <summary>
+			/// Center point (in OCS).
+			/// </summary>
+			[DxfCodeValue(10, 20)]
+			public XY Center { get; set; }
+
+			/// <summary>
+			/// Is counterclockwise flag.
+			/// </summary>
+			[DxfCodeValue(73)]
+			public bool CounterClockWise { get; set; }
+
+			/// <summary>
+			/// End angle.
+			/// </summary>
+			[DxfCodeValue(DxfReferenceType.IsAngle, 51)]
+			public double EndAngle { get; set; }
+
+			/// <summary>
+			/// Radius.
+			/// </summary>
+			/// <remarks>
+			/// For the ellipse this is the length of minor axis (percentage of major axis length).
+			/// </remarks>
+			[DxfCodeValue(40)]
+			public double Radius { get; set; }
+
+			/// <summary>
+			/// Start angle.
+			/// </summary>
+			[DxfCodeValue(DxfReferenceType.IsAngle, 50)]
+			public double StartAngle { get; set; }
+
+			/// <inheritdoc/>
+			public override EdgeType Type => EdgeType.CircularArc;
+
+			/// <summary>
+			/// Initializes a new instance of the Arc class.
+			/// </summary>
+			public Arc()
+			{ }
+
+			/// <summary>
+			/// Initializes a new instance of the Arc class based on the specified circle or arc geometry.
+			/// </summary>
+			/// <remarks>
+			/// If the provided circle is an arc, the arc's center, radius, start angle, and end angle are
+			/// used. If the provided circle is a full circle, the arc will represent a full circle with a start angle of 0 and
+			/// an end angle of 2π. The arc is always constructed in a counterclockwise direction.
+			/// </remarks>
+			/// <param name="circle">The circle or arc from which to construct the arc. Must not be null.</param>
+			public Arc(Circle circle)
 			{
-				/// <summary>
-				/// Center point (in OCS).
-				/// </summary>
-				[DxfCodeValue(10, 20)]
-				public XY Center { get; set; }
-
-				/// <summary>
-				/// Is counterclockwise flag.
-				/// </summary>
-				[DxfCodeValue(73)]
-				public bool CounterClockWise { get; set; }
-
-				/// <summary>
-				/// End angle.
-				/// </summary>
-				[DxfCodeValue(DxfReferenceType.IsAngle, 51)]
-				public double EndAngle { get; set; }
-
-				/// <summary>
-				/// Radius.
-				/// </summary>
-				/// <remarks>
-				/// For the ellipse this is the length of minor axis (percentage of major axis length).
-				/// </remarks>
-				[DxfCodeValue(40)]
-				public double Radius { get; set; }
-
-				/// <summary>
-				/// Start angle.
-				/// </summary>
-				[DxfCodeValue(DxfReferenceType.IsAngle, 50)]
-				public double StartAngle { get; set; }
-
-				/// <inheritdoc/>
-				public override EdgeType Type => EdgeType.CircularArc;
-
-				/// <summary>
-				/// Initializes a new instance of the Arc class.
-				/// </summary>
-				public Arc() { }
-
-				/// <summary>
-				/// Initializes a new instance of the Arc class based on the specified circle or arc geometry.
-				/// </summary>
-				/// <remarks>
-				/// If the provided circle is an arc, the arc's center, radius, start angle, and end angle are
-				/// used. If the provided circle is a full circle, the arc will represent a full circle with a start angle of 0 and
-				/// an end angle of 2π. The arc is always constructed in a counterclockwise direction.
-				/// </remarks>
-				/// <param name="circle">The circle or arc from which to construct the arc. Must not be null.</param>
-				public Arc(Circle circle)
+				XYZ point;
+				Matrix3 trans = Matrix3.ArbitraryAxis(circle.Normal).Transpose();
+				switch (circle)
 				{
-					XYZ point;
-					Matrix3 trans = Matrix3.ArbitraryAxis(circle.Normal).Transpose();
-					switch (circle)
-					{
-						case Entities.Arc arc:
-							point = trans * arc.Center;
-							this.Center = new XY(point.X, point.Y);
-							this.Radius = arc.Radius;
-							this.StartAngle = arc.StartAngle;
-							this.EndAngle = arc.EndAngle;
-							this.CounterClockWise = true;
-							break;
-						case Circle:
-							point = trans * circle.Center;
-							this.Center = new XY(point.X, point.Y);
-							this.Radius = circle.Radius;
-							this.StartAngle = 0.0;
-							this.EndAngle = MathHelper.TwoPI;
-							this.CounterClockWise = true;
-							break;
-					}
+					case Entities.Arc arc:
+						point = trans * arc.Center;
+						this.Center = new XY(point.X, point.Y);
+						this.Radius = arc.Radius;
+						this.StartAngle = arc.StartAngle;
+						this.EndAngle = arc.EndAngle;
+						this.CounterClockWise = true;
+						break;
+					case Circle:
+						point = trans * circle.Center;
+						this.Center = new XY(point.X, point.Y);
+						this.Radius = circle.Radius;
+						this.StartAngle = 0.0;
+						this.EndAngle = MathHelper.TwoPI;
+						this.CounterClockWise = true;
+						break;
+				}
+			}
+
+			/// <inheritdoc/>
+			public override void ApplyTransform(Transform transform)
+			{
+				double num = this.Radius;
+				double num2 = this.StartAngle;
+				double num3 = this.EndAngle;
+				bool flag = this.CounterClockWise;
+				this.Center = transform.ApplyTransform(this.Center.Convert<XYZ>()).Convert<XY>();
+				this.Radius = transform.ApplyTransform(new XYZ(this.Radius, 0.0, 0.0)).GetLength();
+
+				if (!this.CounterClockWise)
+				{
+					this.StartAngle = 0.0 - this.StartAngle;
+					this.EndAngle = 0.0 - this.EndAngle;
 				}
 
-				/// <inheritdoc/>
-				public override void ApplyTransform(Transform transform)
+				XYZ vstart = new XYZ(Math.Cos(StartAngle), Math.Sin(StartAngle), 0);
+				XYZ vend = new XYZ(Math.Cos(EndAngle), Math.Sin(EndAngle), 0);
+
+				vstart = transform.ApplyTransform(vstart);
+				this.StartAngle = Math.Atan2(vstart.Y, vstart.X);
+
+				vend = transform.ApplyTransform(vend);
+				this.EndAngle = Math.Atan2(vend.Y, vend.X);
+
+				if (!this.CounterClockWise)
 				{
-					double num = this.Radius;
-					double num2 = this.StartAngle;
-					double num3 = this.EndAngle;
-					bool flag = this.CounterClockWise;
-					this.Center = transform.ApplyTransform(this.Center.Convert<XYZ>()).Convert<XY>();
-					this.Radius = transform.ApplyTransform(new XYZ(this.Radius, 0.0, 0.0)).GetLength();
-
-					if (!this.CounterClockWise)
-					{
-						this.StartAngle = 0.0 - this.StartAngle;
-						this.EndAngle = 0.0 - this.EndAngle;
-					}
-
-					XYZ vstart = new XYZ(Math.Cos(StartAngle), Math.Sin(StartAngle), 0);
-					XYZ vend = new XYZ(Math.Cos(EndAngle), Math.Sin(EndAngle), 0);
-
-					vstart = transform.ApplyTransform(vstart);
-					this.StartAngle = Math.Atan2(vstart.Y, vstart.X);
-
-					vend = transform.ApplyTransform(vend);
-					this.EndAngle = Math.Atan2(vend.Y, vend.X);
-
-					if (!this.CounterClockWise)
-					{
-						this.StartAngle = 0.0 - this.StartAngle;
-						this.EndAngle = 0.0 - this.EndAngle;
-					}
+					this.StartAngle = 0.0 - this.StartAngle;
+					this.EndAngle = 0.0 - this.EndAngle;
 				}
+			}
 
-				/// <inheritdoc/>
-				public override BoundingBox GetBoundingBox()
+			/// <inheritdoc/>
+			public override IEnumerable<XY> FindIntersections(Line2D line)
+			{
+				var arc = this.ToArc2D();
+				return arc.FindIntersections(line);
+			}
+
+			/// <inheritdoc/>
+			public override BoundingBox GetBoundingBox()
+			{
+				return ((Entities.Arc)this.ToEntity()).GetBoundingBox();
+			}
+
+			/// <summary>
+			/// Converts the arc in a list of vertexes.
+			/// </summary>
+			/// <param name="precision">Number of vertexes generated.</param>
+			/// <returns>A list vertexes that represents the arc expressed in object coordinate system.</returns>
+			public List<XYZ> PolygonalVertexes(int precision)
+			{
+				return ((Entities.Arc)this.ToEntity()).PolygonalVertexes(precision);
+			}
+
+			public Arc2D ToArc2D()
+			{
+				if (this.CounterClockWise)
 				{
-					return ((Entities.Arc)this.ToEntity()).GetBoundingBox();
+					return new Arc2D(this.Center, this.Radius, this.EndAngle, this.StartAngle);
 				}
-
-				/// <summary>
-				/// Converts the arc in a list of vertexes.
-				/// </summary>
-				/// <param name="precision">Number of vertexes generated.</param>
-				/// <returns>A list vertexes that represents the arc expressed in object coordinate system.</returns>
-				public List<XYZ> PolygonalVertexes(int precision)
+				else
 				{
-					return ((Entities.Arc)this.ToEntity()).PolygonalVertexes(precision);
+					return new Arc2D(this.Center, this.Radius, this.StartAngle, this.EndAngle);
 				}
+			}
 
-				/// <inheritdoc/>
-				public override Entity ToEntity()
+			/// <inheritdoc/>
+			public override Entity ToEntity()
+			{
+				if (this.CounterClockWise)
 				{
-					if (this.CounterClockWise)
-					{
-						return new ACadSharp.Entities.Arc
-						{
-							Center = (XYZ)this.Center,
-							Radius = this.Radius,
-							StartAngle = this.StartAngle,
-							EndAngle = this.EndAngle
-						};
-					}
-
 					return new ACadSharp.Entities.Arc
 					{
 						Center = (XYZ)this.Center,
 						Radius = this.Radius,
-						StartAngle = 2 * Math.PI - this.EndAngle,
-						EndAngle = 2 * Math.PI - this.StartAngle
+						StartAngle = this.StartAngle,
+						EndAngle = this.EndAngle
 					};
 				}
+
+				return new ACadSharp.Entities.Arc
+				{
+					Center = (XYZ)this.Center,
+					Radius = this.Radius,
+					StartAngle = 2 * Math.PI - this.EndAngle,
+					EndAngle = 2 * Math.PI - this.StartAngle
+				};
 			}
 		}
 	}

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.Arc.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.Arc.cs
@@ -3,6 +3,7 @@ using CSMath;
 using CSMath.Geometry;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ACadSharp.Entities;
 
@@ -123,8 +124,32 @@ public partial class Hatch
 			/// <inheritdoc/>
 			public override IEnumerable<XY> FindIntersections(Line2D line)
 			{
-				var arc = this.ToArc2D();
-				return arc.FindIntersections(line);
+				List<XYZ> pts = this.PolygonalVertexes(256);
+				if (pts.Count == 0)
+				{
+					yield break;
+				}
+
+				Segment2D s;
+				XY intersection;
+				for (int i = 0; i < pts.Count - 1; i++)
+				{
+					s = new Segment2D(pts[i].Convert<XY>(), pts[i + 1].Convert<XY>());
+					if (s.TryFindIntersection(line, out intersection))
+					{
+						yield return intersection;
+					}
+				}
+
+				s = new Segment2D(pts.Last().Convert<XY>(), pts.First().Convert<XY>());
+				if (s.TryFindIntersection(line, out intersection))
+				{
+					yield return intersection;
+				}
+
+				//TODO: improve the method by calculating the intersection between the line and the arc directly, without the need of generating a list of vertexes.
+				//var arc = this.ToArc2D();
+				//return arc.FindIntersections(line);
 			}
 
 			/// <inheritdoc/>

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.Edge.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.Edge.cs
@@ -1,54 +1,62 @@
 ﻿using CSMath;
+using CSMath.Geometry;
+using System.Collections.Generic;
 
-namespace ACadSharp.Entities
+namespace ACadSharp.Entities;
+
+public partial class Hatch
 {
-	public partial class Hatch
+	/// <summary>
+	/// Defines a hatch boundary.
+	/// </summary>
+	public partial class BoundaryPath
 	{
-		/// <summary>
-		/// Defines a hatch boundary.
-		/// </summary>
-		public partial class BoundaryPath
+		public enum EdgeType
 		{
-			public enum EdgeType
+			/// <remarks>
+			/// Not included in the documentation.
+			/// </remarks>
+			Polyline = 0,
+			Line = 1,
+			CircularArc = 2,
+			EllipticArc = 3,
+			Spline = 4,
+		}
+
+		public abstract class Edge : IGeometricEntity
+		{
+			/// <summary>
+			/// Edge type.
+			/// </summary>
+			public abstract EdgeType Type { get; }
+
+			/// <inheritdoc/>
+			public abstract void ApplyTransform(Transform transform);
+
+			/// <summary>
+			/// Creates a new object that is a copy of the current instance.
+			/// </summary>
+			/// <returns></returns>
+			public virtual Edge Clone()
 			{
-				/// <remarks>
-				/// Not included in the documentation.
-				/// </remarks>
-				Polyline = 0,
-				Line = 1,
-				CircularArc = 2,
-				EllipticArc = 3,
-				Spline = 4,
+				return (Edge)this.MemberwiseClone();
 			}
 
-			public abstract class Edge : IGeometricEntity
-			{
-				/// <summary>
-				/// Edge type.
-				/// </summary>
-				public abstract EdgeType Type { get; }
+			/// <inheritdoc/>
+			public abstract BoundingBox GetBoundingBox();
 
-				/// <inheritdoc/>
-				public abstract void ApplyTransform(Transform transform);
+			/// <summary>
+			/// Create the equivalent entity for this Edge.
+			/// </summary>
+			/// <returns></returns>
+			public abstract Entity ToEntity();
 
-				/// <summary>
-				/// Creates a new object that is a copy of the current instance.
-				/// </summary>
-				/// <returns></returns>
-				public virtual Edge Clone()
-				{
-					return (Edge)this.MemberwiseClone();
-				}
-
-				/// <inheritdoc/>
-				public abstract BoundingBox GetBoundingBox();
-
-				/// <summary>
-				/// Create the equivalent entity for this Edge.
-				/// </summary>
-				/// <returns></returns>
-				public abstract Entity ToEntity();
-			}
+			/// <summary>
+			/// Find the intersection points between this edge and a line. The line is expressed in the object coordinate system of the edge.
+			/// </summary>
+			/// <param name="line">The line to find intersections with.</param>
+			/// <returns>An enumerable of intersection points.</returns>
+			public abstract IEnumerable<XY> FindIntersections(Line2D line);
 		}
 	}
 }

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.Ellipse.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.Ellipse.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Geometry;
 using System;
 using System.Collections.Generic;
 
@@ -142,6 +143,11 @@ public partial class Hatch
 				ellipse.RadiusRatio = this.RadiusRatio;
 
 				return ellipse;
+			}
+
+			public override IEnumerable<XY> FindIntersections(Line2D line)
+			{
+				throw new NotImplementedException();
 			}
 		}
 	}

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.Ellipse.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.Ellipse.cs
@@ -3,6 +3,7 @@ using CSMath;
 using CSMath.Geometry;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ACadSharp.Entities;
 
@@ -145,9 +146,31 @@ public partial class Hatch
 				return ellipse;
 			}
 
+			/// <inheritdoc/>
 			public override IEnumerable<XY> FindIntersections(Line2D line)
 			{
-				throw new NotImplementedException();
+				List<XYZ> pts = this.PolygonalVertexes(256);
+				if (pts.Count == 0)
+				{
+					yield break;
+				}
+
+				Segment2D s;
+				XY intersection;
+				for (int i = 0; i < pts.Count - 1; i++)
+				{
+					s = new Segment2D(pts[i].Convert<XY>(), pts[i + 1].Convert<XY>());
+					if (s.TryFindIntersection(line, out intersection))
+					{
+						yield return intersection;
+					}
+				}
+
+				s = new Segment2D(pts.Last().Convert<XY>(), pts.First().Convert<XY>());
+				if (s.TryFindIntersection(line, out intersection))
+				{
+					yield return intersection;
+				}
 			}
 		}
 	}

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.Line.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.Line.cs
@@ -62,7 +62,14 @@ public partial class Hatch
 			/// <inheritdoc/>
 			public override IEnumerable<XY> FindIntersections(Line2D line)
 			{
-				return new[] { this.ToSegment2D().FindIntersection(line) };
+				if (this.ToSegment2D().TryFindIntersection(line, out XY intersection))
+				{
+					return new[] { intersection };
+				}
+				else
+				{
+					return [];
+				}
 			}
 
 			public Segment2D ToSegment2D()

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.Line.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.Line.cs
@@ -1,61 +1,73 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Geometry;
+using System.Collections.Generic;
 
-namespace ACadSharp.Entities
+namespace ACadSharp.Entities;
+
+public partial class Hatch
 {
-	public partial class Hatch
+	public partial class BoundaryPath
 	{
-		public partial class BoundaryPath
+		public class Line : Edge
 		{
-			public class Line : Edge
+			/// <summary>
+			/// Endpoint (in OCS)
+			/// </summary>
+			[DxfCodeValue(11, 21)]
+			public XY End { get; set; }
+
+			/// <summary>
+			/// Start point (in OCS)
+			/// </summary>
+			[DxfCodeValue(10, 20)]
+			public XY Start { get; set; }
+
+			public override EdgeType Type => EdgeType.Line;
+
+			/// <summary>
+			/// Initializes a new instance of the Line class.
+			/// </summary>
+			public Line() { }
+
+			/// <summary>
+			/// Initializes a new instance of the Line class using the specified line entity.
+			/// </summary>
+			/// <param name="line">The line entity from which to initialize the start and end points. Cannot be null.</param>
+			public Line(Entities.Line line)
 			{
-				/// <summary>
-				/// Endpoint (in OCS)
-				/// </summary>
-				[DxfCodeValue(11, 21)]
-				public XY End { get; set; }
+				this.Start = line.StartPoint.Convert<XY>();
+				this.End = line.EndPoint.Convert<XY>();
+			}
 
-				/// <summary>
-				/// Start point (in OCS)
-				/// </summary>
-				[DxfCodeValue(10, 20)]
-				public XY Start { get; set; }
+			/// <inheritdoc/>
+			public override void ApplyTransform(Transform transform)
+			{
+				this.Start = transform.ApplyTransform(this.Start.Convert<XYZ>()).Convert<XY>();
+				this.End = transform.ApplyTransform(this.End.Convert<XYZ>()).Convert<XY>();
+			}
 
-				public override EdgeType Type => EdgeType.Line;
+			/// <inheritdoc/>
+			public override BoundingBox GetBoundingBox()
+			{
+				return BoundingBox.FromPoints([(XYZ)this.Start, (XYZ)this.End]);
+			}
 
-				/// <summary>
-				/// Initializes a new instance of the Line class.
-				/// </summary>
-				public Line() { }
+			/// <inheritdoc/>
+			public override Entity ToEntity()
+			{
+				return new Entities.Line(this.Start, this.End);
+			}
 
-				/// <summary>
-				/// Initializes a new instance of the Line class using the specified line entity.
-				/// </summary>
-				/// <param name="line">The line entity from which to initialize the start and end points. Cannot be null.</param>
-				public Line(Entities.Line line)
-				{
-					this.Start = line.StartPoint.Convert<XY>();
-					this.End = line.EndPoint.Convert<XY>();
-				}
+			/// <inheritdoc/>
+			public override IEnumerable<XY> FindIntersections(Line2D line)
+			{
+				return new[] { this.ToSegment2D().FindIntersection(line) };
+			}
 
-				/// <inheritdoc/>
-				public override void ApplyTransform(Transform transform)
-				{
-					this.Start = transform.ApplyTransform(this.Start.Convert<XYZ>()).Convert<XY>();
-					this.End = transform.ApplyTransform(this.End.Convert<XYZ>()).Convert<XY>();
-				}
-
-				/// <inheritdoc/>
-				public override BoundingBox GetBoundingBox()
-				{
-					return BoundingBox.FromPoints([(XYZ)this.Start, (XYZ)this.End]);
-				}
-
-				/// <inheritdoc/>
-				public override Entity ToEntity()
-				{
-					return new Entities.Line(this.Start, this.End);
-				}
+			public Segment2D ToSegment2D()
+			{
+				return new Segment2D(this.Start, this.End);
 			}
 		}
 	}

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.Polyline.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.Polyline.cs
@@ -1,129 +1,151 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Geometry;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace ACadSharp.Entities
+namespace ACadSharp.Entities;
+
+public partial class Hatch
 {
-	public partial class Hatch
+	public partial class BoundaryPath
 	{
-		public partial class BoundaryPath
+		public class Polyline : Edge
 		{
-			public class Polyline : Edge
+			/// <summary>
+			/// Bulges applied to each vertice, the number of bulges must be equal to the vertices or empty.
+			/// </summary>
+			/// <remarks>
+			/// default value, 0 if not set
+			/// </remarks>
+			[DxfCodeValue(DxfReferenceType.Optional, 42)]
+			public IEnumerable<double> Bulges { get { return this.Vertices.Select(v => v.Z); } }
+
+			/// <summary>
+			/// The polyline has bulges with value different than 0.
+			/// </summary>
+			[DxfCodeValue(72)]
+			public bool HasBulge => this.Bulges.Any(b => b != 0);
+
+			/// <summary>
+			/// Is closed flag.
+			/// </summary>
+			[DxfCodeValue(73)]
+			public bool IsClosed { get; set; }
+
+			/// <inheritdoc/>
+			public override EdgeType Type => EdgeType.Polyline;
+
+			/// <summary>
+			/// Position values are only X and Y.
+			/// </summary>
+			/// <remarks>
+			/// The vertex bulge is stored in the Z component.
+			/// </remarks>
+			[DxfCodeValue(DxfReferenceType.Count, 93)]
+			public List<XYZ> Vertices { get; private set; } = new();
+
+			/// <summary>
+			/// Initializes a new instance of the Polyline class.
+			/// </summary>
+			public Polyline()
+			{ }
+
+			/// <summary>
+			/// Initializes a new instance of the Polyline class with the specified vertices and closure state.
+			/// </summary>
+			/// <param name="vertices">The collection of points that define the vertices of the polyline. The order of the points determines the
+			/// sequence of the polyline's segments. Cannot be null or empty.</param>
+			/// <param name="isClosed">true to create a closed polyline where the last vertex connects to the first; otherwise, false.</param>
+			public Polyline(IEnumerable<XYZ> vertices, bool isClosed = true)
 			{
-				/// <summary>
-				/// Bulges applied to each vertice, the number of bulges must be equal to the vertices or empty.
-				/// </summary>
-				/// <remarks>
-				/// default value, 0 if not set
-				/// </remarks>
-				[DxfCodeValue(DxfReferenceType.Optional, 42)]
-				public IEnumerable<double> Bulges { get { return this.Vertices.Select(v => v.Z); } }
+				this.Vertices.AddRange(vertices);
+				this.IsClosed = isClosed;
+			}
 
-				/// <summary>
-				/// The polyline has bulges with value different than 0.
-				/// </summary>
-				[DxfCodeValue(72)]
-				public bool HasBulge => this.Bulges.Any(b => b != 0);
-
-				/// <summary>
-				/// Is closed flag.
-				/// </summary>
-				[DxfCodeValue(73)]
-				public bool IsClosed { get; set; }
-
-				/// <inheritdoc/>
-				public override EdgeType Type => EdgeType.Polyline;
-
-				/// <summary>
-				/// Position values are only X and Y.
-				/// </summary>
-				/// <remarks>
-				/// The vertex bulge is stored in the Z component.
-				/// </remarks>
-				[DxfCodeValue(DxfReferenceType.Count, 93)]
-				public List<XYZ> Vertices { get; private set; } = new();
-
-				/// <summary>
-				/// Initializes a new instance of the Polyline class.
-				/// </summary>
-				public Polyline()
-				{ }
-
-				/// <summary>
-				/// Initializes a new instance of the Polyline class with the specified vertices and closure state.
-				/// </summary>
-				/// <param name="vertices">The collection of points that define the vertices of the polyline. The order of the points determines the
-				/// sequence of the polyline's segments. Cannot be null or empty.</param>
-				/// <param name="isClosed">true to create a closed polyline where the last vertex connects to the first; otherwise, false.</param>
-				public Polyline(IEnumerable<XYZ> vertices, bool isClosed = true)
+			/// <summary>
+			/// Initializes a new instance of the Polyline class by copying the vertices and closed state from the specified
+			/// polyline.
+			/// </summary>
+			/// <param name="polyline">The source polyline whose vertices and closed state are used to initialize the new instance. Cannot be null.</param>
+			public Polyline(IPolyline polyline)
+			{
+				foreach (var v in polyline.Vertices)
 				{
-					this.Vertices.AddRange(vertices);
-					this.IsClosed = isClosed;
+					XY xy = v.Location.Convert<XY>();
+					this.Vertices.Add(new XYZ(xy.X, xy.Y, v.Bulge));
 				}
 
-				/// <summary>
-				/// Initializes a new instance of the Polyline class by copying the vertices and closed state from the specified
-				/// polyline.
-				/// </summary>
-				/// <param name="polyline">The source polyline whose vertices and closed state are used to initialize the new instance. Cannot be null.</param>
-				public Polyline(IPolyline polyline)
-				{
-					foreach (var v in polyline.Vertices)
-					{
-						XY xy = v.Location.Convert<XY>();
-						this.Vertices.Add(new XYZ(xy.X, xy.Y, v.Bulge));
-					}
+				this.IsClosed = polyline.IsClosed;
+			}
 
-					this.IsClosed = polyline.IsClosed;
+			/// <inheritdoc/>
+			public override void ApplyTransform(Transform transform)
+			{
+				var arr = this.Vertices.ToArray();
+				this.Vertices.Clear();
+				for (int i = 0; i < arr.Length; i++)
+				{
+					var bulge = arr[i].Z;
+					var v = transform.ApplyTransform(arr[i]);
+					v.Z = bulge;
+
+					this.Vertices.Add(v);
 				}
+			}
 
-				/// <inheritdoc/>
-				public override void ApplyTransform(Transform transform)
+			/// <inheritdoc/>
+			public override Edge Clone()
+			{
+				Polyline clone = (Polyline)base.Clone();
+
+				clone.Vertices = new List<XYZ>(this.Vertices);
+
+				return clone;
+			}
+
+			/// <inheritdoc/>
+			public override IEnumerable<XY> FindIntersections(Line2D line)
+			{
+				for (int i = 0; i < this.Vertices.Count - 1; i++)
 				{
-					var arr = this.Vertices.ToArray();
-					this.Vertices.Clear();
-					for (int i = 0; i < arr.Length; i++)
+					var curr = new Segment2D(this.Vertices[i].Convert<XY>(), this.Vertices[i + 1].Convert<XY>());
+					if (curr.TryFindIntersection(line, out XY intersection))
 					{
-						var bulge = arr[i].Z;
-						var v = transform.ApplyTransform(arr[i]);
-						v.Z = bulge;
-
-						this.Vertices.Add(v);
+						yield return intersection;
 					}
 				}
 
-				/// <inheritdoc/>
-				public override Edge Clone()
+				if (this.IsClosed)
 				{
-					Polyline clone = (Polyline)base.Clone();
-
-					clone.Vertices = new List<XYZ>(Vertices);
-
-					return clone;
-				}
-
-				/// <inheritdoc/>
-				public override BoundingBox GetBoundingBox()
-				{
-					return BoundingBox.FromPoints(this.Vertices);
-				}
-
-				/// <inheritdoc/>
-				public override Entity ToEntity()
-				{
-					List<Vertex> vertices = new();
-					foreach (XYZ v in this.Vertices)
+					var curr = new Segment2D(this.Vertices.First().Convert<XY>(), this.Vertices.Last().Convert<XY>());
+					if (curr.TryFindIntersection(line, out XY intersection))
 					{
-						var vertex = new Vertex2D(v.Convert<XY>())
-						{
-							Bulge = v.Z,
-						};
-						vertices.Add(vertex);
+						yield return intersection;
 					}
-
-					return new Polyline2D(vertices.Cast<Vertex2D>(), this.IsClosed);
 				}
+			}
+
+			/// <inheritdoc/>
+			public override BoundingBox GetBoundingBox()
+			{
+				return BoundingBox.FromPoints(this.Vertices);
+			}
+
+			/// <inheritdoc/>
+			public override Entity ToEntity()
+			{
+				List<Vertex> vertices = new();
+				foreach (XYZ v in this.Vertices)
+				{
+					var vertex = new Vertex2D(v.Convert<XY>())
+					{
+						Bulge = v.Z,
+					};
+					vertices.Add(vertex);
+				}
+
+				return new Polyline2D(vertices.Cast<Vertex2D>(), this.IsClosed);
 			}
 		}
 	}

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.Polyline.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.Polyline.cs
@@ -1,4 +1,5 @@
 ﻿using ACadSharp.Attributes;
+using ACadSharp.Extensions;
 using CSMath;
 using CSMath.Geometry;
 using System.Collections.Generic;
@@ -107,21 +108,27 @@ public partial class Hatch
 			/// <inheritdoc/>
 			public override IEnumerable<XY> FindIntersections(Line2D line)
 			{
-				for (int i = 0; i < this.Vertices.Count - 1; i++)
-				{
-					var curr = new Segment2D(this.Vertices[i].Convert<XY>(), this.Vertices[i + 1].Convert<XY>());
-					if (curr.TryFindIntersection(line, out XY intersection))
-					{
-						yield return intersection;
-					}
-				}
+				var pline = this.ToEntity() as Polyline2D;
+				var entities = pline.Explode();
 
-				if (this.IsClosed)
+				foreach (var entity in entities)
 				{
-					var curr = new Segment2D(this.Vertices.First().Convert<XY>(), this.Vertices.Last().Convert<XY>());
-					if (curr.TryFindIntersection(line, out XY intersection))
+					if (entity is Entities.Line l)
 					{
-						yield return intersection;
+						var s = l.ToSegment3D();
+						var seg2d = new Segment2D(s.Origin.Convert<XY>(), s.End.Convert<XY>());
+						if (seg2d.TryFindIntersection(line, out XY intersection))
+						{
+							yield return intersection;
+						}
+					}
+					else if (entity is Entities.Arc arc)
+					{
+						var a = arc.ToArc2D();
+						foreach (var intersection in a.FindIntersections(line))
+						{
+							yield return intersection;
+						}
 					}
 				}
 			}

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.Spline.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.Spline.cs
@@ -138,7 +138,28 @@ public partial class Hatch
 			/// <inheritdoc/>
 			public override IEnumerable<XY> FindIntersections(Line2D line)
 			{
-				throw new NotImplementedException();
+				List<XYZ> pts = this.PolygonalVertexes(256);
+				if (pts.Count == 0)
+				{
+					yield break;
+				}
+
+				Segment2D s;
+				XY intersection;
+				for (int i = 0; i < pts.Count - 1; i++)
+				{
+					s = new Segment2D(pts[i].Convert<XY>(), pts[i + 1].Convert<XY>());
+					if (s.TryFindIntersection(line, out intersection))
+					{
+						yield return intersection;
+					}
+				}
+
+				s = new Segment2D(pts.Last().Convert<XY>(), pts.First().Convert<XY>());
+				if (s.TryFindIntersection(line, out intersection))
+				{
+					yield return intersection;
+				}
 			}
 
 			/// <inheritdoc/>
@@ -162,7 +183,7 @@ public partial class Hatch
 			public override Entity ToEntity()
 			{
 				Entities.Spline spline = new();
-
+				spline.IsClosed = true;
 				spline.Degree = this.Degree;
 				spline.Flags = this.IsPeriodic ? spline.Flags |= (SplineFlags.Periodic) : spline.Flags;
 				spline.Flags = this.IsRational ? spline.Flags |= (SplineFlags.Rational) : spline.Flags;
@@ -170,7 +191,7 @@ public partial class Hatch
 				spline.StartTangent = this.StartTangent.Convert<XYZ>();
 				spline.EndTangent = this.EndTangent.Convert<XYZ>();
 
-				spline.ControlPoints.AddRange(this.ControlPoints);
+				spline.ControlPoints.AddRange(this.ControlPoints.Select(cp => new XYZ(cp.X, cp.Y, 0)));
 				spline.Weights.AddRange(this.ControlPoints.Select(x => x.Z));
 				spline.FitPoints.AddRange(this.FitPoints.Select(x => x.Convert<XYZ>()));
 				spline.Knots.AddRange(this.Knots);

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.Spline.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.Spline.cs
@@ -1,175 +1,181 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Geometry;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace ACadSharp.Entities
+namespace ACadSharp.Entities;
+
+public partial class Hatch
 {
-	public partial class Hatch
+	public partial class BoundaryPath
 	{
-		public partial class BoundaryPath
+		public class Spline : Edge
 		{
-			public class Spline : Edge
+			/// <remarks>
+			/// Position values are only X and Y, Z represents the weight.
+			/// </remarks>
+			[DxfCodeValue(96)]
+			//42	Weights(optional, default = 1)	??
+			public List<XYZ> ControlPoints { get; private set; } = new List<XYZ>();
+
+			/// <summary>
+			/// Degree.
+			/// </summary>
+			[DxfCodeValue(94)]
+			public int Degree { get; set; }
+
+			/// <summary>
+			/// End tangent.
+			/// </summary>
+			[DxfCodeValue(13, 23)]
+			public XY EndTangent { get; set; }
+
+			/// <remarks>
+			/// Number of fit data.
+			/// </remarks>
+			[DxfCodeValue(97)]
+			public List<XY> FitPoints { get; private set; } = new List<XY>();
+
+			/// <summary>
+			/// Gets or sets a value indicating whether the spline is periodic.
+			/// </summary>
+			/// <remarks>A periodic spline forms a closed, continuous curve where the start and end points are joined
+			/// seamlessly. Setting this property to true creates a smooth, looping spline; setting it to false creates an open
+			/// spline.</remarks>
+			[DxfCodeValue(74)]
+			public bool IsPeriodic { get; set; }
+
+			/// <summary>
+			/// Gets or sets a value indicating whether the spline is rational.
+			/// </summary>
+			[DxfCodeValue(73)]
+			public bool IsRational { get; set; }
+
+			/// <summary>
+			/// Number of knots.
+			/// </summary>
+			[DxfCodeValue(95)]
+			public List<double> Knots { get; private set; } = new List<double>();
+
+			/// <summary>
+			/// Start tangent.
+			/// </summary>
+			[DxfCodeValue(12, 22)]
+			public XY StartTangent { get; set; }
+
+			/// <inheritdoc/>
+			public override EdgeType Type => EdgeType.Spline;
+
+			/// <summary>
+			/// Gets a collection of weights derived from the Z-coordinates of the control points.
+			/// </summary>
+			public IEnumerable<double> Weights { get { return this.ControlPoints.Select(c => c.Z); } }
+
+			/// <summary>
+			/// Initializes a new instance of the Spline class.
+			/// </summary>
+			public Spline()
+			{ }
+
+			/// <summary>
+			/// Initializes a new instance of the Spline class using the specified spline entity.
+			/// </summary>
+			/// <param name="spline">The spline entity that provides the data for initializing this Spline instance. Cannot be null.</param>
+			public Spline(Entities.Spline spline)
 			{
-				/// <remarks>
-				/// Position values are only X and Y, Z represents the weight.
-				/// </remarks>
-				[DxfCodeValue(96)]
-				//42	Weights(optional, default = 1)	??
-				public List<XYZ> ControlPoints { get; private set; } = new List<XYZ>();
-
-				/// <summary>
-				/// Degree.
-				/// </summary>
-				[DxfCodeValue(94)]
-				public int Degree { get; set; }
-
-				/// <summary>
-				/// End tangent.
-				/// </summary>
-				[DxfCodeValue(13, 23)]
-				public XY EndTangent { get; set; }
-
-				/// <remarks>
-				/// Number of fit data.
-				/// </remarks>
-				[DxfCodeValue(97)]
-				public List<XY> FitPoints { get; private set; } = new List<XY>();
-
-				/// <summary>
-				/// Number of knots.
-				/// </summary>
-				[DxfCodeValue(95)]
-				public List<double> Knots { get; private set; } = new List<double>();
-
-				/// <summary>
-				/// Gets or sets a value indicating whether the spline is periodic.
-				/// </summary>
-				/// <remarks>A periodic spline forms a closed, continuous curve where the start and end points are joined
-				/// seamlessly. Setting this property to true creates a smooth, looping spline; setting it to false creates an open
-				/// spline.</remarks>
-				[DxfCodeValue(74)]
-				public bool IsPeriodic { get; set; }
-
-				/// <summary>
-				/// Gets or sets a value indicating whether the spline is rational.
-				/// </summary>
-				[DxfCodeValue(73)]
-				public bool IsRational { get; set; }
-
-				/// <summary>
-				/// Start tangent.
-				/// </summary>
-				[DxfCodeValue(12, 22)]
-				public XY StartTangent { get; set; }
-
-				/// <inheritdoc/>
-				public override EdgeType Type => EdgeType.Spline;
-
-				/// <summary>
-				/// Gets a collection of weights derived from the Z-coordinates of the control points.
-				/// </summary>
-				public IEnumerable<double> Weights { get { return this.ControlPoints.Select(c => c.Z); } }
-
-				/// <summary>
-				/// Initializes a new instance of the Spline class.
-				/// </summary>
-				public Spline()
-				{ }
-
-				/// <summary>
-				/// Initializes a new instance of the Spline class using the specified spline entity.
-				/// </summary>
-				/// <param name="spline">The spline entity that provides the data for initializing this Spline instance. Cannot be null.</param>
-				public Spline(Entities.Spline spline)
+				this.Degree = spline.Degree;
+				this.IsRational = true;
+				this.IsPeriodic = spline.IsClosed;
+				if (!spline.ControlPoints.Any())
 				{
-					this.Degree = spline.Degree;
-					this.IsRational = true;
-					this.IsPeriodic = spline.IsClosed;
-					if (!spline.ControlPoints.Any())
-					{
-						throw new ArgumentException("The HatchBoundaryPath spline edge requires a spline entity with control points.", nameof(spline));
-					}
-
-					Matrix3 trans = Matrix3.ArbitraryAxis(spline.Normal).Transpose();
-					for (int i = 0; i < spline.ControlPoints.Count; i++)
-					{
-						XYZ point = trans * spline.ControlPoints[i];
-						this.ControlPoints.Add(new XYZ(point.X, point.Y, spline.Weights[i]));
-					}
-
-					this.Knots.AddRange(spline.Knots);
+					throw new ArgumentException("The HatchBoundaryPath spline edge requires a spline entity with control points.", nameof(spline));
 				}
 
-				/// <inheritdoc/>
-				public override void ApplyTransform(Transform transform)
+				Matrix3 trans = Matrix3.ArbitraryAxis(spline.Normal).Transpose();
+				for (int i = 0; i < spline.ControlPoints.Count; i++)
 				{
-					var arr = this.ControlPoints.ToArray();
-					this.ControlPoints.Clear();
-					for (int i = 0; i < arr.Length; i++)
-					{
-						var weight = arr[i].Z;
-						var v = transform.ApplyTransform(arr[i]);
-						v.Z = weight;
-
-						this.ControlPoints.Add(v);
-					}
-
-					for (int i = 0; i < this.FitPoints.Count; i++)
-					{
-						this.FitPoints[i] = transform.ApplyTransform(this.FitPoints[i].Convert<XYZ>()).Convert<XY>();
-					}
+					XYZ point = trans * spline.ControlPoints[i];
+					this.ControlPoints.Add(new XYZ(point.X, point.Y, spline.Weights[i]));
 				}
 
-				/// <inheritdoc/>
-				public override Edge Clone()
+				this.Knots.AddRange(spline.Knots);
+			}
+
+			/// <inheritdoc/>
+			public override void ApplyTransform(Transform transform)
+			{
+				var arr = this.ControlPoints.ToArray();
+				this.ControlPoints.Clear();
+				for (int i = 0; i < arr.Length; i++)
 				{
-					Spline clone = (Spline)base.Clone();
+					var weight = arr[i].Z;
+					var v = transform.ApplyTransform(arr[i]);
+					v.Z = weight;
 
-					clone.ControlPoints = new List<XYZ>(this.ControlPoints);
-					clone.FitPoints = new List<XY>(this.FitPoints);
-					clone.Knots = new List<double>(this.Knots);
-
-					return clone;
+					this.ControlPoints.Add(v);
 				}
 
-				/// <inheritdoc/>
-				public override BoundingBox GetBoundingBox()
+				for (int i = 0; i < this.FitPoints.Count; i++)
 				{
-					return BoundingBox.FromPoints(this.ControlPoints);
+					this.FitPoints[i] = transform.ApplyTransform(this.FitPoints[i].Convert<XYZ>()).Convert<XY>();
 				}
+			}
 
-				/// <summary>
-				/// Converts the spline in a list of vertexes.
-				/// </summary>
-				/// <param name="precision">Number of vertexes generated.</param>
-				/// <returns>A list vertexes that represents the spline expressed in object coordinate system.</returns>
-				public List<XYZ> PolygonalVertexes(int precision)
-				{
-					Entities.Spline spline = (Entities.Spline)this.ToEntity();
-					return spline.PolygonalVertexes(precision);
-				}
+			/// <inheritdoc/>
+			public override Edge Clone()
+			{
+				Spline clone = (Spline)base.Clone();
 
-				/// <inheritdoc/>
-				public override Entity ToEntity()
-				{
-					Entities.Spline spline = new();
+				clone.ControlPoints = new List<XYZ>(this.ControlPoints);
+				clone.FitPoints = new List<XY>(this.FitPoints);
+				clone.Knots = new List<double>(this.Knots);
 
-					spline.Degree = this.Degree;
-					spline.Flags = this.IsPeriodic ? spline.Flags |= (SplineFlags.Periodic) : spline.Flags;
-					spline.Flags = this.IsRational ? spline.Flags |= (SplineFlags.Rational) : spline.Flags;
+				return clone;
+			}
 
-					spline.StartTangent = this.StartTangent.Convert<XYZ>();
-					spline.EndTangent = this.EndTangent.Convert<XYZ>();
+			/// <inheritdoc/>
+			public override IEnumerable<XY> FindIntersections(Line2D line)
+			{
+				throw new NotImplementedException();
+			}
 
-					spline.ControlPoints.AddRange(this.ControlPoints);
-					spline.Weights.AddRange(this.ControlPoints.Select(x => x.Z));
-					spline.FitPoints.AddRange(this.FitPoints.Select(x => x.Convert<XYZ>()));
-					spline.Knots.AddRange(this.Knots);
+			/// <inheritdoc/>
+			public override BoundingBox GetBoundingBox()
+			{
+				return BoundingBox.FromPoints(this.ControlPoints);
+			}
 
-					return spline;
-				}
+			/// <summary>
+			/// Converts the spline in a list of vertexes.
+			/// </summary>
+			/// <param name="precision">Number of vertexes generated.</param>
+			/// <returns>A list vertexes that represents the spline expressed in object coordinate system.</returns>
+			public List<XYZ> PolygonalVertexes(int precision)
+			{
+				Entities.Spline spline = (Entities.Spline)this.ToEntity();
+				return spline.PolygonalVertexes(precision);
+			}
+
+			/// <inheritdoc/>
+			public override Entity ToEntity()
+			{
+				Entities.Spline spline = new();
+
+				spline.Degree = this.Degree;
+				spline.Flags = this.IsPeriodic ? spline.Flags |= (SplineFlags.Periodic) : spline.Flags;
+				spline.Flags = this.IsRational ? spline.Flags |= (SplineFlags.Rational) : spline.Flags;
+
+				spline.StartTangent = this.StartTangent.Convert<XYZ>();
+				spline.EndTangent = this.EndTangent.Convert<XYZ>();
+
+				spline.ControlPoints.AddRange(this.ControlPoints);
+				spline.Weights.AddRange(this.ControlPoints.Select(x => x.Z));
+				spline.FitPoints.AddRange(this.FitPoints.Select(x => x.Convert<XYZ>()));
+				spline.Knots.AddRange(this.Knots);
+
+				return spline;
 			}
 		}
 	}

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.cs
@@ -1,6 +1,7 @@
 ﻿using ACadSharp.Attributes;
 using ACadSharp.Extensions;
 using CSMath;
+using CSMath.Geometry;
 using CSUtilities.Extensions;
 using System;
 using System.Collections.Generic;
@@ -8,239 +9,251 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
 
-namespace ACadSharp.Entities
+namespace ACadSharp.Entities;
+
+public partial class Hatch
 {
-	public partial class Hatch
+	public partial class BoundaryPath : IGeometricEntity
 	{
-		public partial class BoundaryPath : IGeometricEntity
+		public IEnumerable<XY> FindIntersections(Line2D line)
 		{
-			/// <summary>
-			/// Edges that form the boundary.
-			/// </summary>
-			[DxfCodeValue(DxfReferenceType.Count, 93)]
-			public ObservableCollection<Edge> Edges { get; private set; } = new();
+			var intersections = new List<XY>();
 
-			/// <summary>
-			/// Source boundary objects.
-			/// </summary>
-			[DxfCodeValue(DxfReferenceType.Count, 97)]
-			public List<Entity> Entities { get; set; } = new List<Entity>();
-
-			/// <summary>
-			/// Boundary path type flag
-			/// </summary>
-			[DxfCodeValue(92)]
-			public BoundaryPathFlags Flags
+			foreach (Edge edge in this.Edges)
 			{
-				get
+				foreach (var intersection in edge.FindIntersections(line))
 				{
-					if (this.IsPolyline)
-					{
-						this._flags.AddFlag(BoundaryPathFlags.Polyline);
-					}
-					else
-					{
-						this._flags.RemoveFlag(BoundaryPathFlags.Polyline);
-					}
-
-					return this._flags;
-				}
-				set
-				{
-					this._flags = value;
+					yield return intersection;
 				}
 			}
+		}
 
-			/// <summary>
-			/// Flag that indicates that this boundary path is formed by a polyline.
-			/// </summary>
-			public bool IsPolyline { get { return this.Edges.OfType<Polyline>().Any(); } }
+		/// <summary>
+		/// Edges that form the boundary.
+		/// </summary>
+		[DxfCodeValue(DxfReferenceType.Count, 93)]
+		public ObservableCollection<Edge> Edges { get; private set; } = new();
 
-			private BoundaryPathFlags _flags;
+		/// <summary>
+		/// Source boundary objects.
+		/// </summary>
+		[DxfCodeValue(DxfReferenceType.Count, 97)]
+		public List<Entity> Entities { get; set; } = new List<Entity>();
 
-			/// <summary>
-			/// Initializes a new instance of the BoundaryPath class.
-			/// </summary>
-			/// <remarks>Subscribes to changes in the Edges collection to keep the BoundaryPath instance updated when
-			/// the collection is modified.</remarks>
-			public BoundaryPath()
+		/// <summary>
+		/// Boundary path type flag
+		/// </summary>
+		[DxfCodeValue(92)]
+		public BoundaryPathFlags Flags
+		{
+			get
 			{
-				this.Edges.CollectionChanged += this.onEdgesCollectionChanged;
-			}
-
-			/// <summary>
-			/// Initializes a new instance of the BoundaryPath class with the specified collection of edges.
-			/// </summary>
-			/// <param name="edges">A collection of Edge objects that define the boundary path. Cannot be null.</param>
-			public BoundaryPath(IEnumerable<Edge> edges) : this()
-			{
-				foreach (var edge in edges)
+				if (this.IsPolyline)
 				{
-					this.Edges.Add(edge);
+					this._flags.AddFlag(BoundaryPathFlags.Polyline);
 				}
-			}
-
-			/// <summary>
-			/// Initializes a new instance of the BoundaryPath class using the specified collection of entities.
-			/// </summary>
-			/// <remarks>The entities provided are added to the Entities collection of the BoundaryPath. The path is
-			/// marked as derived and external by default.</remarks>
-			/// <param name="entities">A collection of Entity objects that define the segments of the boundary path. Cannot be null.</param>
-			public BoundaryPath(params IEnumerable<Entity> entities) : this()
-			{
-				this._flags = BoundaryPathFlags.Derived | BoundaryPathFlags.External;
-				this.Entities.AddRange(entities);
-				this.UpdateEdges();
-			}
-
-			/// <inheritdoc/>
-			public void ApplyTransform(Transform transform)
-			{
-				foreach (var e in this.Edges)
+				else
 				{
-					e.ApplyTransform(transform);
-				}
-			}
-
-			/// <inheritdoc/>
-			public BoundaryPath Clone()
-			{
-				BoundaryPath path = (BoundaryPath)this.MemberwiseClone();
-
-				path.Entities = new List<Entity>();
-				path.Entities.AddRange(this.Entities.Select(e => (Entity)e.Clone()));
-
-				path.Edges = new ObservableCollection<Edge>(
-					this.Edges.Select(e => e.Clone()));
-
-				return path;
-			}
-
-			/// <inheritdoc/>
-			public BoundingBox GetBoundingBox()
-			{
-				BoundingBox box = BoundingBox.Null;
-
-				foreach (Edge edge in this.Edges)
-				{
-					box = box.Merge(edge.GetBoundingBox());
+					this._flags.RemoveFlag(BoundaryPathFlags.Polyline);
 				}
 
-				foreach (Entity entity in this.Entities)
-				{
-					box = box.Merge(entity.GetBoundingBox());
-				}
+				return this._flags;
+			}
+			set
+			{
+				this._flags = value;
+			}
+		}
 
-				return box;
+		/// <summary>
+		/// Flag that indicates that this boundary path is formed by a polyline.
+		/// </summary>
+		public bool IsPolyline { get { return this.Edges.OfType<Polyline>().Any(); } }
+
+		private BoundaryPathFlags _flags;
+
+		/// <summary>
+		/// Initializes a new instance of the BoundaryPath class.
+		/// </summary>
+		/// <remarks>Subscribes to changes in the Edges collection to keep the BoundaryPath instance updated when
+		/// the collection is modified.</remarks>
+		public BoundaryPath()
+		{
+			this.Edges.CollectionChanged += this.onEdgesCollectionChanged;
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the BoundaryPath class with the specified collection of edges.
+		/// </summary>
+		/// <param name="edges">A collection of Edge objects that define the boundary path. Cannot be null.</param>
+		public BoundaryPath(IEnumerable<Edge> edges) : this()
+		{
+			foreach (var edge in edges)
+			{
+				this.Edges.Add(edge);
+			}
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the BoundaryPath class using the specified collection of entities.
+		/// </summary>
+		/// <remarks>The entities provided are added to the Entities collection of the BoundaryPath. The path is
+		/// marked as derived and external by default.</remarks>
+		/// <param name="entities">A collection of Entity objects that define the segments of the boundary path. Cannot be null.</param>
+		public BoundaryPath(params IEnumerable<Entity> entities) : this()
+		{
+			this._flags = BoundaryPathFlags.Derived | BoundaryPathFlags.External;
+			this.Entities.AddRange(entities);
+			this.UpdateEdges();
+		}
+
+		/// <inheritdoc/>
+		public void ApplyTransform(Transform transform)
+		{
+			foreach (var e in this.Edges)
+			{
+				e.ApplyTransform(transform);
+			}
+		}
+
+		/// <inheritdoc/>
+		public BoundaryPath Clone()
+		{
+			BoundaryPath path = (BoundaryPath)this.MemberwiseClone();
+
+			path.Entities = new List<Entity>();
+			path.Entities.AddRange(this.Entities.Select(e => (Entity)e.Clone()));
+
+			path.Edges = new ObservableCollection<Edge>(
+				this.Edges.Select(e => e.Clone()));
+
+			return path;
+		}
+
+		/// <inheritdoc/>
+		public BoundingBox GetBoundingBox()
+		{
+			BoundingBox box = BoundingBox.Null;
+
+			foreach (Edge edge in this.Edges)
+			{
+				box = box.Merge(edge.GetBoundingBox());
 			}
 
-			/// <summary>
-			/// Retrieves the points of the specified boundary as a sequence of the specified vector type.
-			/// </summary>
-			/// <param name="precision">The number of points to generate for each arc segment. Must be equal to or greater than 2.</param>
-			/// <returns>An <see cref="IEnumerable{T}"/> containing the points of the polyline, including interpolated points for arcs.</returns>
-			public IEnumerable<XYZ> GetPoints(int precision = 256)
+			foreach (Entity entity in this.Entities)
 			{
-				List<XYZ> pts = new();
-				foreach (Edge edge in this.Edges)
-				{
-					switch (edge)
-					{
-						case Arc arc:
-							pts.AddRange(arc.PolygonalVertexes(precision));
-							break;
-						case Ellipse ellipse:
-							pts.AddRange(ellipse.PolygonalVertexes(precision));
-							break;
-						case Line line:
-							pts.Add((XYZ)line.Start);
-							pts.Add((XYZ)line.End);
-							break;
-						case Polyline poly:
-							Polyline2D pline2d = (Polyline2D)poly.ToEntity();
-							pts.AddRange(pline2d.GetPoints<XYZ>(precision));
-							break;
-						case Spline spline:
-							pts.AddRange(spline.PolygonalVertexes(precision));
-							break;
-					}
-				}
-
-				return pts;
+				box = box.Merge(entity.GetBoundingBox());
 			}
 
-			/// <summary>
-			/// Updates the collection of edges to reflect the current set of entities in the boundary definition.
-			/// </summary>
-			/// <remarks>This method clears the existing edges and reconstructs them based on the current entities. It
-			/// should be called after modifying the entities collection to ensure the edges remain consistent with the boundary
-			/// definition.</remarks>
-			/// <exception cref="ArgumentException">Thrown if an entity in the collection is not of a supported type. Only Arc, Circle, Ellipse, Line, Polyline2D,
-			/// Polyline3D, and Spline entities are allowed as hatch boundary elements.</exception>
-			public void UpdateEdges()
+			return box;
+		}
+
+		/// <summary>
+		/// Retrieves the points of the specified boundary as a sequence of the specified vector type.
+		/// </summary>
+		/// <param name="precision">The number of points to generate for each arc segment. Must be equal to or greater than 2.</param>
+		/// <returns>An <see cref="IEnumerable{T}"/> containing the points of the polyline, including interpolated points for arcs.</returns>
+		public IEnumerable<XYZ> GetPoints(int precision = 256)
+		{
+			List<XYZ> pts = new();
+			foreach (Edge edge in this.Edges)
 			{
-				if (!this.Entities.Any())
+				switch (edge)
 				{
-					return;
-				}
-
-				this.Edges.Clear();
-
-				foreach (var entity in this.Entities)
-				{
-					switch (entity)
-					{
-						case Entities.Arc arc:
-							this.Edges.Add(new Arc(arc));
-							break;
-						case Entities.Circle circle:
-							this.Edges.Add(new Arc(circle));
-							break;
-						case Entities.Ellipse ellipse:
-							this.Edges.Add(new Ellipse(ellipse));
-							break;
-						case Entities.Line line:
-							this.Edges.Add(new Line(line));
-							break;
-						case IPolyline polyline:
-							this.Edges.Add(new Polyline(polyline));
-							break;
-						case Entities.Spline spline:
-							this.Edges.Add(new Spline(spline));
-							break;
-						default:
-							throw new ArgumentException(($"The entity type {entity.ObjectName} cannot be part of a hatch boundary. Only Arc, Circle, Ellipse, Line, Polyline2D, Polyline3D, and Spline entities are allowed."));
-					}
-				}
-			}
-
-			private void onAdd(NotifyCollectionChangedEventArgs e)
-			{
-				foreach (Edge edge in e.NewItems)
-				{
-					if (this.Edges.Count > 1 && this.IsPolyline)
-					{
-						throw new System.InvalidOperationException();
-					}
-				}
-			}
-
-			private void onEdgesCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-			{
-				switch (e.Action)
-				{
-					case System.Collections.Specialized.NotifyCollectionChangedAction.Add:
-						this.onAdd(e);
+					case Arc arc:
+						pts.AddRange(arc.PolygonalVertexes(precision));
 						break;
-					case System.Collections.Specialized.NotifyCollectionChangedAction.Remove:
+					case Ellipse ellipse:
+						pts.AddRange(ellipse.PolygonalVertexes(precision));
 						break;
-					case System.Collections.Specialized.NotifyCollectionChangedAction.Replace:
+					case Line line:
+						pts.Add((XYZ)line.Start);
+						pts.Add((XYZ)line.End);
 						break;
-					case System.Collections.Specialized.NotifyCollectionChangedAction.Move:
+					case Polyline poly:
+						Polyline2D pline2d = (Polyline2D)poly.ToEntity();
+						pts.AddRange(pline2d.GetPoints<XYZ>(precision));
 						break;
-					case System.Collections.Specialized.NotifyCollectionChangedAction.Reset:
+					case Spline spline:
+						pts.AddRange(spline.PolygonalVertexes(precision));
 						break;
 				}
+			}
+
+			return pts;
+		}
+
+		/// <summary>
+		/// Updates the collection of edges to reflect the current set of entities in the boundary definition.
+		/// </summary>
+		/// <remarks>This method clears the existing edges and reconstructs them based on the current entities. It
+		/// should be called after modifying the entities collection to ensure the edges remain consistent with the boundary
+		/// definition.</remarks>
+		/// <exception cref="ArgumentException">Thrown if an entity in the collection is not of a supported type. Only Arc, Circle, Ellipse, Line, Polyline2D,
+		/// Polyline3D, and Spline entities are allowed as hatch boundary elements.</exception>
+		public void UpdateEdges()
+		{
+			if (!this.Entities.Any())
+			{
+				return;
+			}
+
+			this.Edges.Clear();
+
+			foreach (var entity in this.Entities)
+			{
+				switch (entity)
+				{
+					case Entities.Arc arc:
+						this.Edges.Add(new Arc(arc));
+						break;
+					case Entities.Circle circle:
+						this.Edges.Add(new Arc(circle));
+						break;
+					case Entities.Ellipse ellipse:
+						this.Edges.Add(new Ellipse(ellipse));
+						break;
+					case Entities.Line line:
+						this.Edges.Add(new Line(line));
+						break;
+					case IPolyline polyline:
+						this.Edges.Add(new Polyline(polyline));
+						break;
+					case Entities.Spline spline:
+						this.Edges.Add(new Spline(spline));
+						break;
+					default:
+						throw new ArgumentException(($"The entity type {entity.ObjectName} cannot be part of a hatch boundary. Only Arc, Circle, Ellipse, Line, Polyline2D, Polyline3D, and Spline entities are allowed."));
+				}
+			}
+		}
+
+		private void onAdd(NotifyCollectionChangedEventArgs e)
+		{
+			foreach (Edge edge in e.NewItems)
+			{
+				if (this.Edges.Count > 1 && this.IsPolyline)
+				{
+					throw new System.InvalidOperationException();
+				}
+			}
+		}
+
+		private void onEdgesCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			switch (e.Action)
+			{
+				case System.Collections.Specialized.NotifyCollectionChangedAction.Add:
+					this.onAdd(e);
+					break;
+				case System.Collections.Specialized.NotifyCollectionChangedAction.Remove:
+					break;
+				case System.Collections.Specialized.NotifyCollectionChangedAction.Replace:
+					break;
+				case System.Collections.Specialized.NotifyCollectionChangedAction.Move:
+					break;
+				case System.Collections.Specialized.NotifyCollectionChangedAction.Reset:
+					break;
 			}
 		}
 	}

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.cs
@@ -15,19 +15,6 @@ public partial class Hatch
 {
 	public partial class BoundaryPath : IGeometricEntity
 	{
-		public IEnumerable<XY> FindIntersections(Line2D line)
-		{
-			var intersections = new List<XY>();
-
-			foreach (Edge edge in this.Edges)
-			{
-				foreach (var intersection in edge.FindIntersections(line))
-				{
-					yield return intersection;
-				}
-			}
-		}
-
 		/// <summary>
 		/// Edges that form the boundary.
 		/// </summary>
@@ -128,6 +115,24 @@ public partial class Hatch
 				this.Edges.Select(e => e.Clone()));
 
 			return path;
+		}
+
+		/// <summary>
+		/// Finds the intersection points between the boundary path and a given line. The method iterates through each edge in the boundary path and collects the intersection points with the specified line, returning them as an enumerable collection of XY coordinates.
+		/// </summary>
+		/// <param name="line">The line to check for intersections with the boundary path.</param>
+		/// <returns>An enumerable collection of XY coordinates representing the intersection points.</returns>
+		public IEnumerable<XY> FindIntersections(Line2D line)
+		{
+			var intersections = new List<XY>();
+
+			foreach (Edge edge in this.Edges)
+			{
+				foreach (var intersection in edge.FindIntersections(line))
+				{
+					yield return intersection;
+				}
+			}
 		}
 
 		/// <inheritdoc/>

--- a/src/ACadSharp/Entities/Hatch.cs
+++ b/src/ACadSharp/Entities/Hatch.cs
@@ -291,7 +291,8 @@ public partial class Hatch : Entity
 
 					Line2D geomLine = new Line2D(basePoint, patLine.Direction);
 
-					List<XY> intersections = boundary.FindIntersections(geomLine).ToList();
+					// Collect intersections, removing duplicates (vertex hits).
+					List<XY> intersections = boundary.FindIntersections(geomLine).Distinct().ToList();
 					if (intersections.Count < 2)
 					{
 						continue;
@@ -306,14 +307,23 @@ public partial class Hatch : Entity
 
 					for (int i = 0; i + 1 < intersections.Count; i += 2)
 					{
-						XY start = intersections[i];
-						XY end = intersections[i + 1];
-						if (start.Equals(end))
+						XY a = intersections[i];
+						XY b = intersections[i + 1];
+
+						double tA = (a.X - basePoint.X) * patLine.Direction.X + (a.Y - basePoint.Y) * patLine.Direction.Y;
+						double tB = (b.X - basePoint.X) * patLine.Direction.X + (b.Y - basePoint.Y) * patLine.Direction.Y;
+
+						if (tB < tA)
+						{
+							(tA, tB) = (tB, tA);
+						}
+
+						if ((tB - tA) <= MathHelper.Epsilon)
 						{
 							continue;
 						}
 
-						entities.Add(new Line(start, end));
+						entities.AddRange(emitDashedSegment(basePoint, patLine.Direction, tA, tB, patLine.DashLengths));
 					}
 				}
 			}
@@ -321,6 +331,90 @@ public partial class Hatch : Entity
 
 		return entities;
 	}
+
+	private IEnumerable<Line> emitDashedSegment(XY origin, XY dir, double tStart, double tEnd, List<double> dashLengths)
+	{
+		// Continuous if no dash pattern.
+		if (dashLengths == null || dashLengths.Count == 0)
+		{
+			return new[] { new Line(pointInLineAt(origin, dir, tStart), pointInLineAt(origin, dir, tEnd)) };
+		}
+
+		double[] abs = dashLengths.Select(d => System.Math.Abs(d)).ToArray();
+		double cycle = abs.Sum();
+		if (cycle <= MathHelper.Epsilon)
+		{
+			return Enumerable.Empty<Line>();
+		}
+
+		double pos = mod(tStart, cycle);
+		int idx = 0;
+		double acc = 0.0;
+
+		while (idx < abs.Length && acc + abs[idx] <= pos + MathHelper.Epsilon)
+		{
+			acc += abs[idx];
+			idx++;
+		}
+
+		if (idx >= abs.Length)
+		{
+			idx = 0;
+			acc = 0.0;
+			pos = 0.0;
+		}
+
+		var entities = new List<Line>();
+
+		double cursor = tStart;
+		double remaining = abs[idx] - (pos - acc);
+		while (cursor < tEnd - MathHelper.Epsilon)
+		{
+			int guard = 0;
+			while (remaining <= MathHelper.Epsilon && guard < abs.Length + 1)
+			{
+				idx = (idx + 1) % abs.Length;
+				remaining = abs[idx];
+				guard++;
+			}
+
+			if (remaining <= MathHelper.Epsilon)
+			{
+				break;
+			}
+
+			double step = System.Math.Min(remaining, tEnd - cursor);
+			if (dashLengths[idx] > 0.0 && step > MathHelper.Epsilon)
+			{
+				double t0 = cursor;
+				double t1 = cursor + step;
+				entities.Add(new Line(pointInLineAt(origin, dir, t0), pointInLineAt(origin, dir, t1)));
+			}
+
+			cursor += step;
+			remaining -= step;
+
+			if (remaining <= MathHelper.Epsilon)
+			{
+				idx = (idx + 1) % abs.Length;
+				remaining = abs[idx];
+			}
+		}
+
+		return entities;
+	}
+
+	private static XYZ pointInLineAt(XY origin, XY dir, double t)
+	{
+		return new XYZ(origin.X + dir.X * t, origin.Y + dir.Y * t, 0.0);
+	}
+
+	private static double mod(double value, double period)
+	{
+		double m = value % period;
+		return m < 0 ? m + period : m;
+	}
+
 
 	/// <inheritdoc/>
 	public override BoundingBox GetBoundingBox()

--- a/src/ACadSharp/Entities/Hatch.cs
+++ b/src/ACadSharp/Entities/Hatch.cs
@@ -205,7 +205,7 @@ public partial class Hatch : Entity
 	/// <summary>
 	/// Explode the hatch edges into the equivalent entities.
 	/// </summary>
-	/// <returns></returns>
+	/// <returns>A collection of entities representing the exploded hatch edges.</returns>
 	public IEnumerable<Entity> Explode()
 	{
 		List<Entity> entities = new List<Entity>();
@@ -221,6 +221,10 @@ public partial class Hatch : Entity
 		return entities;
 	}
 
+	/// <summary>
+	/// Explode the hatch pattern into the equivalent entities.
+	/// </summary>
+	/// <returns>A collection of entities representing the exploded hatch pattern.</returns>
 	public IEnumerable<Entity> ExplodePattern()
 	{
 		List<Entity> entities = new();
@@ -291,7 +295,6 @@ public partial class Hatch : Entity
 
 					Line2D geomLine = new Line2D(basePoint, patLine.Direction);
 
-					// Collect intersections, removing duplicates (vertex hits).
 					List<XY> intersections = boundary.FindIntersections(geomLine).Distinct().ToList();
 					if (intersections.Count < 2)
 					{
@@ -323,7 +326,8 @@ public partial class Hatch : Entity
 							continue;
 						}
 
-						entities.AddRange(emitDashedSegment(basePoint, patLine.Direction, tA, tB, patLine.DashLengths));
+						Line2D line = new Line2D(basePoint, patLine.Direction);
+						entities.AddRange(emitDashedSegment(line, tA, tB, patLine.DashLengths));
 					}
 				}
 			}
@@ -332,12 +336,24 @@ public partial class Hatch : Entity
 		return entities;
 	}
 
-	private IEnumerable<Line> emitDashedSegment(XY origin, XY dir, double tStart, double tEnd, List<double> dashLengths)
+	/// <inheritdoc/>
+	public override BoundingBox GetBoundingBox()
 	{
-		// Continuous if no dash pattern.
+		BoundingBox box = BoundingBox.Null;
+
+		foreach (BoundaryPath bp in this.Paths)
+		{
+			box = box.Merge(bp.GetBoundingBox());
+		}
+
+		return box;
+	}
+
+	private IEnumerable<Line> emitDashedSegment(Line2D line, double tStart, double tEnd, List<double> dashLengths)
+	{
 		if (dashLengths == null || dashLengths.Count == 0)
 		{
-			return new[] { new Line(pointInLineAt(origin, dir, tStart), pointInLineAt(origin, dir, tEnd)) };
+			return new[] { new Line(line.PointInLine(tStart), line.PointInLine(tEnd)) };
 		}
 
 		double[] abs = dashLengths.Select(d => System.Math.Abs(d)).ToArray();
@@ -347,7 +363,8 @@ public partial class Hatch : Entity
 			return Enumerable.Empty<Line>();
 		}
 
-		double pos = mod(tStart, cycle);
+		double m = tStart % cycle;
+		double pos = m < 0 ? m + cycle : m;
 		int idx = 0;
 		double acc = 0.0;
 
@@ -388,7 +405,7 @@ public partial class Hatch : Entity
 			{
 				double t0 = cursor;
 				double t1 = cursor + step;
-				entities.Add(new Line(pointInLineAt(origin, dir, t0), pointInLineAt(origin, dir, t1)));
+				entities.Add(new Line(line.PointInLine(t0), line.PointInLine(t1)));
 			}
 
 			cursor += step;
@@ -402,30 +419,5 @@ public partial class Hatch : Entity
 		}
 
 		return entities;
-	}
-
-	private static XYZ pointInLineAt(XY origin, XY dir, double t)
-	{
-		return new XYZ(origin.X + dir.X * t, origin.Y + dir.Y * t, 0.0);
-	}
-
-	private static double mod(double value, double period)
-	{
-		double m = value % period;
-		return m < 0 ? m + period : m;
-	}
-
-
-	/// <inheritdoc/>
-	public override BoundingBox GetBoundingBox()
-	{
-		BoundingBox box = BoundingBox.Null;
-
-		foreach (BoundaryPath bp in this.Paths)
-		{
-			box = box.Merge(bp.GetBoundingBox());
-		}
-
-		return box;
 	}
 }

--- a/src/ACadSharp/Entities/Hatch.cs
+++ b/src/ACadSharp/Entities/Hatch.cs
@@ -1,6 +1,8 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Geometry;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ACadSharp.Entities;
 
@@ -221,7 +223,7 @@ public partial class Hatch : Entity
 
 	public IEnumerable<Entity> ExplodePattern()
 	{
-		List<Entity> entities = new List<Entity>();
+		List<Entity> entities = new();
 
 		if (this.Pattern == null
 			|| this.Pattern.Lines.Count == 0
@@ -230,16 +232,89 @@ public partial class Hatch : Entity
 			return entities;
 		}
 
-		foreach (BoundaryPath b in this.Paths)
+		foreach (BoundaryPath boundary in this.Paths)
 		{
-			foreach (var pl in this.Pattern.Lines)
-			{
-				var l = pl.ToLine2D();
+			BoundingBox box = boundary.GetBoundingBox();
 
-				var intersections = b.FindIntersections(l);
-				foreach (var intersection in b.FindIntersections(l))
+			XY[] corners =
+			[
+				new XY(box.Min.X, box.Min.Y),
+				new XY(box.Min.X, box.Max.Y),
+				new XY(box.Max.X, box.Min.Y),
+				new XY(box.Max.X, box.Max.Y)
+			];
+
+			foreach (var patLine in this.Pattern.Lines)
+			{
+				if (patLine.Direction.IsZero())
 				{
-					entities.Add(new Circle(intersection.Convert<XYZ>(), 0.5));
+					continue;
+				}
+
+				XY normal = new XY(-patLine.Direction.Y, patLine.Direction.X);
+
+				double minProj = double.PositiveInfinity;
+				double maxProj = double.NegativeInfinity;
+				for (int i = 0; i < corners.Length; i++)
+				{
+					double p = corners[i].X * normal.X + corners[i].Y * normal.Y;
+					if (p < minProj) minProj = p;
+					if (p > maxProj) maxProj = p;
+				}
+
+				double c0 = patLine.BasePoint.X * normal.X + patLine.BasePoint.Y * normal.Y;
+
+				int kStart;
+				int kEnd;
+				if (System.Math.Abs((double)patLine.LineOffset) <= MathHelper.Epsilon)
+				{
+					kStart = 0;
+					kEnd = 0;
+				}
+				else
+				{
+					double k1 = (minProj - c0) / (double)patLine.LineOffset;
+					double k2 = (maxProj - c0) / (double)patLine.LineOffset;
+
+					double kMin = System.Math.Min(k1, k2);
+					double kMax = System.Math.Max(k1, k2);
+
+					kStart = (int)System.Math.Floor(kMin) - 1;
+					kEnd = (int)System.Math.Ceiling(kMax) + 1;
+				}
+
+				for (int k = kStart; k <= kEnd; k++)
+				{
+					XY basePoint = new XY(
+						patLine.BasePoint.X + patLine.Offset.X * k,
+						patLine.BasePoint.Y + patLine.Offset.Y * k);
+
+					Line2D geomLine = new Line2D(basePoint, patLine.Direction);
+
+					List<XY> intersections = boundary.FindIntersections(geomLine).ToList();
+					if (intersections.Count < 2)
+					{
+						continue;
+					}
+
+					intersections.Sort((a, b) =>
+					{
+						double ta = (a.X - basePoint.X) * patLine.Direction.X + (a.Y - basePoint.Y) * patLine.Direction.Y;
+						double tb = (b.X - basePoint.X) * patLine.Direction.X + (b.Y - basePoint.Y) * patLine.Direction.Y;
+						return ta.CompareTo(tb);
+					});
+
+					for (int i = 0; i + 1 < intersections.Count; i += 2)
+					{
+						XY start = intersections[i];
+						XY end = intersections[i + 1];
+						if (start.Equals(end))
+						{
+							continue;
+						}
+
+						entities.Add(new Line(start, end));
+					}
 				}
 			}
 		}

--- a/src/ACadSharp/Entities/Hatch.cs
+++ b/src/ACadSharp/Entities/Hatch.cs
@@ -2,234 +2,247 @@
 using CSMath;
 using System.Collections.Generic;
 
-namespace ACadSharp.Entities
+namespace ACadSharp.Entities;
+
+/// <summary>
+/// Represents a <see cref="Hatch"/> entity.
+/// </summary>
+/// <remarks>
+/// Object name <see cref="DxfFileToken.EntityHatch"/> <br/>
+/// Dxf class name <see cref="DxfSubclassMarker.Hatch"/>
+/// </remarks>
+[DxfName(DxfFileToken.EntityHatch)]
+[DxfSubClass(DxfSubclassMarker.Hatch)]
+public partial class Hatch : Entity
 {
 	/// <summary>
-	/// Represents a <see cref="Hatch"/> entity.
+	/// The current elevation of the object.
 	/// </summary>
-	/// <remarks>
-	/// Object name <see cref="DxfFileToken.EntityHatch"/> <br/>
-	/// Dxf class name <see cref="DxfSubclassMarker.Hatch"/>
-	/// </remarks>
-	[DxfName(DxfFileToken.EntityHatch)]
-	[DxfSubClass(DxfSubclassMarker.Hatch)]
-	public partial class Hatch : Entity
+	[DxfCodeValue(30)]
+	public double Elevation { get; set; }
+
+	/// <summary>
+	/// Gradient color pattern, if exists.
+	/// </summary>
+	[DxfCodeValue(DxfReferenceType.Name, 470)]
+	public HatchGradientPattern GradientColor { get; set; } = new HatchGradientPattern();
+
+	/// <summary>
+	/// Associativity flag.
+	/// </summary>
+	[DxfCodeValue(71)]
+	public bool IsAssociative { get; set; }
+
+	/// <summary>
+	/// Hatch pattern double flag (pattern fill only)
+	/// </summary>
+	[DxfCodeValue(77)]
+	public bool IsDouble { get; set; }
+
+	/// <summary>
+	/// Solid fill flag
+	/// </summary>
+	[DxfCodeValue(70)]
+	public bool IsSolid { get; set; }
+
+	/// <summary>
+	/// Specifies the three-dimensional normal unit vector for the object.
+	/// </summary>
+	[DxfCodeValue(210, 220, 230)]
+	public XYZ Normal { get; set; } = XYZ.AxisZ;
+
+	/// <inheritdoc/>
+	public override string ObjectName => DxfFileToken.EntityHatch;
+
+	/// <inheritdoc/>
+	public override ObjectType ObjectType => ObjectType.HATCH;
+
+	/// <summary>
+	/// Boundary paths (loops).
+	/// </summary>
+	[DxfCodeValue(DxfReferenceType.Count, 91)]
+	public List<BoundaryPath> Paths { get; set; } = new List<BoundaryPath>();
+
+	/// <summary>
+	/// Pattern of this hatch.
+	/// </summary>
+	/// <value>
+	/// Default value: SOLID pattern.
+	/// </value>
+	[DxfCodeValue(DxfReferenceType.Name, 2)]
+	public HatchPattern Pattern { get; set; } = HatchPattern.Solid;
+
+	/// <summary>
+	/// Hatch pattern angle (pattern fill only).
+	/// </summary>
+	[DxfCodeValue(DxfReferenceType.IsAngle, 52)]
+	public double PatternAngle
 	{
-		/// <summary>
-		/// The current elevation of the object.
-		/// </summary>
-		[DxfCodeValue(30)]
-		public double Elevation { get; set; }
-
-		/// <summary>
-		/// Gradient color pattern, if exists.
-		/// </summary>
-		[DxfCodeValue(DxfReferenceType.Name, 470)]
-		public HatchGradientPattern GradientColor { get; set; } = new HatchGradientPattern();
-
-		/// <summary>
-		/// Associativity flag.
-		/// </summary>
-		[DxfCodeValue(71)]
-		public bool IsAssociative { get; set; }
-
-		/// <summary>
-		/// Hatch pattern double flag (pattern fill only)
-		/// </summary>
-		[DxfCodeValue(77)]
-		public bool IsDouble { get; set; }
-
-		/// <summary>
-		/// Solid fill flag
-		/// </summary>
-		[DxfCodeValue(70)]
-		public bool IsSolid { get; set; }
-
-		/// <summary>
-		/// Specifies the three-dimensional normal unit vector for the object.
-		/// </summary>
-		[DxfCodeValue(210, 220, 230)]
-		public XYZ Normal { get; set; } = XYZ.AxisZ;
-
-		/// <inheritdoc/>
-		public override string ObjectName => DxfFileToken.EntityHatch;
-
-		/// <inheritdoc/>
-		public override ObjectType ObjectType => ObjectType.HATCH;
-
-		/// <summary>
-		/// Boundary paths (loops).
-		/// </summary>
-		[DxfCodeValue(DxfReferenceType.Count, 91)]
-		public List<BoundaryPath> Paths { get; set; } = new List<BoundaryPath>();
-
-		/// <summary>
-		/// Pattern of this hatch.
-		/// </summary>
-		/// <value>
-		/// Default value: SOLID pattern.
-		/// </value>
-		[DxfCodeValue(DxfReferenceType.Name, 2)]
-		public HatchPattern Pattern { get; set; } = HatchPattern.Solid;
-
-		/// <summary>
-		/// Hatch pattern angle (pattern fill only).
-		/// </summary>
-		[DxfCodeValue(DxfReferenceType.IsAngle, 52)]
-		public double PatternAngle
+		get
 		{
-			get
-			{
-				return this._patternAngle;
-			}
+			return this._patternAngle;
+		}
 
-			set
+		set
+		{
+			this._patternAngle = value;
+			this.Pattern?.Update(XY.Zero, this._patternAngle, 1);
+		}
+	}
+
+	/// <summary>
+	/// Hatch pattern scale or spacing(pattern fill only).
+	/// </summary>
+	[DxfCodeValue(41)]
+	public double PatternScale
+	{
+		get
+		{
+			return this._patternScale;
+		}
+
+		set
+		{
+			this._patternScale = value;
+			this.Pattern?.Update(XY.Zero, 0, this._patternScale);
+		}
+	}
+
+	/// <summary>
+	/// Hatch pattern type
+	/// </summary>
+	[DxfCodeValue(76)]
+	public HatchPatternType PatternType { get; set; }
+
+	/// <summary>
+	/// Pixel size used to determine the density to perform various intersection and ray casting operations in hatch pattern computation for associative hatches and hatches created with the Flood method of hatching
+	/// </summary>
+	[DxfCodeValue(47)]
+	public double PixelSize { get; set; }
+
+	/// <summary>
+	/// Seed points codes (in OCS)
+	/// </summary>
+	[DxfCodeValue(DxfReferenceType.Count, 98)]
+	[DxfCollectionCodeValue(10, 20)]
+	public List<XY> SeedPoints { get; set; } = new List<XY>();
+
+	//63	For MPolygon, pattern fill color as the ACI
+	/// <summary>
+	/// Hatch style.
+	/// </summary>
+	[DxfCodeValue(75)]
+	public HatchStyleType Style { get; set; }
+
+	/// <inheritdoc/>
+	public override string SubclassMarker => DxfSubclassMarker.Hatch;
+
+	private double _patternAngle;
+
+	private double _patternScale;
+
+	//73	For MPolygon, boundary annotation flag:
+	//0 = boundary is not an annotated boundary
+	//1 = boundary is an annotated boundary
+	//78	Number of pattern definition lines
+	//varies
+	//Pattern line data.Repeats number of times specified by code 78. See Pattern Data
+	//11	For MPolygon, offset vector
+	//99	For MPolygon, number of degenerate boundary paths(loops), where a degenerate boundary path is a border that is ignored by the hatch
+	/// <inheritdoc/>
+	public Hatch() : base() { }
+
+	/// <inheritdoc/>
+	public override void ApplyTransform(Transform transform)
+	{
+		if (this.IsAssociative)
+		{
+			//Not sure how this effects the hatch
+		}
+
+		var newNormal = this.transformNormal(transform, this.Normal);
+		var worldTransform = this.getWorldMatrix(transform, this.Normal, newNormal, out Matrix3 transOW, out Matrix3 transWO);
+
+		foreach (BoundaryPath p in this.Paths)
+		{
+			p.ApplyTransform(transform);
+		}
+
+		XY refAxis = XY.Rotate(XY.AxisX, this._patternAngle);
+		refAxis = this._patternScale * refAxis;
+		XYZ v = transOW * new XYZ(refAxis.X, refAxis.Y, 0.0);
+		v = worldTransform * v;
+		v = transWO * v;
+		XY axis = new XY(v.X, v.Y);
+		this._patternAngle = axis.GetAngle();
+
+		double patScale = axis.GetLength();
+		this._patternScale = MathHelper.IsZero(patScale) ? MathHelper.Epsilon : patScale;
+
+		this.Pattern?.Update(transform.Translation.Convert<XY>(), this._patternAngle, this._patternScale);
+		this.Normal = newNormal;
+	}
+
+	/// <inheritdoc/>
+	public override CadObject Clone()
+	{
+		Hatch clone = base.Clone() as Hatch;
+
+		clone.GradientColor = this.GradientColor?.Clone();
+		clone.Pattern = this.Pattern?.Clone();
+
+		clone.Paths = new List<BoundaryPath>();
+		foreach (BoundaryPath item in this.Paths)
+		{
+			clone.Paths.Add(item.Clone());
+		}
+
+		return clone;
+	}
+
+	/// <summary>
+	/// Explode the hatch edges into the equivalent entities.
+	/// </summary>
+	/// <returns></returns>
+	public IEnumerable<Entity> Explode()
+	{
+		List<Entity> entities = new List<Entity>();
+
+		foreach (BoundaryPath b in this.Paths)
+		{
+			foreach (BoundaryPath.Edge e in b.Edges)
 			{
-				this._patternAngle = value;
-				this.Pattern?.Update(XY.Zero, this._patternAngle, 1);
+				entities.Add(e.ToEntity());
 			}
 		}
 
-		/// <summary>
-		/// Hatch pattern scale or spacing(pattern fill only).
-		/// </summary>
-		[DxfCodeValue(41)]
-		public double PatternScale
-		{
-			get
-			{
-				return this._patternScale;
-			}
+		return entities;
+	}
 
-			set
-			{
-				this._patternScale = value;
-				this.Pattern?.Update(XY.Zero, 0, this._patternScale);
-			}
+	public IEnumerable<Line> ExplodePattern()
+	{
+		List<Line> lines = new List<Line>();
+
+		if (this.Pattern == null
+			|| this.Pattern.Lines.Count == 0
+			|| this.Paths.Count == 0)
+		{
+			return lines;
 		}
 
-		/// <summary>
-		/// Hatch pattern type
-		/// </summary>
-		[DxfCodeValue(76)]
-		public HatchPatternType PatternType { get; set; }
+		throw new System.NotImplementedException();
+	}
 
-		/// <summary>
-		/// Pixel size used to determine the density to perform various intersection and ray casting operations in hatch pattern computation for associative hatches and hatches created with the Flood method of hatching
-		/// </summary>
-		[DxfCodeValue(47)]
-		public double PixelSize { get; set; }
+	/// <inheritdoc/>
+	public override BoundingBox GetBoundingBox()
+	{
+		BoundingBox box = BoundingBox.Null;
 
-		/// <summary>
-		/// Seed points codes (in OCS)
-		/// </summary>
-		[DxfCodeValue(DxfReferenceType.Count, 98)]
-		[DxfCollectionCodeValue(10, 20)]
-		public List<XY> SeedPoints { get; set; } = new List<XY>();
-
-		//63	For MPolygon, pattern fill color as the ACI
-		/// <summary>
-		/// Hatch style.
-		/// </summary>
-		[DxfCodeValue(75)]
-		public HatchStyleType Style { get; set; }
-
-		/// <inheritdoc/>
-		public override string SubclassMarker => DxfSubclassMarker.Hatch;
-
-		private double _patternAngle;
-
-		private double _patternScale;
-
-		//73	For MPolygon, boundary annotation flag:
-		//0 = boundary is not an annotated boundary
-		//1 = boundary is an annotated boundary
-		//78	Number of pattern definition lines
-		//varies
-		//Pattern line data.Repeats number of times specified by code 78. See Pattern Data
-		//11	For MPolygon, offset vector
-		//99	For MPolygon, number of degenerate boundary paths(loops), where a degenerate boundary path is a border that is ignored by the hatch
-		/// <inheritdoc/>
-		public Hatch() : base() { }
-
-		/// <inheritdoc/>
-		public override void ApplyTransform(Transform transform)
+		foreach (BoundaryPath bp in this.Paths)
 		{
-			if (this.IsAssociative)
-			{
-				//Not sure how this effects the hatch
-			}
-
-			var newNormal = this.transformNormal(transform, this.Normal);
-			var worldTransform = this.getWorldMatrix(transform, this.Normal, newNormal, out Matrix3 transOW, out Matrix3 transWO);
-
-			foreach (BoundaryPath p in this.Paths)
-			{
-				p.ApplyTransform(transform);
-			}
-
-			XY refAxis = XY.Rotate(XY.AxisX, this._patternAngle);
-			refAxis = this._patternScale * refAxis;
-			XYZ v = transOW * new XYZ(refAxis.X, refAxis.Y, 0.0);
-			v = worldTransform * v;
-			v = transWO * v;
-			XY axis = new XY(v.X, v.Y);
-			this._patternAngle = axis.GetAngle();
-
-			double patScale = axis.GetLength();
-			this._patternScale = MathHelper.IsZero(patScale) ? MathHelper.Epsilon : patScale;
-
-			this.Pattern?.Update(transform.Translation.Convert<XY>(), this._patternAngle, this._patternScale);
-			this.Normal = newNormal;
+			box = box.Merge(bp.GetBoundingBox());
 		}
 
-		/// <inheritdoc/>
-		public override CadObject Clone()
-		{
-			Hatch clone = base.Clone() as Hatch;
-
-			clone.GradientColor = this.GradientColor?.Clone();
-			clone.Pattern = this.Pattern?.Clone();
-
-			clone.Paths = new List<BoundaryPath>();
-			foreach (BoundaryPath item in this.Paths)
-			{
-				clone.Paths.Add(item.Clone());
-			}
-
-			return clone;
-		}
-
-		/// <summary>
-		/// Explode the hatch edges into the equivalent entities.
-		/// </summary>
-		/// <returns></returns>
-		public IEnumerable<Entity> Explode()
-		{
-			List<Entity> entities = new List<Entity>();
-
-			foreach (BoundaryPath b in this.Paths)
-			{
-				foreach (BoundaryPath.Edge e in b.Edges)
-				{
-					entities.Add(e.ToEntity());
-				}
-			}
-
-			return entities;
-		}
-
-		/// <inheritdoc/>
-		public override BoundingBox GetBoundingBox()
-		{
-			BoundingBox box = BoundingBox.Null;
-
-			foreach (BoundaryPath bp in this.Paths)
-			{
-				box = box.Merge(bp.GetBoundingBox());
-			}
-
-			return box;
-		}
+		return box;
 	}
 }

--- a/src/ACadSharp/Entities/Hatch.cs
+++ b/src/ACadSharp/Entities/Hatch.cs
@@ -219,18 +219,32 @@ public partial class Hatch : Entity
 		return entities;
 	}
 
-	public IEnumerable<Line> ExplodePattern()
+	public IEnumerable<Entity> ExplodePattern()
 	{
-		List<Line> lines = new List<Line>();
+		List<Entity> entities = new List<Entity>();
 
 		if (this.Pattern == null
 			|| this.Pattern.Lines.Count == 0
 			|| this.Paths.Count == 0)
 		{
-			return lines;
+			return entities;
 		}
 
-		throw new System.NotImplementedException();
+		foreach (BoundaryPath b in this.Paths)
+		{
+			foreach (var pl in this.Pattern.Lines)
+			{
+				var l = pl.ToLine2D();
+
+				var intersections = b.FindIntersections(l);
+				foreach (var intersection in b.FindIntersections(l))
+				{
+					entities.Add(new Circle(intersection.Convert<XYZ>(), 0.5));
+				}
+			}
+		}
+
+		return entities;
 	}
 
 	/// <inheritdoc/>

--- a/src/ACadSharp/Entities/HatchPattern.Line.cs
+++ b/src/ACadSharp/Entities/HatchPattern.Line.cs
@@ -1,77 +1,95 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Geometry;
 using System;
 using System.Collections.Generic;
 
-namespace ACadSharp.Entities
+namespace ACadSharp.Entities;
+
+public partial class HatchPattern
 {
-	public partial class HatchPattern
+	public class Line
 	{
-		public class Line
+		/// <summary>
+		/// Pattern line angle.
+		/// </summary>
+		[DxfCodeValue(DxfReferenceType.IsAngle, 53)]
+		public double Angle { get; set; }
+
+		/// <summary>
+		/// Pattern line base point.
+		/// </summary>
+		[DxfCodeValue(43, 44)]
+		public XY BasePoint { get; set; }
+
+		/// <summary>
+		/// Line dashes.
+		/// </summary>
+		[DxfCodeValue(DxfReferenceType.Count, 79)]
+		[DxfCollectionCodeValue(49)]
+		public List<double> DashLengths { get; set; } = new List<double>();
+
+		/// <summary>
+		/// Gets the direction vector of the pattern line based on the specified angle.
+		/// </summary>
+		public XY Direction
 		{
-			/// <summary>
-			/// Pattern line angle.
-			/// </summary>
-			[DxfCodeValue(DxfReferenceType.IsAngle, 53)]
-			public double Angle { get; set; }
-
-			/// <summary>
-			/// Pattern line base point.
-			/// </summary>
-			[DxfCodeValue(43, 44)]
-			public XY BasePoint { get; set; }
-
-			/// <summary>
-			/// Line dashes.
-			/// </summary>
-			[DxfCodeValue(DxfReferenceType.Count, 79)]
-			[DxfCollectionCodeValue(49)]
-			public List<double> DashLengths { get; set; } = new List<double>();
-
-			/// <summary>
-			/// Perpendicular distance for the next line to be located.
-			/// </summary>
-			public double LineOffset
+			get
 			{
-				get
-				{
-					double cos = Math.Cos(0.0 - this.Angle);
-					double sin = Math.Sin(0.0 - this.Angle);
-
-					return this.Offset.X * sin + this.Offset.Y * cos;
-				}
+				double cos = Math.Cos(this.Angle);
+				double sin = Math.Sin(this.Angle);
+				return new XY(cos, sin);
 			}
+		}
 
-			/// <summary>
-			/// Gets or sets the local displacements between lines of the same family.
-			/// </summary>
-			[DxfCodeValue(45, 46)]
-			public XY Offset { get; set; }
-
-			/// <summary>
-			/// Gets the horizontal shift of the offset after applying the specified angle transformation.
-			/// </summary>
-			public double Shift
+		/// <summary>
+		/// Perpendicular distance for the next line to be located.
+		/// </summary>
+		public double LineOffset
+		{
+			get
 			{
-				get
-				{
-					double cos = Math.Cos(0.0 - this.Angle);
-					double sin = Math.Sin(0.0 - this.Angle);
+				double cos = Math.Cos(0.0 - this.Angle);
+				double sin = Math.Sin(0.0 - this.Angle);
 
-					return this.Offset.X * cos - this.Offset.Y * sin;
-				}
+				return this.Offset.X * sin + this.Offset.Y * cos;
 			}
+		}
 
-			/// <summary>
-			/// Clones this line.
-			/// </summary>
-			/// <returns></returns>
-			public Line Clone()
+		/// <summary>
+		/// Gets or sets the local displacements between lines of the same family.
+		/// </summary>
+		[DxfCodeValue(45, 46)]
+		public XY Offset { get; set; }
+
+		/// <summary>
+		/// Gets the horizontal shift of the offset after applying the specified angle transformation.
+		/// </summary>
+		public double Shift
+		{
+			get
 			{
-				Line clone = (Line)this.MemberwiseClone();
-				clone.DashLengths = new List<double>(this.DashLengths);
-				return clone;
+				double cos = Math.Cos(0.0 - this.Angle);
+				double sin = Math.Sin(0.0 - this.Angle);
+
+				return this.Offset.X * cos - this.Offset.Y * sin;
 			}
+		}
+
+		/// <summary>
+		/// Clones this line.
+		/// </summary>
+		/// <returns></returns>
+		public Line Clone()
+		{
+			Line clone = (Line)this.MemberwiseClone();
+			clone.DashLengths = new List<double>(this.DashLengths);
+			return clone;
+		}
+
+		public Line2D ToLine2D()
+		{
+			return new Line2D(this.BasePoint, this.Direction);
 		}
 	}
 }

--- a/src/ACadSharp/Entities/HatchPattern.cs
+++ b/src/ACadSharp/Entities/HatchPattern.cs
@@ -8,202 +8,201 @@ using System.IO;
 using System.Linq;
 using System.Text;
 
-namespace ACadSharp.Entities
+namespace ACadSharp.Entities;
+
+public partial class HatchPattern
 {
-	public partial class HatchPattern
+	public static HatchPattern Solid { get { return new HatchPattern("SOLID"); } }
+
+	/// <summary>
+	/// Description for this pattern.
+	/// </summary>
+	/// <remarks>
+	/// The description is not saved in dxf or dwg files, its only used in the .pat files.
+	/// </remarks>
+	public string Description { get; set; }
+
+	/// <summary>
+	/// Gets or sets the collection of <see cref="Line"/> objects.
+	/// </summary>
+	/// <remarks>This property allows adding, removing, or modifying the lines in the collection. Changes to this
+	/// collection directly affect the associated context.</remarks>
+	[DxfCodeValue(DxfReferenceType.Count, 79)]
+	public List<Line> Lines { get; set; } = new List<Line>();
+
+	/// <summary>
+	/// Name for this pattern.
+	/// </summary>
+	[DxfCodeValue(2)]
+	public string Name { get; set; }
+
+	/// <summary>
+	/// Default constructor of a hatch pattern.
+	/// </summary>
+	/// <param name="name"></param>
+	public HatchPattern(string name)
 	{
-		public static HatchPattern Solid { get { return new HatchPattern("SOLID"); } }
+		this.Name = name;
+	}
 
-		/// <summary>
-		/// Description for this pattern.
-		/// </summary>
-		/// <remarks>
-		/// The description is not saved in dxf or dwg files, its only used in the .pat files.
-		/// </remarks>
-		public string Description { get; set; }
+	/// <summary>
+	/// Load a collection of patterns from a .pat file.
+	/// </summary>
+	/// <param name="path"></param>
+	/// <returns></returns>
+	public static IEnumerable<HatchPattern> LoadFrom(string path)
+	{
+		List<HatchPattern> patterns = new List<HatchPattern>();
+		HatchPattern current = null;
 
-		/// <summary>
-		/// Gets or sets the collection of <see cref="Line"/> objects.
-		/// </summary>
-		/// <remarks>This property allows adding, removing, or modifying the lines in the collection. Changes to this
-		/// collection directly affect the associated context.</remarks>
-		[DxfCodeValue(DxfReferenceType.Count, 79)]
-		public List<Line> Lines { get; set; } = new List<Line>();
+		var lines = File.ReadLines(path)
+			.Select(line => line.Trim())
+			.Where(line => !string.IsNullOrWhiteSpace(line) && !line.StartsWith(";"))
+			.ToQueue();
 
-		/// <summary>
-		/// Name for this pattern.
-		/// </summary>
-		[DxfCodeValue(2)]
-		public string Name { get; set; }
+		List<int> leadingIndices = lines.Select((line, i) => (line, i))
+			.Where(t => t.line.StartsWith("*"))
+			.Select(t => t.i)
+			.OrderBy(i => i).ToList();
 
-		/// <summary>
-		/// Default constructor of a hatch pattern.
-		/// </summary>
-		/// <param name="name"></param>
-		public HatchPattern(string name)
+		leadingIndices.Add(lines.Count);
+
+		while (lines.TryDequeue(out string line))
 		{
-			this.Name = name;
+			if (line.StartsWith("*"))
+			{
+				int index = line.IndexOf(',');
+				string noPrefix = line.Remove(0, 1);
+				current = new HatchPattern(noPrefix.Substring(0, index - 1));
+				current.Description = new string(noPrefix.Skip(index).ToArray()).Trim();
+
+				patterns.Add(current);
+			}
+			else
+			{
+				//;angle, x, y, shift, offset, [dash, space, ...]
+				string[] data = line.Split(',');
+				Line l = new Line();
+				//angle
+				l.Angle = MathHelper.DegToRad(double.Parse(data[0], CultureInfo.InvariantCulture));
+				//x, y
+				l.BasePoint = new XY(double.Parse(data[1], CultureInfo.InvariantCulture), double.Parse(data[2], CultureInfo.InvariantCulture));
+
+				double shift = double.Parse(data[3], CultureInfo.InvariantCulture);
+				double offset = double.Parse(data[4], CultureInfo.InvariantCulture);
+				XY dir = new XY(shift, offset);
+				double cos = Math.Cos(l.Angle);
+				double sin = Math.Sin(l.Angle);
+				l.Offset = new XY(dir.X * cos - dir.Y * sin, dir.X * sin + dir.Y * cos);
+
+				IEnumerable<string> dashes = data.Skip(5);
+				if (dashes.Any())
+				{
+					l.DashLengths.AddRange(dashes.Select(d => double.Parse(d, CultureInfo.InvariantCulture)));
+				}
+
+				current.Lines.Add(l);
+			}
 		}
 
-		/// <summary>
-		/// Load a collection of patterns from a .pat file.
-		/// </summary>
-		/// <param name="path"></param>
-		/// <returns></returns>
-		public static IEnumerable<HatchPattern> LoadFrom(string path)
+		return patterns;
+	}
+
+	/// <summary>
+	/// Write a pattern or a collection of patterns into a .pat file.
+	/// </summary>
+	/// <param name="filename"></param>
+	/// <param name="patterns"></param>
+	public static void SavePatterns(string filename, params HatchPattern[] patterns)
+	{
+		using StreamWriter writer = File.CreateText(filename);
+
+		foreach (HatchPattern p in patterns)
 		{
-			List<HatchPattern> patterns = new List<HatchPattern>();
-			HatchPattern current = null;
+			writer.Write($"*{p.Name}");
 
-			var lines = File.ReadLines(path)
-				.Select(line => line.Trim())
-				.Where(line => !string.IsNullOrWhiteSpace(line) && !line.StartsWith(";"))
-				.ToQueue();
-
-			List<int> leadingIndices = lines.Select((line, i) => (line, i))
-				.Where(t => t.line.StartsWith("*"))
-				.Select(t => t.i)
-				.OrderBy(i => i).ToList();
-
-			leadingIndices.Add(lines.Count);
-
-			while (lines.TryDequeue(out string line))
+			if (!p.Description.IsNullOrEmpty())
 			{
-				if (line.StartsWith("*"))
-				{
-					int index = line.IndexOf(',');
-					string noPrefix = line.Remove(0, 1);
-					current = new HatchPattern(noPrefix.Substring(0, index - 1));
-					current.Description = new string(noPrefix.Skip(index).ToArray()).Trim();
-
-					patterns.Add(current);
-				}
-				else
-				{
-					//;angle, x, y, shift, offset, [dash, space, ...]
-					string[] data = line.Split(',');
-					Line l = new Line();
-					//angle
-					l.Angle = MathHelper.DegToRad(double.Parse(data[0], CultureInfo.InvariantCulture));
-					//x, y
-					l.BasePoint = new XY(double.Parse(data[1], CultureInfo.InvariantCulture), double.Parse(data[2], CultureInfo.InvariantCulture));
-
-					double shift = double.Parse(data[3], CultureInfo.InvariantCulture);
-					double offset = double.Parse(data[4], CultureInfo.InvariantCulture);
-					XY dir = new XY(shift, offset);
-					double cos = Math.Cos(l.Angle);
-					double sin = Math.Sin(l.Angle);
-					l.Offset = new XY(dir.X * cos - dir.Y * sin, dir.X * sin + dir.Y * cos);
-
-					IEnumerable<string> dashes = data.Skip(5);
-					if (dashes.Any())
-					{
-						l.DashLengths.AddRange(dashes.Select(d => double.Parse(d, CultureInfo.InvariantCulture)));
-					}
-
-					current.Lines.Add(l);
-				}
+				writer.Write($",{p.Description}");
 			}
 
-			return patterns;
-		}
+			writer.WriteLine();
 
-		/// <summary>
-		/// Write a pattern or a collection of patterns into a .pat file.
-		/// </summary>
-		/// <param name="filename"></param>
-		/// <param name="patterns"></param>
-		public static void SavePatterns(string filename, params HatchPattern[] patterns)
-		{
-			using StreamWriter writer = File.CreateText(filename);
-
-			foreach (HatchPattern p in patterns)
+			foreach (Line line in p.Lines)
 			{
-				writer.Write($"*{p.Name}");
+				StringBuilder sb = new StringBuilder();
 
-				if (!p.Description.IsNullOrEmpty())
+				double angle = MathHelper.DegToRad(line.Angle);
+				double cos = Math.Cos(0.0 - line.Angle);
+				double sin = Math.Sin(0.0 - line.Angle);
+
+				var v = new XY(line.Offset.X * cos - line.Offset.Y * sin, line.Offset.X * sin + line.Offset.Y * cos);
+
+				sb.Append(angle.ToString(CultureInfo.InvariantCulture));
+				sb.Append(",");
+				sb.Append(line.BasePoint.ToString(CultureInfo.InvariantCulture));
+				sb.Append(",");
+				sb.Append(v.ToString(CultureInfo.InvariantCulture));
+
+				if (line.DashLengths.Count > 0)
 				{
-					writer.Write($",{p.Description}");
-				}
-
-				writer.WriteLine();
-
-				foreach (Line line in p.Lines)
-				{
-					StringBuilder sb = new StringBuilder();
-
-					double angle = MathHelper.DegToRad(line.Angle);
-					double cos = Math.Cos(0.0 - line.Angle);
-					double sin = Math.Sin(0.0 - line.Angle);
-
-					var v = new XY(line.Offset.X * cos - line.Offset.Y * sin, line.Offset.X * sin + line.Offset.Y * cos);
-
-					sb.Append(angle.ToString(CultureInfo.InvariantCulture));
 					sb.Append(",");
-					sb.Append(line.BasePoint.ToString(CultureInfo.InvariantCulture));
-					sb.Append(",");
-					sb.Append(v.ToString(CultureInfo.InvariantCulture));
-
-					if (line.DashLengths.Count > 0)
+					sb.Append(line.DashLengths[0].ToString(CultureInfo.InvariantCulture));
+					for (int i = 1; i < line.DashLengths.Count; i++)
 					{
 						sb.Append(",");
-						sb.Append(line.DashLengths[0].ToString(CultureInfo.InvariantCulture));
-						for (int i = 1; i < line.DashLengths.Count; i++)
-						{
-							sb.Append(",");
-							sb.Append(line.DashLengths[i].ToString(CultureInfo.InvariantCulture));
-						}
+						sb.Append(line.DashLengths[i].ToString(CultureInfo.InvariantCulture));
 					}
-
-					writer.WriteLine(sb.ToString());
 				}
+
+				writer.WriteLine(sb.ToString());
 			}
 		}
+	}
 
-		/// <summary>
-		/// Clones the current pattern.
-		/// </summary>
-		/// <returns></returns>
-		public HatchPattern Clone()
+	/// <summary>
+	/// Clones the current pattern.
+	/// </summary>
+	/// <returns></returns>
+	public HatchPattern Clone()
+	{
+		HatchPattern clone = (HatchPattern)this.MemberwiseClone();
+
+		clone.Lines = new List<Line>();
+		foreach (var item in this.Lines)
 		{
-			HatchPattern clone = (HatchPattern)this.MemberwiseClone();
-
-			clone.Lines = new List<Line>();
-			foreach (var item in this.Lines)
-			{
-				clone.Lines.Add(item.Clone());
-			}
-
-			return clone;
+			clone.Lines.Add(item.Clone());
 		}
 
-		/// <inheritdoc/>
-		public override string ToString()
+		return clone;
+	}
+
+	/// <inheritdoc/>
+	public override string ToString()
+	{
+		return $"{this.Name}";
+	}
+
+	/// <summary>
+	/// Update the pattern geometry with a translation, rotation and scale.
+	/// </summary>
+	/// <param name="translation"></param>
+	/// <param name="rotation"></param>
+	/// <param name="scale"></param>
+	public void Update(XY translation, double rotation, double scale)
+	{
+		var tr = Transform.CreateTranslation(translation.Convert<XYZ>());
+		var sc = Transform.CreateScaling(new XYZ(scale));
+		var rot = Transform.CreateRotation(XYZ.AxisZ, rotation);
+
+		var transform = new Transform(tr.Matrix * sc.Matrix * rot.Matrix);
+
+		foreach (var line in Lines)
 		{
-			return $"{this.Name}";
-		}
-
-		/// <summary>
-		/// Update the pattern geometry with a translation, rotation and scale.
-		/// </summary>
-		/// <param name="translation"></param>
-		/// <param name="rotation"></param>
-		/// <param name="scale"></param>
-		public void Update(XY translation, double rotation, double scale)
-		{
-			var tr = Transform.CreateTranslation(translation.Convert<XYZ>());
-			var sc = Transform.CreateScaling(new XYZ(scale));
-			var rot = Transform.CreateRotation(XYZ.AxisZ, rotation);
-
-			var transform = new Transform(tr.Matrix * sc.Matrix * rot.Matrix);
-
-			foreach (var line in Lines)
-			{
-				line.Angle += rotation;
-				line.BasePoint = transform.ApplyTransform(line.BasePoint.Convert<XYZ>()).Convert<XY>();
-				line.Offset = transform.ApplyTransform(line.Offset.Convert<XYZ>()).Convert<XY>();
-				line.DashLengths = line.DashLengths.Select(d => d * scale).ToList();
-			}
+			line.Angle += rotation;
+			line.BasePoint = transform.ApplyTransform(line.BasePoint.Convert<XYZ>()).Convert<XY>();
+			line.Offset = transform.ApplyTransform(line.Offset.Convert<XYZ>()).Convert<XY>();
+			line.DashLengths = line.DashLengths.Select(d => d * scale).ToList();
 		}
 	}
 }

--- a/src/ACadSharp/Entities/HatchStyleType.cs
+++ b/src/ACadSharp/Entities/HatchStyleType.cs
@@ -1,21 +1,20 @@
-﻿namespace ACadSharp.Entities
+﻿namespace ACadSharp.Entities;
+
+/// <summary>
+/// Hatch pattern style.
+/// </summary>
+public enum HatchStyleType
 {
 	/// <summary>
-	/// Hatch pattern style.
+	/// Hatch "odd parity" area.
 	/// </summary>
-	public enum HatchStyleType
-	{
-		/// <summary>
-		/// Hatch "odd parity" area.
-		/// </summary>
-		Normal = 0,
-		/// <summary>
-		/// Hatch outermost area only.
-		/// </summary>
-		Outer = 1,
-		/// <summary>
-		/// Hatch through entire area.
-		/// </summary>
-		Ignore = 2
-	}
+	Normal = 0,
+	/// <summary>
+	/// Hatch outermost area only.
+	/// </summary>
+	Outer = 1,
+	/// <summary>
+	/// Hatch through entire area.
+	/// </summary>
+	Ignore = 2
 }

--- a/src/ACadSharp/Entities/Line.cs
+++ b/src/ACadSharp/Entities/Line.cs
@@ -1,94 +1,99 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Geometry;
 
-namespace ACadSharp.Entities
+namespace ACadSharp.Entities;
+
+/// <summary>
+/// Represents a <see cref="Line"/> entity.
+/// </summary>
+/// <remarks>
+/// Object name <see cref="DxfFileToken.EntityLine"/> <br/>
+/// Dxf class name <see cref="DxfSubclassMarker.Line"/>
+/// </remarks>
+[DxfName(DxfFileToken.EntityLine)]
+[DxfSubClass(DxfSubclassMarker.Line)]
+public class Line : Entity
 {
 	/// <summary>
-	/// Represents a <see cref="Line"/> entity.
+	/// A 3D coordinate representing the end point of the object.
 	/// </summary>
-	/// <remarks>
-	/// Object name <see cref="DxfFileToken.EntityLine"/> <br/>
-	/// Dxf class name <see cref="DxfSubclassMarker.Line"/>
-	/// </remarks>
-	[DxfName(DxfFileToken.EntityLine)]
-	[DxfSubClass(DxfSubclassMarker.Line)]
-	public class Line : Entity
+	[DxfCodeValue(11, 21, 31)]
+	public XYZ EndPoint { get; set; } = XYZ.Zero;
+
+	/// <summary>
+	/// Specifies the three-dimensional normal unit vector for the object.
+	/// </summary>
+	[DxfCodeValue(210, 220, 230)]
+	public XYZ Normal { get; set; } = XYZ.AxisZ;
+
+	/// <inheritdoc/>
+	public override string ObjectName => DxfFileToken.EntityLine;
+
+	/// <inheritdoc/>
+	public override ObjectType ObjectType => ObjectType.LINE;
+
+	/// <summary>
+	/// A 3D coordinate representing the start point of the object.
+	/// </summary>
+	[DxfCodeValue(10, 20, 30)]
+	public XYZ StartPoint { get; set; } = XYZ.Zero;
+
+	/// <inheritdoc/>
+	public override string SubclassMarker => DxfSubclassMarker.Line;
+
+	/// <summary>
+	/// Specifies the distance a 2D object is extruded above or below its elevation.
+	/// </summary>
+	[DxfCodeValue(39)]
+	public double Thickness { get; set; } = 0.0;
+
+	/// <summary>
+	/// Default constructor.
+	/// </summary>
+	public Line() : base() { }
+
+	/// <summary>
+	/// Constructor with the start and end.
+	/// </summary>
+	/// <param name="start"></param>
+	/// <param name="end"></param>
+	public Line(IVector start, IVector end) : base()
 	{
-		/// <summary>
-		/// A 3D coordinate representing the end point of the object.
-		/// </summary>
-		[DxfCodeValue(11, 21, 31)]
-		public XYZ EndPoint { get; set; } = XYZ.Zero;
+		this.StartPoint = start.Convert<XYZ>();
+		this.EndPoint = end.Convert<XYZ>();
+	}
 
-		/// <summary>
-		/// Specifies the three-dimensional normal unit vector for the object.
-		/// </summary>
-		[DxfCodeValue(210, 220, 230)]
-		public XYZ Normal { get; set; } = XYZ.AxisZ;
+	/// <summary>
+	/// Constructor with the start and end.
+	/// </summary>
+	/// <param name="start"></param>
+	/// <param name="end"></param>
+	public Line(XYZ start, XYZ end) : base()
+	{
+		this.StartPoint = start;
+		this.EndPoint = end;
+	}
 
-		/// <inheritdoc/>
-		public override string ObjectName => DxfFileToken.EntityLine;
+	/// <inheritdoc/>
+	public override void ApplyTransform(Transform transform)
+	{
+		this.StartPoint = transform.ApplyTransform(this.StartPoint);
+		this.EndPoint = transform.ApplyTransform(this.EndPoint);
+		this.Normal = this.transformNormal(transform, this.Normal);
+	}
 
-		/// <inheritdoc/>
-		public override ObjectType ObjectType => ObjectType.LINE;
+	/// <inheritdoc/>
+	public override BoundingBox GetBoundingBox()
+	{
+		var min = new XYZ(System.Math.Min(this.StartPoint.X, this.EndPoint.X), System.Math.Min(this.StartPoint.Y, this.EndPoint.Y), System.Math.Min(this.StartPoint.Z, this.EndPoint.Z));
+		var max = new XYZ(System.Math.Max(this.StartPoint.X, this.EndPoint.X), System.Math.Max(this.StartPoint.Y, this.EndPoint.Y), System.Math.Max(this.StartPoint.Z, this.EndPoint.Z));
 
-		/// <summary>
-		/// A 3D coordinate representing the start point of the object.
-		/// </summary>
-		[DxfCodeValue(10, 20, 30)]
-		public XYZ StartPoint { get; set; } = XYZ.Zero;
+		return new BoundingBox(min, max);
+	}
 
-		/// <inheritdoc/>
-		public override string SubclassMarker => DxfSubclassMarker.Line;
-
-		/// <summary>
-		/// Specifies the distance a 2D object is extruded above or below its elevation.
-		/// </summary>
-		[DxfCodeValue(39)]
-		public double Thickness { get; set; } = 0.0;
-
-		/// <summary>
-		/// Default constructor.
-		/// </summary>
-		public Line() : base() { }
-
-		/// <summary>
-		/// Constructor with the start and end.
-		/// </summary>
-		/// <param name="start"></param>
-		/// <param name="end"></param>
-		public Line(IVector start, IVector end) : base()
-		{
-			this.StartPoint = start.Convert<XYZ>();
-			this.EndPoint = end.Convert<XYZ>();
-		}
-
-		/// <summary>
-		/// Constructor with the start and end.
-		/// </summary>
-		/// <param name="start"></param>
-		/// <param name="end"></param>
-		public Line(XYZ start, XYZ end) : base()
-		{
-			this.StartPoint = start;
-			this.EndPoint = end;
-		}
-
-		/// <inheritdoc/>
-		public override void ApplyTransform(Transform transform)
-		{
-			this.StartPoint = transform.ApplyTransform(this.StartPoint);
-			this.EndPoint = transform.ApplyTransform(this.EndPoint);
-			this.Normal = this.transformNormal(transform, this.Normal);
-		}
-
-		/// <inheritdoc/>
-		public override BoundingBox GetBoundingBox()
-		{
-			var min = new XYZ(System.Math.Min(this.StartPoint.X, this.EndPoint.X), System.Math.Min(this.StartPoint.Y, this.EndPoint.Y), System.Math.Min(this.StartPoint.Z, this.EndPoint.Z));
-			var max = new XYZ(System.Math.Max(this.StartPoint.X, this.EndPoint.X), System.Math.Max(this.StartPoint.Y, this.EndPoint.Y), System.Math.Max(this.StartPoint.Z, this.EndPoint.Z));
-
-			return new BoundingBox(min, max);
-		}
+	public Segment3D ToSegment3D()
+	{
+		return new Segment3D(this.StartPoint, this.EndPoint);
 	}
 }


### PR DESCRIPTION
# Description

ExplodePattern() now computes candidate pattern lines from boundary bounding boxes, sorts intersection points along each pattern line, and emits inside spans in intersection pairs.

Added dashed-pattern support in emitDashedSegment(...), including cycle handling, positive/negative dash lengths (draw/skip), and guard logic for degenerate dash sequences; plus tests covering arc/ellipse/line/polyline boundaries and explode behavior.