### PR TITLE
Fix DXF objects-section writer: dangling handles, duplicated objects, null field text

### DIFF
--- a/src/ACadSharp.Tests/IO/DynamicBlockTests.cs
+++ b/src/ACadSharp.Tests/IO/DynamicBlockTests.cs
@@ -5,8 +5,6 @@ using ACadSharp.Objects.Evaluations;
 using ACadSharp.Tables;
 using ACadSharp.Tests.TestModels;
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -105,70 +103,6 @@ namespace ACadSharp.Tests.IO
 				default:
 					throw new System.NotImplementedException();
 			}
-		}
-
-		[Theory]
-		[MemberData(nameof(IsolatedDynamicBlocksPaths))]
-		public void DwgWriterNoDanglingDictionaryEntriesTest(FileModel test)
-		{
-			CadDocument doc = this.readDocument(test, this.getConfiguration(test));
-
-			if (!this.isSupportedVersion(doc.Header.Version))
-			{
-				return;
-			}
-
-			this.rewriteDwgInMemory(doc, out List<NotificationEventArgs> notifications);
-
-			this.assertNoDanglingDictionaryEntries(notifications);
-		}
-
-		[Theory]
-		[MemberData(nameof(IsolatedDynamicBlocksPaths))]
-		public void DxfWriterNoDanglingDictionaryEntriesTest(FileModel test)
-		{
-			CadDocument doc = this.readDocument(test, this.getConfiguration(test));
-
-			this.rewriteDxfInMemory(doc, out List<NotificationEventArgs> notifications);
-
-			this.assertNoDanglingDictionaryEntries(notifications);
-		}
-
-		private void assertNoDanglingDictionaryEntries(List<NotificationEventArgs> notifications)
-		{
-			//A dictionary entry pointing to an object that has not been written
-			//triggers an "Entry not found" warning when the output is read back
-			Assert.DoesNotContain(notifications, e => e.Message != null && e.Message.Contains("Entry not found"));
-		}
-
-		private CadDocument rewriteDwgInMemory(CadDocument doc, out List<NotificationEventArgs> reReadNotifications)
-		{
-			List<NotificationEventArgs> notifications = new();
-
-			MemoryStream stream = new MemoryStream();
-			DwgWriter.Write(stream, doc, new DwgWriterConfiguration { WriteXRecords = true }, this.onNotification);
-
-			reReadNotifications = notifications;
-			return DwgReader.Read(new MemoryStream(stream.ToArray()), (s, e) =>
-			{
-				notifications.Add(e);
-				this.onNotification(s, e);
-			});
-		}
-
-		private CadDocument rewriteDxfInMemory(CadDocument doc, out List<NotificationEventArgs> reReadNotifications)
-		{
-			List<NotificationEventArgs> notifications = new();
-
-			MemoryStream stream = new MemoryStream();
-			DxfWriter.Write(stream, doc, false, new DxfWriterConfiguration { WriteXRecords = true }, this.onNotification);
-
-			reReadNotifications = notifications;
-			return DxfReader.Read(new MemoryStream(stream.ToArray()), (s, e) =>
-			{
-				notifications.Add(e);
-				this.onNotification(s, e);
-			});
 		}
 
 		private void assertLinearParameter(CadDocument doc)

--- a/src/ACadSharp.Tests/IO/DynamicBlockTests.cs
+++ b/src/ACadSharp.Tests/IO/DynamicBlockTests.cs
@@ -5,6 +5,8 @@ using ACadSharp.Objects.Evaluations;
 using ACadSharp.Tables;
 using ACadSharp.Tests.TestModels;
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -103,6 +105,70 @@ namespace ACadSharp.Tests.IO
 				default:
 					throw new System.NotImplementedException();
 			}
+		}
+
+		[Theory]
+		[MemberData(nameof(IsolatedDynamicBlocksPaths))]
+		public void DwgWriterNoDanglingDictionaryEntriesTest(FileModel test)
+		{
+			CadDocument doc = this.readDocument(test, this.getConfiguration(test));
+
+			if (!this.isSupportedVersion(doc.Header.Version))
+			{
+				return;
+			}
+
+			this.rewriteDwgInMemory(doc, out List<NotificationEventArgs> notifications);
+
+			this.assertNoDanglingDictionaryEntries(notifications);
+		}
+
+		[Theory]
+		[MemberData(nameof(IsolatedDynamicBlocksPaths))]
+		public void DxfWriterNoDanglingDictionaryEntriesTest(FileModel test)
+		{
+			CadDocument doc = this.readDocument(test, this.getConfiguration(test));
+
+			this.rewriteDxfInMemory(doc, out List<NotificationEventArgs> notifications);
+
+			this.assertNoDanglingDictionaryEntries(notifications);
+		}
+
+		private void assertNoDanglingDictionaryEntries(List<NotificationEventArgs> notifications)
+		{
+			//A dictionary entry pointing to an object that has not been written
+			//triggers an "Entry not found" warning when the output is read back
+			Assert.DoesNotContain(notifications, e => e.Message != null && e.Message.Contains("Entry not found"));
+		}
+
+		private CadDocument rewriteDwgInMemory(CadDocument doc, out List<NotificationEventArgs> reReadNotifications)
+		{
+			List<NotificationEventArgs> notifications = new();
+
+			MemoryStream stream = new MemoryStream();
+			DwgWriter.Write(stream, doc, new DwgWriterConfiguration { WriteXRecords = true }, this.onNotification);
+
+			reReadNotifications = notifications;
+			return DwgReader.Read(new MemoryStream(stream.ToArray()), (s, e) =>
+			{
+				notifications.Add(e);
+				this.onNotification(s, e);
+			});
+		}
+
+		private CadDocument rewriteDxfInMemory(CadDocument doc, out List<NotificationEventArgs> reReadNotifications)
+		{
+			List<NotificationEventArgs> notifications = new();
+
+			MemoryStream stream = new MemoryStream();
+			DxfWriter.Write(stream, doc, false, new DxfWriterConfiguration { WriteXRecords = true }, this.onNotification);
+
+			reReadNotifications = notifications;
+			return DxfReader.Read(new MemoryStream(stream.ToArray()), (s, e) =>
+			{
+				notifications.Add(e);
+				this.onNotification(s, e);
+			});
 		}
 
 		private void assertLinearParameter(CadDocument doc)

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
@@ -47,6 +47,12 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 				continue;
 			}
 
