### PR TITLE
Add AcDbBlockLookupParameter reader + expose 2pt property labels

### DIFF
--- a/src/ACadSharp.Tests/IO/DynamicBlockTests.cs
+++ b/src/ACadSharp.Tests/IO/DynamicBlockTests.cs
@@ -100,6 +100,9 @@ namespace ACadSharp.Tests.IO
 				case DxfFileToken.ObjectBlockLinearParameter:
 					this.assertLinearParameter(doc);
 					break;
+				case DxfFileToken.ObjectBlockLookupParameter:
+					this.assertLookupParameter(doc);
+					break;
 				default:
 					throw new System.NotImplementedException();
 			}
@@ -139,6 +142,39 @@ namespace ACadSharp.Tests.IO
 		private void assertPointParameter(CadDocument doc)
 		{
 			//Not implemented in this PR
+		}
+
+		private void assertLookupParameter(CadDocument doc)
+		{
+			foreach (Insert insert in doc.Entities.OfType<Insert>())
+			{
+				if (insert.XDictionary == null)
+				{
+					continue;
+				}
+
+				var lookupParams = insert.Block.Source.EvaluationGraph.Nodes
+					.Select(n => n.Expression)
+					.OfType<BlockLookupParameter>()
+					.ToList();
+
+				Assert.NotEmpty(lookupParams);
+
+				foreach (BlockLookupParameter param in lookupParams)
+				{
+					Assert.False(string.IsNullOrEmpty(param.Name),
+						$"BlockLookupParameter (Id={param.Id}) should have a non-empty Name.");
+				}
+
+				XRecord record = insert.XDictionary
+					.GetEntry<CadDictionary>("AcDbBlockRepresentation")
+					.GetEntry<CadDictionary>("AppDataCache")
+					.GetEntry<CadDictionary>("ACAD_ENHANCEDBLOCKDATA")
+					.OfType<XRecord>().First();
+
+				var value = record.Entries.FirstOrDefault(e => e.Code == 1).Value as string;
+				Assert.False(string.IsNullOrEmpty(value));
+			}
 		}
 
 		private void assertRotationParameter(CadDocument doc)

--- a/src/ACadSharp/DxfFileToken.cs
+++ b/src/ACadSharp/DxfFileToken.cs
@@ -168,6 +168,8 @@ public static class DxfFileToken
 
 	public const string ObjectBlockLinearParameter = "BLOCKLINEARPARAMETER";
 
+	public const string ObjectBlockLookupParameter = "BLOCKLOOKUPPARAMETER";
+
 	public const string ObjectBlockPointParameter = "BLOCKPOINTPARAMETER";
 
 	public const string ObjectBlockRepresentationData = "ACDB_BLOCKREPRESENTATION_DATA";

--- a/src/ACadSharp/DxfSubclassMarker.cs
+++ b/src/ACadSharp/DxfSubclassMarker.cs
@@ -34,6 +34,8 @@
 
 		public const string Block2PtParameter = "AcDbBlock2PtParameter";
 
+		public const string BlockLookupParameter = "AcDbBlockLookupParameter";
+
 		public const string BlockAction = "AcDbBlockAction";
 
 		public const string BlockActionBasePt = "AcDbBlockActionWithBasePt";

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.Objects.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.Objects.cs
@@ -62,8 +62,9 @@ internal partial class DwgObjectReader : DwgSectionIO
 			{
 				//94 95 (I guess 96 97)
 				var d = this._mergedReaders.ReadBitLong();
-				//303 304
-				var e = this._mergedReaders.ReadVariableText();
+				//303 304 : exposed custom property label
+				string label = this._mergedReaders.ReadVariableText();
+				template.Block2PtParameter.PropertyLabels.Add(label);
 			}
 		}
 
@@ -245,6 +246,25 @@ internal partial class DwgObjectReader : DwgSectionIO
 		{
 			blockLinearParameter.Values.Add(this._mergedReaders.ReadBitDouble());
 		}
