### PR TITLE
issue 1108

### DIFF
--- a/src/ACadSharp.Tests/Entities/AttributeDefinitionTests.cs
+++ b/src/ACadSharp.Tests/Entities/AttributeDefinitionTests.cs
@@ -3,28 +3,27 @@ using ACadSharp.Tests.Common;
 using CSMath;
 using Xunit;
 
-namespace ACadSharp.Tests.Entities
+namespace ACadSharp.Tests.Entities;
+
+public class AttributeDefinitionTests : CommonEntityTests<AttributeDefinition>
 {
-	public class AttributeDefinitionTests : CommonEntityTests<AttributeDefinition>
+	[Fact]
+	public void AttConstructor()
 	{
-		[Fact]
-		public void AttConstructor()
-		{
-			AttributeEntity att = EntityFactory.CreateDefault<AttributeEntity>();
+		AttributeEntity att = EntityFactory.CreateDefault<AttributeEntity>();
 
-			AttributeDefinition attributeDefinition = new AttributeDefinition(att);
+		AttributeDefinition attributeDefinition = new AttributeDefinition(att);
 
-			EntityComparator.IsEqual(att, attributeDefinition);
-		}
+		EntityComparator.IsEqual(att, attributeDefinition);
+	}
 
-		public override void GetBoundingBoxTest()
-		{
-			AttributeDefinition att = new AttributeDefinition();
-			att.InsertPoint = new CSMath.XYZ(5, 5, 5);
+	public override void GetBoundingBoxTest()
+	{
+		AttributeDefinition att = new AttributeDefinition();
+		att.InsertPoint = new CSMath.XYZ(5, 5, 5);
 
-			BoundingBox box = att.GetBoundingBox();
+		BoundingBox box = att.GetBoundingBox();
 
-			Assert.Equal(new BoundingBox(new CSMath.XYZ(5, 5, 5)), box);
-		}
+		Assert.Equal(new BoundingBox(new CSMath.XYZ(5, 5, 5)), box);
 	}
 }

--- a/src/ACadSharp.Tests/Entities/AttributeEntityTests.cs
+++ b/src/ACadSharp.Tests/Entities/AttributeEntityTests.cs
@@ -1,0 +1,35 @@
+﻿using ACadSharp.Entities;
+using ACadSharp.Tables;
+using CSMath;
+using Xunit;
+
+namespace ACadSharp.Tests.Entities;
+
+public class AttributeEntityTests : CommonEntityTests<AttributeEntity>
+{
+	[Fact]
+	public void AttributeDefinitionWithMText()
+	{
+		BlockRecord record = new("TestRecord");
+
+		AttributeDefinition testAtt = new();
+		testAtt.MText = new();
+
+		record.Entities.Add(testAtt);
+		Insert recordInsert = new(record);
+
+		Assert.True(recordInsert.HasAttributes);
+		Assert.True(recordInsert.Attributes.Count == 1);
+		Assert.Contains(recordInsert.Attributes, attributeEntity => attributeEntity.MText is not null);
+	}
+
+	public override void GetBoundingBoxTest()
+	{
+		AttributeEntity att = new AttributeEntity();
+		att.InsertPoint = new CSMath.XYZ(5, 5, 5);
+
+		BoundingBox box = att.GetBoundingBox();
+
+		Assert.Equal(new BoundingBox(new CSMath.XYZ(5, 5, 5)), box);
+	}
+}

--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>3.6.31</Version>
+		<Version>3.6.32</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>../ACadSharp.snk</AssemblyOriginatorKeyFile>

--- a/src/ACadSharp/Entities/AttributeEntity.cs
+++ b/src/ACadSharp/Entities/AttributeEntity.cs
@@ -1,4 +1,5 @@
 ﻿using ACadSharp.Attributes;
+using ACadSharp.Extensions;
 
 namespace ACadSharp.Entities;
 
@@ -34,5 +35,6 @@ public class AttributeEntity : AttributeBase
 	public AttributeEntity(AttributeDefinition definition) : this()
 	{
 		this.matchAttributeProperties(definition);
+		this.MText = definition.MText.CloneTyped();
 	}
 }

--- a/src/ACadSharp/Entities/AttributeEntity.cs
+++ b/src/ACadSharp/Entities/AttributeEntity.cs
@@ -35,6 +35,6 @@ public class AttributeEntity : AttributeBase
 	public AttributeEntity(AttributeDefinition definition) : this()
 	{
 		this.matchAttributeProperties(definition);
-		this.MText = definition.MText.CloneTyped();
+		this.MText = definition.MText?.CloneTyped();
 	}
 }


### PR DESCRIPTION
# Description

Refactored AttributeDefinitionTests for clarity and moved bounding box test to new AttributeEntityTests. Ensured AttributeEntity clones MText from AttributeDefinition. Added tests to verify MText handling and bounding box calculation.