### PR TITLE
Add SVG clipping support for wipeouts and spatial filters

### DIFF
--- a/src/ACadSharp.Tests/IO/SVG/SvgWriterClippingTests.cs
+++ b/src/ACadSharp.Tests/IO/SVG/SvgWriterClippingTests.cs
@@ -6,6 +6,8 @@ using ACadSharp.Tests.IO;
 using ACadSharp.Tables;
 using CSMath;
 using System.IO;
+using System.Linq;
+using System.Xml.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -43,6 +45,13 @@ namespace ACadSharp.Tests.IO.SVG
 
 			using SvgWriter writer = this.createWriter("wipeout.svg", document);
 			writer.Write();
+
+			string svg = File.ReadAllText(Path.Combine(TestVariables.OutputSvgFolder, "wipeout.svg"));
+			XElement root = XDocument.Parse(svg).Root!;
+			XElement? wipeoutPolygon = root.Descendants().FirstOrDefault(e => e.Name.LocalName == "polygon" && e.Attribute("stroke")?.Value == "none");
+			Assert.NotNull(wipeoutPolygon);
+			Assert.Equal("white", wipeoutPolygon!.Attribute("fill")?.Value);
+			Assert.Equal("1", wipeoutPolygon.Attribute("fill-opacity")?.Value);
 		}
 
 		[Fact]

--- a/src/ACadSharp.Tests/IO/SVG/SvgWriterClippingTests.cs
+++ b/src/ACadSharp.Tests/IO/SVG/SvgWriterClippingTests.cs
@@ -1,0 +1,134 @@
+﻿using ACadSharp;
+using ACadSharp.Entities;
+using ACadSharp.IO;
+using ACadSharp.Objects;
+using ACadSharp.Tests.IO;
+using ACadSharp.Tables;
+using CSMath;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ACadSharp.Tests.IO.SVG
+{
+	public class SvgWriterClippingTests : IOTestsBase
+	{
+		public SvgWriterClippingTests(ITestOutputHelper output) : base(output)
+		{
+		}
+
+		[Fact]
+		public void WriteSingleWipeout()
+		{
+			CadDocument document = new CadDocument();
+
+			document.Entities.Add(new Line(new XYZ(-10, 0, 0), new XYZ(110, 0, 0))
+			{
+				Color = Color.Red
+			});
+
+			Wipeout wipeout = new Wipeout
+			{
+				InsertPoint = XYZ.Zero,
+				Size = new XY(100, 100),
+				ClippingState = true
+			};
+
+			wipeout.ClipBoundaryVertices.Add(new XY(0, 0));
+			wipeout.ClipBoundaryVertices.Add(new XY(0, 100));
+			wipeout.ClipBoundaryVertices.Add(new XY(100, 100));
+			wipeout.ClipBoundaryVertices.Add(new XY(100, 0));
+
+			document.Entities.Add(wipeout);
+
+			using SvgWriter writer = this.createWriter("wipeout.svg", document);
+			writer.Write();
+		}
+
+		[Fact]
+		public void WriteInsertWithSpatialFilter()
+		{
+			CadDocument document = new CadDocument();
+			BlockRecord block = new BlockRecord("clip_block");
+
+			block.Entities.Add(new Solid
+			{
+				FirstCorner = new XYZ(-30, -20, 0),
+				SecondCorner = new XYZ(170, -20, 0),
+				ThirdCorner = new XYZ(170, 110, 0),
+				FourthCorner = new XYZ(-30, 110, 0),
+				Color = Color.Black
+			});
+
+			block.Entities.Add(new Solid
+			{
+				FirstCorner = new XYZ(18, 18, 0),
+				SecondCorner = new XYZ(102, 18, 0),
+				ThirdCorner = new XYZ(102, 78, 0),
+				FourthCorner = new XYZ(18, 78, 0),
+				Color = Color.Default
+			});
+
+			block.Entities.Add(new Line(new XYZ(-40, 18, 0), new XYZ(160, 18, 0))
+			{
+				Color = Color.Blue
+			});
+
+			block.Entities.Add(new Line(new XYZ(12, -30, 0), new XYZ(12, 120, 0))
+			{
+				Color = Color.Green
+			});
+
+			block.Entities.Add(new Line(new XYZ(-20, 105, 0), new XYZ(140, -15, 0))
+			{
+				Color = Color.Red
+			});
+
+			block.Entities.Add(new Line(new XYZ(-35, -20, 0), new XYZ(160, 110, 0))
+			{
+				Color = Color.Magenta
+			});
+
+			block.Entities.Add(new Circle
+			{
+				Center = new XYZ(75, 52, 0),
+				Radius = 26,
+				Color = Color.Black
+			});
+
+			block.Entities.Add(new Circle
+			{
+				Center = new XYZ(132, 78, 0),
+				Radius = 14,
+				Color = Color.Cyan
+			});
+
+			Insert insert = new Insert(block);
+			insert.InsertPoint = new XYZ(140, 90, 0);
+
+			SpatialFilter filter = new SpatialFilter
+			{
+				DisplayBoundary = true
+			};
+
+			filter.BoundaryPoints.Add(new XY(20, 12));
+			filter.BoundaryPoints.Add(new XY(96, 82));
+
+			insert.SpatialFilter = filter;
+			document.Entities.Add(insert);
+
+			using SvgWriter writer = this.createWriter("spatial-filter.svg", document);
+			writer.Write();
+		}
+
+		private SvgWriter createWriter(string filename, CadDocument doc)
+		{
+			string output = Path.Combine(TestVariables.OutputSvgFolder, filename);
+
+			var writer = new SvgWriter(output, doc);
+			writer.Configuration = this._svgConfiguration;
+			writer.OnNotification += this.onNotification;
+			return writer;
+		}
+	}
+}