+
+		return template;
+	}
+
+	private CadTemplate readBlockLookupParameter()
+	{
+		BlockLookupParameter blockLookupParameter = new BlockLookupParameter();
+		CadBlockLookupParameterTemplate template = new CadBlockLookupParameterTemplate(blockLookupParameter);
+
+		// Only the common block-element prefix is decoded. This is enough to capture the parameter
+		// Id (code 90, read in readEvaluationExpression) and ElementName (code 300, read in
+		// readBlockElement) - the readable lookup name. The lookup-specific tail (lookup table) is
+		// intentionally not decoded; the object is read from its own bounded stream so this is safe.
+		this.readBlock1PtParameter(template);
+
+		// The display name is the first variable text of the lookup-specific body.
+		// The rest of the lookup table is not decoded; the object is read from
+		// its own bounded stream so leaving it unread is safe.
+		blockLookupParameter.Name = this._mergedReaders.ReadVariableText();
 
 		return template;
 	}

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -5613,6 +5613,9 @@ namespace ACadSharp.IO.DWG
 				case DxfFileToken.ObjectBlockVisibilityParameter:
 					template = this.readBlockVisibilityParameter();
 					break;
+				case DxfFileToken.ObjectBlockLookupParameter:
+					template = this.readBlockLookupParameter();
+					break;
 				case "BLOCKFLIPPARAMETER":
 					template = this.readBlockFlipParameter();
 					break;

--- a/src/ACadSharp/IO/DXF/DxfStreamReader/DxfObjectsSectionReader.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamReader/DxfObjectsSectionReader.cs
@@ -130,6 +130,8 @@ internal class DxfObjectsSectionReader : DxfSectionReaderBase
 				return this.readObjectCodes<BlockRotationParameter>(new CadBlockRotationParameterTemplate(), this.readBlockRotationParameter);
 			case DxfFileToken.ObjectBlockLinearParameter:
 				return this.readObjectCodes<BlockLinearParameter>(new CadBlockLinearParameterTemplate(), this.readBlockLinearParameter);
+			case DxfFileToken.ObjectBlockLookupParameter:
+				return this.readObjectCodes<BlockLookupParameter>(new CadBlockLookupParameterTemplate(new BlockLookupParameter()), this.readBlockLookupParameter);
 			case DxfFileToken.ObjectBlockRotationGrip:
 				return this.readObjectCodes<BlockRotationGrip>(new CadBlockRotationGripTemplate(), this.readBlockRotationGrip);
 			case DxfFileToken.ObjectBlockRotateAction:
@@ -2111,6 +2113,19 @@ internal class DxfObjectsSectionReader : DxfSectionReaderBase
 				if (!this.tryAssignCurrentValue(template.CadObject, map))
 				{
 					return this.readBlock2PtParameter(template, map);
+				}
+				return true;
+		}
+	}
+
+	private bool readBlockLookupParameter(CadTemplate template, DxfMap map)
+	{
+		switch (this._reader.Code)
+		{
+			default:
+				if (!this.tryAssignCurrentValue(template.CadObject, map.SubClasses[DxfSubclassMarker.BlockLookupParameter]))
+				{
+					return this.readBlock1PtParameter(template, map);
 				}
 				return true;
 		}

--- a/src/ACadSharp/IO/Templates/CadBlockLookupParameterTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadBlockLookupParameterTemplate.cs
@@ -1,0 +1,15 @@
+using ACadSharp.Objects.Evaluations;
+
+namespace ACadSharp.IO.Templates
+{
+	internal class CadBlockLookupParameterTemplate : CadBlock1PtParameterTemplate
+	{
+		public BlockLookupParameter BlockLookupParameter { get { return this.CadObject as BlockLookupParameter; } }
+
+		public CadBlockLookupParameterTemplate(BlockLookupParameter cadObject)
+			: base(cadObject)
+		{
+		}
+	}
+}
+

--- a/src/ACadSharp/Objects/Evaluations/Block2PtParameter.cs
+++ b/src/ACadSharp/Objects/Evaluations/Block2PtParameter.cs
@@ -48,4 +48,11 @@ public abstract class Block2PtParameter : BlockParameter
 
 	[DxfCodeValue(95)]
 	public int Value95 { get; set; }
+
+	/// <summary>
+	/// Custom property labels declared by this parameter (DWG codes 303/304).
+	/// Non-empty when the parameter publishes named properties to the Properties palette
+	/// (e.g. a linear "Displacement" parameter with a label).
+	/// </summary>
+	public System.Collections.Generic.List<string> PropertyLabels { get; } = new();
 }

