### PR TITLE
Fix Entity.IsInvisible import/export for version < AC1015

### DIFF
--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -434,7 +434,7 @@ namespace ACadSharp.IO.DWG
 			{
 				//Common:
 				//Invisibility BS 60
-				entity.IsInvisible = (this._objectReader.ReadBitShort() & 1) == 0;
+				entity.IsInvisible = (this._objectReader.ReadBitShort() & 1) == 1;
 
 				return;
 			}

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -2308,8 +2308,8 @@ namespace ACadSharp.IO.DWG
 				if (this._objectReader.ReadBit())
 					layer.Flags |= LayerFlags.Frozen;
 
-				//On B if on.
-				layer.IsOn = this._objectReader.ReadBit();
+				//On B 1 if off (bit set = off)
+				layer.IsOn = !this._objectReader.ReadBit();
 
 				//Frz in new B 70 if frozen by default in new viewports (2 bit)
 				if (this._objectReader.ReadBit())

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Common.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Common.cs
@@ -258,7 +258,7 @@ namespace ACadSharp.IO.DWG
 			{
 				//Common:
 				//Invisibility BS 60
-				this._writer.WriteBitShort((short)(entity.IsInvisible ? 0 : 1));
+				this._writer.WriteBitShort((short)(entity.IsInvisible ? 1 : 0));
 
 				return;
 			}

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.cs
@@ -763,8 +763,8 @@ internal partial class DwgObjectWriter : DwgSectionIO
 		{
 			//Frozen B 70 if frozen (1 bit)
 			this._writer.WriteBit(layer.Flags.HasFlag(LayerFlags.Frozen));
-			//On B if on.
-			this._writer.WriteBit(layer.IsOn);
+			//On B 1 if off (bit set = off)
+			this._writer.WriteBit(!layer.IsOn);
 			//Frz in new B 70 if frozen by default in new viewports (2 bit)
 			this._writer.WriteBit(layer.Flags.HasFlag(LayerFlags.FrozenNewViewports));
 			//Locked B 70 if locked (4 bit)


### PR DESCRIPTION
# Description

Fix inverted visibility flags for pre-R2000 (R13–R14) DWG files

The pre-R2000 branch of the DWG reader/writer inverts two flags:
- Entity.IsInvisible (code 60)
- Layer.IsOn

Both are 0 = visible/on, 1 = invisible/off. Same as R2000+, no format-level inversion. 
Verified empirically against a Release 14 file (visible in AutoCAD TrueView, reported as hidden/off by ACadSharp).