--- a/src/ACadSharp/IO/SVG/SvgXmlWriter.cs
+++ b/src/ACadSharp/IO/SVG/SvgXmlWriter.cs
@@ -19,6 +19,8 @@ namespace ACadSharp.IO.SVG
 	{
 		public event NotificationEventHandler OnNotification;
 
+		private string? _clipPathId;
+
 		public SvgConfiguration Configuration { get; } = new();
 
 		public Layout Layout { get; set; }
@@ -154,6 +156,9 @@ namespace ACadSharp.IO.SVG
 				case Solid solid:
 					this.writeSolid(solid, transform);
 					break;
+				case Wipeout wipeout:
+					this.writeWipeout(wipeout, transform);
+					break;
 				default:
 					this.notify($"[{entity.ObjectName}] Entity not implemented.", NotificationType.NotImplemented);
 					break;
@@ -259,6 +264,24 @@ namespace ACadSharp.IO.SVG
 			StringBuilder sb = new StringBuilder();
 			sb.Append(points.First().ToPixelSize(this.Units).ToSvg());
 			foreach (T point in points.Skip(1))
+			{
+				sb.Append(' ');
+				sb.Append(point.ToPixelSize(this.Units).ToSvg());
+			}
+
+			return sb.ToString();
+		}
+
+		private string svgPoints(IEnumerable<XYZ> points)
+		{
+			if (!points.Any())
+			{
+				return string.Empty;
+			}
+
+			StringBuilder sb = new StringBuilder();
+			sb.Append(points.First().ToPixelSize(this.Units).ToSvg());
+			foreach (var point in points.Skip(1))
 			{
 				sb.Append(' ');
 				sb.Append(point.ToPixelSize(this.Units).ToSvg());
@@ -451,6 +474,10 @@ namespace ACadSharp.IO.SVG
 			this.WriteAttributeString("stroke-width", $"{this.Configuration.GetLineWeightValue(lineWeight, this.Units).ToSvg(UnitsType.Millimeters)}");
 
 			this.writeTransform(transform);
+			if (this._clipPathId != null)
+			{
+				this.WriteAttributeString("clip-path", $"url(#{this._clipPathId})");
+			}
 
 			LineType lt = entity.GetActiveLineType();
 			if (this.drawableLineType(lt))
@@ -621,16 +648,48 @@ namespace ACadSharp.IO.SVG
 		{
 			var insertTransform = insert.GetTransform();
 			var merged = new Transform(transform.Matrix * insertTransform.Matrix);
+			SpatialFilter? filter = insert.SpatialFilter;
 
-			this.WriteStartElement("g");
-			this.writeTransform(merged);
-
-			foreach (var e in insert.Block.Entities)
+			string? clipId = null;
+			if (filter != null && filter.BoundaryPoints.Any())
 			{
-				this.writeEntity(e);
+				clipId = this.writeSpatialFilterClip(filter, merged);
 			}
 
-			this.WriteEndElement();
+			if (clipId != null)
+			{
+				string? previousClip = this._clipPathId;
+				this._clipPathId = clipId;
+
+				foreach (var e in insert.Block.Entities)
+				{
+					this.writeEntity(e, merged);
+				}
+
+				this._clipPathId = previousClip;
+
+				if (filter != null && filter.DisplayBoundary && filter.BoundaryPoints.Any())
+				{
+					this.writeSpatialFilterBoundary(filter, merged);
+				}
+			}
+			else
+			{
+				this.WriteStartElement("g");
+				this.writeTransform(merged);
+
+				foreach (var e in insert.Block.Entities)
+				{
+					this.writeEntity(e);
+				}
+
+				if (filter != null && filter.DisplayBoundary && filter.BoundaryPoints.Any())
+				{
+					this.writeSpatialFilterBoundary(filter, new Transform());
+				}
+
+				this.WriteEndElement();
+			}
 		}
 
 		private void writeLine(Line line, Transform transform)
@@ -701,6 +760,10 @@ namespace ACadSharp.IO.SVG
 			}
 
 			this.WriteStartElement("g");
+			if (this._clipPathId != null)
+			{
+				this.WriteAttributeString("clip-path", $"url(#{this._clipPathId})");
+			}
 			this.writeTransform(transform);
 
 			this.WriteStartElement("text");
@@ -843,6 +906,138 @@ namespace ACadSharp.IO.SVG
 			this.WriteAttributeString("fill", this.colorSvg(solid.GetActiveColor()));
 
 			this.WriteEndElement();
+		}
+
+		private void writeSpatialFilterBoundary(SpatialFilter filter, Transform transform)
+		{
+			this.WriteStartElement("polygon");
+			this.WriteAttributeString("fill", "none");
+			this.WriteAttributeString("stroke", "red");
+			this.WriteAttributeString("stroke-width", "0.25");
+			this.WriteAttributeString("points", this.svgPoints(this.spatialFilterPoints(filter, transform)));
+			this.WriteEndElement();
+		}
+
+		private string writeSpatialFilterClip(SpatialFilter filter, Transform transform)
+		{
+			string id = $"clip_{Guid.NewGuid():N}";
+
+			this.WriteStartElement("defs");
+			this.WriteStartElement("clipPath");
+			this.WriteAttributeString("id", id);
+			this.WriteAttributeString("clipPathUnits", "userSpaceOnUse");
+			this.WriteStartElement("polygon");
+			this.WriteAttributeString("points", this.svgPoints(this.spatialFilterPoints(filter, transform)));
+			this.WriteEndElement();
+			this.WriteEndElement();
+			this.WriteEndElement();
+
+			return id;
+		}
+
+		private void writeWipeout(Wipeout wipeout, Transform transform)
+		{
+			this.WriteStartElement("polygon");
+
+			this.writeEntityHeader(wipeout, transform, drawStroke: false);
+
+			this.WriteAttributeString("fill", "white");
+			this.WriteAttributeString("points", this.svgPoints(this.wipeoutPoints(wipeout)));
+
+			this.WriteEndElement();
+		}
+
+		private IEnumerable<XYZ> spatialFilterPoints(SpatialFilter filter, Transform transform)
+		{
+			IEnumerable<XYZ> points;
+
+			if (filter.BoundaryPoints.Count == 2)
+			{
+				var p1 = filter.BoundaryPoints[0];
+				var p2 = filter.BoundaryPoints[1];
+
+				double minX = Math.Min(p1.X, p2.X);
+				double minY = Math.Min(p1.Y, p2.Y);
+				double maxX = Math.Max(p1.X, p2.X);
+				double maxY = Math.Max(p1.Y, p2.Y);
+
+				points = new[]
+				{
+					new XYZ(minX, minY, 0),
+					new XYZ(minX, maxY, 0),
+					new XYZ(maxX, maxY, 0),
+					new XYZ(maxX, minY, 0),
+				};
+			}
+			else
+			{
+				points = filter.BoundaryPoints.Select(p => new XYZ(p.X, p.Y, 0));
+			}
+
+			var clipTransform = new Transform(transform.Matrix * filter.InsertTransform);
+			return points.Select(p => clipTransform.ApplyTransform(p));
+		}
+
+		private IEnumerable<XYZ> spatialFilterLocalPoints(SpatialFilter filter)
+		{
+			IEnumerable<XYZ> points;
+
+			if (filter.BoundaryPoints.Count == 2)
+			{
+				var p1 = filter.BoundaryPoints[0];
+				var p2 = filter.BoundaryPoints[1];
+
+				double minX = Math.Min(p1.X, p2.X);
+				double minY = Math.Min(p1.Y, p2.Y);
+				double maxX = Math.Max(p1.X, p2.X);
+				double maxY = Math.Max(p1.Y, p2.Y);
+
+				points = new[]
+				{
+					new XYZ(minX, minY, 0),
+					new XYZ(minX, maxY, 0),
+					new XYZ(maxX, maxY, 0),
+					new XYZ(maxX, minY, 0),
+				};
+			}
+			else
+			{
+				points = filter.BoundaryPoints.Select(p => new XYZ(p.X, p.Y, 0));
+			}
+
+			var clipTransform = new Transform(filter.InsertTransform);
+			return points.Select(p => clipTransform.ApplyTransform(p));
+		}
+
+		private IEnumerable<XYZ> wipeoutPoints(Wipeout wipeout)
+		{
+			if (!wipeout.ClipBoundaryVertices.Any())
+			{
+				return Enumerable.Empty<XYZ>();
+			}
+
+			IEnumerable<XY> boundary = wipeout.ClipBoundaryVertices;
+
+			if (boundary.Count() == 2)
+			{
+				var p1 = boundary.First();
+				var p2 = boundary.Last();
+
+				double minX = Math.Min(p1.X, p2.X);
+				double minY = Math.Min(p1.Y, p2.Y);
+				double maxX = Math.Max(p1.X, p2.X);
+				double maxY = Math.Max(p1.Y, p2.Y);
+
+				boundary = new[]
+				{
+					new XY(minX, minY),
+					new XY(minX, maxY),
+					new XY(maxX, maxY),
+					new XY(maxX, minY),
+				};
+			}
+
+			return boundary.Select(v => wipeout.InsertPoint + (wipeout.UVector * v.X) + (wipeout.VVector * v.Y));
 		}
 
 		private void writeSpline(Spline spline, Transform transform)