--- a/src/ACadSharp/Objects/Evaluations/BlockLookupParameter.cs
+++ b/src/ACadSharp/Objects/Evaluations/BlockLookupParameter.cs
@@ -1,0 +1,36 @@
+using ACadSharp.Attributes;
+
+namespace ACadSharp.Objects.Evaluations
+{
+	/// <summary>
+	/// Represents a BLOCKLOOKUPPARAMETER object, used in AutoCAD to drive block geometry from
+	/// a lookup table in the Block Properties Table (the "Lookup" rows of the Customize tab of
+	/// a dynamic block).
+	/// </summary>
+	/// <remarks>
+	/// Object name <see cref="DxfFileToken.ObjectBlockLookupParameter"/> <br/>
+	/// Dxf class name <see cref="DxfSubclassMarker.BlockLookupParameter"/> <br/>
+	/// <br/>
+	/// Minimal implementation: only the common block-element prefix (which carries
+	/// <see cref="EvaluationExpression.Id"/>, code 90 — the key found in ACAD_ENHANCEDBLOCKDATA)
+	/// and the display name are decoded. The lookup table itself is not decoded.
+	/// </remarks>
+	[DxfName(DxfFileToken.ObjectBlockLookupParameter)]
+	[DxfSubClass(DxfSubclassMarker.BlockLookupParameter)]
+	public class BlockLookupParameter : Block1PtParameter
+	{
+		/// <inheritdoc/>
+		public override string ObjectName => DxfFileToken.ObjectBlockLookupParameter;
+
+		/// <inheritdoc/>
+		public override string SubclassMarker => DxfSubclassMarker.BlockLookupParameter;
+
+		/// <summary>
+		/// Display name of the lookup parameter as shown in the AutoCAD Properties palette
+		/// </summary>
+		[DxfCodeValue(301)]
+		public string Name { get; set; } = string.Empty;
+	}
+}
+
+


### PR DESCRIPTION
# Description

`AcDbBlockLookupParameter` objects were silently dropped during DWG parsing because no handler was registered for them in the object reader dispatch switch. This made it impossible to read the display name of Lookup-type parameters from dynamic blocks.

This PR adds minimal support for `BlockLookupParameter` and exposes `PropertyLabels` on `Block2PtParameter`, which together allow consumers to enumerate all parameters visible in AutoCAD's "Customize" tab for a dynamic block insert.

# Tasks done in this PR
* [x] Add `DxfFileToken.ObjectBlockLookupParameter` constant.
* [x] Add `BlockLookupParameter` model class (`Block1PtParameter` subclass) with a `Name` property (DXF code 301) holding the parameter display name.
* [x] Register `BLOCKLOOKUPPARAMETER` in the DWG object reader dispatch switch.
* [x] Add DXF reader support via `readBlockLookupParameter` in `DxfObjectsSectionReader`.
* [x] Expose `PropertyLabels` on `Block2PtParameter` (populated from DWG codes 303/304), allowing callers to identify parameters that publish named properties to the Properties palette.
* [x] Add `assertLookupParameter` test scaffolding and the corresponding `IsolatedTest` case in `DynamicBlockTests`.

# Related Issues / Pull Requests
- None.

# Notes for reviewer
- The lookup table body is intentionally not decoded — only the common block-element prefix and the display name are read. The object is deserialized from its own bounded stream so leaving the tail unread is safe.