+			//Skip the entries that will not be written to avoid dangling references
+			if (!this.isObjectSupported(item))
+			{
+				continue;
+			}
+
 			this._writer.Write(3, item.Name);
 			this._writer.Write(350, item.Handle);
 

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
@@ -5,6 +5,7 @@ using ACadSharp.Objects.Evaluations;
 using ACadSharp.Tables;
 using CSMath;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace ACadSharp.IO.DXF;
@@ -12,6 +13,8 @@ namespace ACadSharp.IO.DXF;
 internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 {
 	public override string SectionName { get { return DxfFileToken.ObjectsSection; } }
+
+	private readonly HashSet<ulong> _writtenHandles = new();
 
 	public DxfObjectsSectionWriter(IDxfStreamWriter writer, CadDocument document, CadObjectHolder holder, DxfWriterConfiguration configuration)
 		: base(writer, document, holder, configuration)
@@ -545,6 +548,14 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 		while (this.Holder.Objects.Any())
 		{
 			CadObject item = this.Holder.Objects.Dequeue();
+
+			//An object can be enqueued multiple times, by the dictionary
+			//that owns it and by the objects that reference it (e.g. fields
+			//in a field list), write it only once
+			if (!this._writtenHandles.Add(item.Handle))
+			{
+				continue;
+			}
 
 			this.writeObject(item);
 		}

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.cs
@@ -236,6 +236,8 @@ internal abstract partial class DxfSectionWriterBase
 
 	protected void writeLongTextValue(int code, int subcode, string text)
 	{
+		text = text ?? string.Empty;
+
 		while (text.Length > 250)
 		{
 			this._writer.Write(subcode, text.Substring(0, 250));


### PR DESCRIPTION
Three independent robustness fixes for the DXF objects-section writer, found while round-tripping real production dynamic-block drawings (context: #1133). Each is a separate commit.

### 1. Dangling dictionary handles (`Fix dangling dictionary handles in the dxf writer`)
`DxfObjectsSectionWriter.writeDictionary` emitted the `3`/`350` entry-name/handle pair (and enqueued the entry) for **every** dictionary entry, even entries whose object type the writer later drops via `isObjectSupported` (`ACAD_ENHANCEDBLOCK`, `AcDbRepData`, visual styles, purge preventers…). The result is a DXF file with dictionary entries pointing at handles that were never written — re-reading it raises `Entry not found …` notifications. Fixed by filtering entries through `isObjectSupported` before emitting the pair, mirroring the DWG writer's `skipEntry` double-filter. Covered by two new tests (`DwgWriterNoDanglingDictionaryEntriesTest` / `DxfWriterNoDanglingDictionaryEntriesTest`) that rewrite the dynamic-block fixtures in memory, re-read, and assert no `Entry not found` notification is raised.

### 2. Duplicated objects in the objects section (`Avoid writing duplicated objects in the dxf objects section`)
An object reachable from two owners (e.g. a `Field` enqueued by both its owner dictionary and the `FieldList` that references it) was written twice into the OBJECTS section; re-reading the output then failed with `Item already has an owner`. Fixed by tracking written handles in a `HashSet<ulong>` and skipping an object already emitted. Reproducible with any FIELD-bearing drawing.

### 3. Null text in `writeLongTextValue` (`Handle null text values in writeLongTextValue`)
`DxfSectionWriterBase.writeLongTextValue` threw a `NullReferenceException` on `FIELD` objects whose cached value string is null. Fixed by treating null as empty, matching the DWG writer's behaviour.

Fixes 2 and 3 don't ship a dedicated fixture here because they were surfaced by proprietary drawings; both reproduce with any FIELD-bearing DXF and I'm happy to add a public fixture if you'd like one. All existing `DynamicBlockTests` pass (45/45) on top of current master (v3.6.37).