--- a/src/ACadSharp/IO/SVG/SvgXmlWriter.cs
+++ b/src/ACadSharp/IO/SVG/SvgXmlWriter.cs
@@ -649,11 +649,13 @@ namespace ACadSharp.IO.SVG
 			var insertTransform = insert.GetTransform();
 			var merged = new Transform(transform.Matrix * insertTransform.Matrix);
 			SpatialFilter? filter = insert.SpatialFilter;
+			var hasBoundary = filter?.BoundaryPoints.Any() == true;
+			var showBoundary = filter?.DisplayBoundary == true && hasBoundary;
 
 			string? clipId = null;
-			if (filter != null && filter.BoundaryPoints.Any())
+			if (hasBoundary)
 			{
-				clipId = this.writeSpatialFilterClip(filter, merged);
+				clipId = this.writeSpatialFilterClip(filter!, merged);
 			}
 
 			if (clipId != null)
@@ -668,9 +670,9 @@ namespace ACadSharp.IO.SVG
 
 				this._clipPathId = previousClip;
 
-				if (filter != null && filter.DisplayBoundary && filter.BoundaryPoints.Any())
+				if (showBoundary)
 				{
-					this.writeSpatialFilterBoundary(filter, merged);
+					this.writeSpatialFilterBoundary(filter!, merged);
 				}
 			}
 			else
