### PR TITLE
issue 1124

### DIFF
--- a/src/ACadSharp.Tests/IO/DXF/DxfWriterTests.cs
+++ b/src/ACadSharp.Tests/IO/DXF/DxfWriterTests.cs
@@ -31,9 +31,7 @@ namespace ACadSharp.Tests.IO.DXF
 				wr.Write();
 			}
 
-			this._output.WriteLine(string.Empty);
 			this._output.WriteLine("Writer successful");
-			this._output.WriteLine(string.Empty);
 
 			using (var re = new DxfReader(path, this.onNotification))
 			{
@@ -60,9 +58,7 @@ namespace ACadSharp.Tests.IO.DXF
 				wr.Write();
 			}
 
-			this._output.WriteLine(string.Empty);
 			this._output.WriteLine("Writer successful");
-			this._output.WriteLine(string.Empty);
 
 			using (var re = new DxfReader(path, this.onNotification))
 			{

--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>3.6.34</Version>
+		<Version>3.6.35</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>../ACadSharp.snk</AssemblyOriginatorKeyFile>

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
@@ -2,6 +2,7 @@
 using ACadSharp.Objects;
 using ACadSharp.Objects.AEC;
 using ACadSharp.Objects.Evaluations;
+using ACadSharp.Tables;
 using CSMath;
 using System;
 using System.Linq;
@@ -609,7 +610,14 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 
 	private void writeCellStyle(TableStyle.CellStyle cellStyle)
 	{
-		this._writer.WriteName(7, cellStyle.TextStyle);
+		if (cellStyle.TextStyle != null)
+		{
+			this._writer.WriteName(7, cellStyle.TextStyle);
+		}
+		else
+		{
+			this._writer.Write(7, TextStyle.DefaultName);
+		}
 
 		this._writer.Write(140, cellStyle.TextHeight);
 		this._writer.Write(170, cellStyle.CellAlignment);

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
@@ -43,7 +43,7 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 			//Not compatible dictionaries
 			if (item.Name == CadDictionary.AcadMaterial)
 			{
-				return;
+				continue;
 			}
 
 			this._writer.Write(3, item.Name);


### PR DESCRIPTION
# Description

Changed control flow to use 'continue' instead of 'return' when encountering CadDictionary.AcadMaterial, allowing the loop to process remaining items rather than exiting the method early.