### PR TITLE
Fix GetActiveColor() to resolve nested ByLayer when Color IsByBlock in Entity.cs

### DIFF
--- a/src/ACadSharp/Entities/Entity.cs
+++ b/src/ACadSharp/Entities/Entity.cs
@@ -169,6 +169,10 @@ public abstract class Entity : CadObject, IEntity
 		else if (this.Color.IsByBlock && this.Owner is BlockRecord record)
 		{
 			color = record.BlockEntity.Color;
+			if (color.IsByLayer)
+			{
+				color = this.Layer.Color;
+			}
 		}
 		else
 		{


### PR DESCRIPTION
- I believe this GetActiveColor() function is intended to return the actual color used to render an entity, not the ByLayer or ByBlock indicator.
- While using the function I received a ByLayer value back, which is not the expected actual color. During debugging I found that the IsByBlock branch returned a color that was ByLayer instead of a resolved actual color. To address that, I added the nested check so that when the block’s color resolves to ByLayer, we instead return the entity’s layer color.
- I am not sure this handles all nested or edge cases. There may be other combinations of nested ByBlock/ByLayer or other owner types that still return an indicator instead of an actual color.
- This tentative fix is based on my debugging and current understanding. It may need a more comprehensive resolution strategy (for example, a generic color resolution helper that traverses layers/blocks until an actual color is found).
- Please review.