@@ -683,9 +685,11 @@ namespace ACadSharp.IO.SVG
 					this.writeEntity(e);
 				}
 
-				if (filter != null && filter.DisplayBoundary && filter.BoundaryPoints.Any())
+				if (showBoundary)
 				{
-					this.writeSpatialFilterBoundary(filter, new Transform());
+					// The boundary is drawn in the insert-local group, so it only needs
+					// the spatial filter transform here.
+					this.writeSpatialFilterBoundary(filter!, new Transform());
 				}
 
 				this.WriteEndElement();
@@ -910,6 +914,7 @@ namespace ACadSharp.IO.SVG
 
 		private void writeSpatialFilterBoundary(SpatialFilter filter, Transform transform)
 		{
+			// Show the filter extent as a red outline when the source DWG requests it.
 			this.WriteStartElement("polygon");
 			this.WriteAttributeString("fill", "none");
 			this.WriteAttributeString("stroke", "red");
@@ -941,7 +946,10 @@ namespace ACadSharp.IO.SVG
 
 			this.writeEntityHeader(wipeout, transform, drawStroke: false);
 
+			// Wipeouts are visibility masks in DWG. SVG has no equivalent retroactive
+			// masking here, so we emit the boundary as an explicit opaque cover shape.
 			this.WriteAttributeString("fill", "white");
+			this.WriteAttributeString("fill-opacity", "1");
 			this.WriteAttributeString("points", this.svgPoints(this.wipeoutPoints(wipeout)));
 
 			this.WriteEndElement();


### PR DESCRIPTION
Adds SVG output for wipeouts and spatial filter clips (with regression test).

This may be a **breaking change**  for consumers that currently rely on wipeouts rendering as invisible, because the new output makes them visible as opaque white cover polygons.

For wipeouts, I was not sure whether the right SVG representation should be a true `clipPath` or an opaque cover polygon. I implemented the opaque polygon approach for now because wipeouts behave like visibility masks in DWG, and SVG does not have a direct retroactive masking equivalent for already-rendered content.

Is the opaque fallback acceptable here, or would you prefer a different SVG strategy for wipeouts?

Spatial filters still emit a clip path for clipped content, and when `DisplayBoundary` is enabled the boundary is drawn as a red outline as a visual aid.
