### PR TITLE
Fix insert bounding boxes for rotated blocks

### DIFF
--- a/src/ACadSharp.Tests/Entities/InsertTest.cs
+++ b/src/ACadSharp.Tests/Entities/InsertTest.cs
@@ -155,6 +155,30 @@ public class InsertTest
 	}
 
 	[Fact]
+	public void GetBoundingBoxUsesAllTransformedCorners()
+	{
+		var solid = new Solid(
+			new XYZ(0, 0, 0),
+			new XYZ(10, 0, 0),
+			new XYZ(10, 20, 0),
+			new XYZ(0, 20, 0));
+		BlockRecord record = new BlockRecord(this._blockName);
+		record.Entities.Add(solid);
+
+		Insert insert = new Insert(record)
+		{
+			Rotation = Math.PI / 4
+		};
+
+		var box = insert.GetBoundingBox();
+
+		Assert.InRange(box.Min.X, -14.143, -14.141);
+		Assert.InRange(box.Min.Y, -0.001, 0.001);
+		Assert.InRange(box.Max.X, 7.070, 7.072);
+		Assert.InRange(box.Max.Y, 21.212, 21.214);
+	}
+
+	[Fact]
 	public void LinkedAttributes()
 	{
 		BlockRecord record = new BlockRecord(this._blockName);

--- a/src/ACadSharp/Entities/Insert.cs
+++ b/src/ACadSharp/Entities/Insert.cs
@@ -364,13 +364,27 @@ public class Insert : Entity
 	public override BoundingBox GetBoundingBox()
 	{
 		BoundingBox box = this.Block.GetBoundingBox();
+		if (box.Extent == BoundingBoxExtent.Null || box.Extent == BoundingBoxExtent.Infinite)
+		{
+			return box;
+		}
 
 		var t = this.GetTransform();
 
-		var min = t.ApplyTransform(box.Min);
-		var max = t.ApplyTransform(box.Max);
+		var points = new[]
+		{
+			new XYZ(box.Min.X, box.Min.Y, box.Min.Z),
+			new XYZ(box.Min.X, box.Min.Y, box.Max.Z),
+			new XYZ(box.Min.X, box.Max.Y, box.Min.Z),
+			new XYZ(box.Min.X, box.Max.Y, box.Max.Z),
+			new XYZ(box.Max.X, box.Min.Y, box.Min.Z),
+			new XYZ(box.Max.X, box.Min.Y, box.Max.Z),
+			new XYZ(box.Max.X, box.Max.Y, box.Min.Z),
+			new XYZ(box.Max.X, box.Max.Y, box.Max.Z),
+		}
+		.Select(point => t.ApplyTransform(point));
 
-		return new BoundingBox(min, max);
+		return BoundingBox.FromPoints(points);
 	}
 
 	/// <summary>


### PR DESCRIPTION
Insert.GetBoundingBox() now transforms all eight corners of the block bounding box instead of only the min/max pair. That avoids underestimating the extents when the inserted block is rotated or mirrored.

This keeps the change small and targeted:
- empty/infinite boxes are passed through unchanged
- the regression test uses a rotated rectangular solid to prove the old min/max shortcut was wrong

Verified with:
- dotnet test src/ACadSharp.Tests/ACadSharp.Tests.csproj -f net9.0 --filter FullyQualifiedName~ACadSharp.Tests.Entities.InsertTest.GetBoundingBoxUsesAllTransformedCorners -v minimal
