### PR TITLE
Fix insert transforms for block base points

### DIFF
--- a/src/ACadSharp.Examples/Entities/InsertExamples.cs
+++ b/src/ACadSharp.Examples/Entities/InsertExamples.cs
@@ -43,5 +43,25 @@ namespace ACadSharp.Examples.Entities
 
 			//Once the file is saved you will have an instance of my_block scaled by 2 and at the point 100, 100
 		}
+
+		/// <summary>
+		/// Create an insert whose block has a non-zero base point.
+		/// </summary>
+		public static void AddInsertWithBasePointIntoModel()
+		{
+			BlockRecord record = new BlockRecord("my_block");
+			record.BlockEntity.BasePoint = new CSMath.XYZ(10, 10, 0);
+			record.Entities.Add(new Line(new CSMath.XYZ(10, 10, 0), new CSMath.XYZ(20, 10, 0)));
+
+			Insert insert = new Insert(record)
+			{
+				InsertPoint = new CSMath.XYZ(100, 100, 0)
+			};
+
+			CadDocument doc = new CadDocument();
+			doc.Entities.Add(insert);
+
+			// The line is now anchored so that the block base point lands on 100, 100.
+		}
 	}
 }

--- a/src/ACadSharp.Tests/Entities/InsertTest.cs
+++ b/src/ACadSharp.Tests/Entities/InsertTest.cs
@@ -155,6 +155,24 @@ public class InsertTest
 	}
 
 	[Fact]
+	public void GetTransformHonorsBlockBasePoint()
+	{
+		BlockRecord record = new BlockRecord(this._blockName);
+		record.BlockEntity.BasePoint = new XYZ(10, 10, 0);
+		record.Entities.Add(new Line(new XYZ(10, 10, 0), new XYZ(20, 10, 0)));
+
+		Insert insert = new Insert(record)
+		{
+			InsertPoint = new XYZ(100, 100, 0)
+		};
+
+		Transform transform = insert.GetTransform();
+
+		Assert.Equal(new XYZ(100, 100, 0), transform.ApplyTransform(new XYZ(10, 10, 0)));
+		Assert.Equal(new XYZ(110, 100, 0), transform.ApplyTransform(new XYZ(20, 10, 0)));
+	}
+
+	[Fact]
 	public void LinkedAttributes()
 	{
 		BlockRecord record = new BlockRecord(this._blockName);

--- a/src/ACadSharp/Entities/Insert.cs
+++ b/src/ACadSharp/Entities/Insert.cs
@@ -375,12 +375,14 @@ public class Insert : Entity
 
 	/// <summary>
 	/// Get the transform that will be applied to the entities in the <see cref="BlockRecord"/> when this entity is processed.
+	/// This accounts for the block base point so the inserted geometry lands in the expected position.
 	/// </summary>
 	/// <returns></returns>
 	public Transform GetTransform()
 	{
 		var world = Matrix4.GetArbitraryAxis(this.Normal);
-		var translation = Transform.CreateTranslation(this.InsertPoint);
+		XYZ basePoint = this.Block?.BlockEntity?.BasePoint ?? XYZ.Zero;
+		var translation = Transform.CreateTranslation(this.InsertPoint - basePoint);
 		var rotation = Transform.CreateRotation(XYZ.AxisZ, this.Rotation);
 		var scale = Transform.CreateScaling(new XYZ(this.XScale, this.YScale, this.ZScale));
 


### PR DESCRIPTION
Insert.GetTransform() now subtracts the block base point before applying the insert transform, which fixes composite block placement when the block definition is offset from (0,0).

This PR includes:
- a focused regression test covering a non-zero block base point
- a small example showing the same case in the examples project

Verified with:
- dotnet test src/ACadSharp.Tests/ACadSharp.Tests.csproj --no-build -f net9.0 --filter FullyQualifiedName~ACadSharp.Tests.Entities.InsertTest
- dotnet build src/ACadSharp.Examples/ACadSharp.Examples.csproj
