### PR TITLE
Write BlockRepresentationData (AcDbRepData) in DWG and DXF

### DIFF
--- a/src/ACadSharp.Tests/IO/DynamicBlockTests.cs
+++ b/src/ACadSharp.Tests/IO/DynamicBlockTests.cs
@@ -88,23 +88,7 @@ namespace ACadSharp.Tests.IO
 			var config = getConfiguration(test);
 			var doc = this.readDocument(test, config);
 
-			switch (test.NoExtensionName)
-			{
-				case DxfFileToken.ObjectBlockVisibilityParameter:
-					this.assertVisibilityParameter(doc);
-					break;
-				case DxfFileToken.ObjectBlockRotationParameter:
-					this.assertRotationParameter(doc);
-					break;
-				case DxfFileToken.ObjectBlockPointParameter:
-					this.assertPointParameter(doc);
-					break;
-				case DxfFileToken.ObjectBlockLinearParameter:
-					this.assertLinearParameter(doc);
-					break;
-				default:
-					throw new System.NotImplementedException();
-			}
+			this.assertIsolatedDocument(test, doc, assertEvaluationGraph: true);
 		}
 
 		[Theory]
@@ -132,6 +116,48 @@ namespace ACadSharp.Tests.IO
 			this.rewriteDxfInMemory(doc, out List<NotificationEventArgs> notifications);
 
 			this.assertNoDanglingDictionaryEntries(notifications);
+		}
+
+		private void assertGraph<T>(CadDocument doc, string blockName)
+			where T : EvaluationExpression
+		{
+			BlockRecord original = doc.BlockRecords[blockName];
+
+			Assert.NotNull(original.EvaluationGraph);
+			Assert.NotEmpty(original.EvaluationGraph.Nodes.Select(n => n.Expression).OfType<T>());
+		}
+
+		private void assertIsolatedDocument(FileModel test, CadDocument doc, bool assertEvaluationGraph)
+		{
+			switch (test.NoExtensionName)
+			{
+				case DxfFileToken.ObjectBlockVisibilityParameter:
+					this.assertRepresentationChain(doc, "block_visibility_parameter", assertXRecordName: true);
+					if (assertEvaluationGraph)
+					{
+						this.assertGraph<BlockVisibilityParameter>(doc, "block_visibility_parameter");
+					}
+					break;
+				case DxfFileToken.ObjectBlockRotationParameter:
+					this.assertRepresentationChain(doc, "dynamic_block");
+					if (assertEvaluationGraph)
+					{
+						this.assertGraph<BlockRotationParameter>(doc, "dynamic_block");
+					}
+					break;
+				case DxfFileToken.ObjectBlockPointParameter:
+					//Point parameter not implemented
+					break;
+				case DxfFileToken.ObjectBlockLinearParameter:
+					this.assertRepresentationChain(doc, "LINEAR_PARAM");
+					if (assertEvaluationGraph)
+					{
+						this.assertGraph<BlockLinearParameter>(doc, "LINEAR_PARAM");
+					}
+					break;
+				default:
+					throw new System.NotImplementedException();
+			}
 		}
 
 		private void assertNoDanglingDictionaryEntries(List<NotificationEventArgs> notifications)
@@ -171,9 +197,9 @@ namespace ACadSharp.Tests.IO
 			});
 		}
 
-		private void assertLinearParameter(CadDocument doc)
+		private void assertRepresentationChain(CadDocument doc, string blockName, bool assertXRecordName = false)
 		{
-			var original = doc.BlockRecords["LINEAR_PARAM"];
+			var original = doc.BlockRecords[blockName];
 			foreach (BlockRecord record in doc.BlockRecords.Where(b => b.IsAnonymous))
 			{
 				Assert.Equal(original, record.Source);
@@ -189,81 +215,19 @@ namespace ACadSharp.Tests.IO
 				var dict = insert.XDictionary.GetEntry<CadDictionary>("AcDbBlockRepresentation");
 				var representation = dict.GetEntry<BlockRepresentationData>("AcDbRepData");
 
-				Assert.NotEmpty(insert.Block.Source.EvaluationGraph.Nodes.Select(n => n.Expression).OfType<BlockLinearParameter>());
-
 				Assert.NotNull(representation);
 				Assert.Equal(original, representation.Block);
 
-				XRecord record = insert.XDictionary
-					.GetEntry<CadDictionary>("AcDbBlockRepresentation")
+				XRecord record = dict
 					.GetEntry<CadDictionary>("AppDataCache")
 					.GetEntry<CadDictionary>("ACAD_ENHANCEDBLOCKDATA")
 					.OfType<XRecord>().First();
-			}
-		}
 
-		private void assertPointParameter(CadDocument doc)
-		{
-			//Not implemented in this PR
-		}
-
-		private void assertRotationParameter(CadDocument doc)
-		{
-			var original = doc.BlockRecords["dynamic_block"];
-			foreach (BlockRecord record in doc.BlockRecords.Where(b => b.IsAnonymous))
-			{
-				Assert.Equal(original, record.Source);
-			}
-
-			foreach (Insert insert in doc.Entities.OfType<Insert>())
-			{
-				if (insert.XDictionary == null)
+				if (assertXRecordName)
 				{
-					continue;
+					var name = record.Entries.FirstOrDefault(e => e.Code == 1).Value as string;
+					Assert.False(string.IsNullOrEmpty(name));
 				}
-
-				var dict = insert.XDictionary.GetEntry<CadDictionary>("AcDbBlockRepresentation");
-				var representation = dict.GetEntry<BlockRepresentationData>("AcDbRepData");
-
-				Assert.NotEmpty(insert.Block.Source.EvaluationGraph.Nodes.Select(n => n.Expression).OfType<BlockRotationParameter>());
-
-				Assert.NotNull(representation);
-				Assert.Equal(original, representation.Block);
-
-				XRecord record = insert.XDictionary
-					.GetEntry<CadDictionary>("AcDbBlockRepresentation")
-					.GetEntry<CadDictionary>("AppDataCache")
-					.GetEntry<CadDictionary>("ACAD_ENHANCEDBLOCKDATA")
-					.OfType<XRecord>().First();
-			}
-		}
-
-		private void assertVisibilityParameter(CadDocument doc)
-		{
-			var original = doc.BlockRecords["block_visibility_parameter"];
-			foreach (BlockRecord record in doc.BlockRecords.Where(b => b.IsAnonymous))
-			{
-				Assert.Equal(original, record.Source);
-			}
-
-			foreach (Insert insert in doc.Entities.OfType<Insert>())
-			{
-				var dict = insert.XDictionary.GetEntry<CadDictionary>("AcDbBlockRepresentation");
-				var representation = dict.GetEntry<BlockRepresentationData>("AcDbRepData");
-
-				Assert.NotEmpty(insert.Block.Source.EvaluationGraph.Nodes.Select(n => n.Expression).OfType<BlockVisibilityParameter>());
-
-				Assert.NotNull(representation);
-				Assert.Equal(original, representation.Block);
-
-				XRecord record = insert.XDictionary
-					.GetEntry<CadDictionary>("AcDbBlockRepresentation")
-					.GetEntry<CadDictionary>("AppDataCache")
-					.GetEntry<CadDictionary>("ACAD_ENHANCEDBLOCKDATA")
-					.OfType<XRecord>().First();
-
-				var name = record.Entries.FirstOrDefault(e => e.Code == 1).Value as string;
-				Assert.False(string.IsNullOrEmpty(name));
 			}
 		}
 	}

--- a/src/ACadSharp.Tests/IO/DynamicBlockTests.cs
+++ b/src/ACadSharp.Tests/IO/DynamicBlockTests.cs
@@ -5,6 +5,8 @@ using ACadSharp.Objects.Evaluations;
 using ACadSharp.Tables;
 using ACadSharp.Tests.TestModels;
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -103,6 +105,70 @@ namespace ACadSharp.Tests.IO
 				default:
 					throw new System.NotImplementedException();
 			}
+		}
+
+		[Theory]
+		[MemberData(nameof(IsolatedDynamicBlocksPaths))]
+		public void DwgWriterNoDanglingDictionaryEntriesTest(FileModel test)
+		{
+			CadDocument doc = this.readDocument(test, this.getConfiguration(test));
+
+			if (!this.isSupportedVersion(doc.Header.Version))
+			{
+				return;
+			}
+
+			this.rewriteDwgInMemory(doc, out List<NotificationEventArgs> notifications);
+
+			this.assertNoDanglingDictionaryEntries(notifications);
+		}
+
+		[Theory]
+		[MemberData(nameof(IsolatedDynamicBlocksPaths))]
+		public void DxfWriterNoDanglingDictionaryEntriesTest(FileModel test)
+		{
+			CadDocument doc = this.readDocument(test, this.getConfiguration(test));
+
+			this.rewriteDxfInMemory(doc, out List<NotificationEventArgs> notifications);
+
+			this.assertNoDanglingDictionaryEntries(notifications);
+		}
+
+		private void assertNoDanglingDictionaryEntries(List<NotificationEventArgs> notifications)
+		{
+			//A dictionary entry pointing to an object that has not been written
+			//triggers an "Entry not found" warning when the output is read back
+			Assert.DoesNotContain(notifications, e => e.Message != null && e.Message.Contains("Entry not found"));
+		}
+
+		private CadDocument rewriteDwgInMemory(CadDocument doc, out List<NotificationEventArgs> reReadNotifications)
+		{
+			List<NotificationEventArgs> notifications = new();
+
+			MemoryStream stream = new MemoryStream();
+			DwgWriter.Write(stream, doc, new DwgWriterConfiguration { WriteXRecords = true }, this.onNotification);
+
+			reReadNotifications = notifications;
+			return DwgReader.Read(new MemoryStream(stream.ToArray()), (s, e) =>
+			{
+				notifications.Add(e);
+				this.onNotification(s, e);
+			});
+		}
+
+		private CadDocument rewriteDxfInMemory(CadDocument doc, out List<NotificationEventArgs> reReadNotifications)
+		{
+			List<NotificationEventArgs> notifications = new();
+
+			MemoryStream stream = new MemoryStream();
+			DxfWriter.Write(stream, doc, false, new DxfWriterConfiguration { WriteXRecords = true }, this.onNotification);
+
+			reReadNotifications = notifications;
+			return DxfReader.Read(new MemoryStream(stream.ToArray()), (s, e) =>
+			{
+				notifications.Add(e);
+				this.onNotification(s, e);
+			});
 		}
 
 		private void assertLinearParameter(CadDocument doc)

--- a/src/ACadSharp.Tests/IO/DynamicBlockTests.cs
+++ b/src/ACadSharp.Tests/IO/DynamicBlockTests.cs
@@ -93,6 +93,37 @@ namespace ACadSharp.Tests.IO
 
 		[Theory]
 		[MemberData(nameof(IsolatedDynamicBlocksPaths))]
+		public void DwgRoundTripTest(FileModel test)
+		{
+			CadDocument doc = this.readDocument(test, this.getConfiguration(test));
+
+			if (!this.isSupportedVersion(doc.Header.Version))
+			{
+				return;
+			}
+
+			CadDocument rewritten = this.rewriteDwgInMemory(doc, out List<NotificationEventArgs> notifications);
+
+			//The evaluation graph is not written yet, only the representation chain survives the rewrite
+			this.assertIsolatedDocument(test, rewritten, assertEvaluationGraph: false);
+			this.assertNoDanglingDictionaryEntries(notifications);
+		}
+
+		[Theory]
+		[MemberData(nameof(IsolatedDynamicBlocksPaths))]
+		public void DxfRoundTripTest(FileModel test)
+		{
+			CadDocument doc = this.readDocument(test, this.getConfiguration(test));
+
+			CadDocument rewritten = this.rewriteDxfInMemory(doc, out List<NotificationEventArgs> notifications);
+
+			//The evaluation graph is not written yet, only the representation chain survives the rewrite
+			this.assertIsolatedDocument(test, rewritten, assertEvaluationGraph: false);
+			this.assertNoDanglingDictionaryEntries(notifications);
+		}
+
+		[Theory]
+		[MemberData(nameof(IsolatedDynamicBlocksPaths))]
 		public void DwgWriterNoDanglingDictionaryEntriesTest(FileModel test)
 		{
 			CadDocument doc = this.readDocument(test, this.getConfiguration(test));

--- a/src/ACadSharp/Classes/DxfClassCollection.cs
+++ b/src/ACadSharp/Classes/DxfClassCollection.cs
@@ -745,6 +745,20 @@ public class DxfClassCollection : ICollection<DxfClass>
 			WasZombie = false,
 			InstanceCount = this._document.GetInstanceCount(DxfFileToken.BlkRefObjectContextData),
 		});
+
+		//AcDbBlockRepresentationData
+		this.AddOrUpdate(new DxfClass
+		{
+			CppClassName = DxfSubclassMarker.BlockRepresentationData,
+			ClassNumber = (short)(500 + this.Count),
+			DwgVersion = ACadVersion.AC1018,
+			DxfName = DxfFileToken.ObjectBlockRepresentationData,
+			ItemClassId = 499,
+			MaintenanceVersion = 58,
+			ProxyFlags = ProxyFlags.EraseAllowed | ProxyFlags.CloningAllowed | ProxyFlags.DisablesProxyWarningDialog,
+			WasZombie = false,
+			InstanceCount = this._document.GetInstanceCount(DxfFileToken.ObjectBlockRepresentationData),
+		});
 	}
 
 	private void resetClassNumbers()

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
@@ -44,7 +44,6 @@ internal partial class DwgObjectWriter : DwgSectionIO
 			case UnknownNonGraphicalObject:
 			case VisualStyle:
 			case ProxyObject:
-			case BlockRepresentationData:
 			case BlockReferenceObjectContextData:
 			case MTextAttributeObjectContextData:
 				return true;
@@ -71,6 +70,15 @@ internal partial class DwgObjectWriter : DwgSectionIO
 	private void writeAnnotScaleObjectContextData(AnnotScaleObjectContextData annotScaleObjectContextData)
 	{
 		this._writer.HandleReference(DwgReferenceType.HardPointer, annotScaleObjectContextData.Scale);
+	}
+
+	private void writeBlockRepresentationData(BlockRepresentationData representation)
+	{
+		//BS	70
+		this._writer.WriteBitShort(representation.Value70);
+
+		//H	340	Source block record (hard pointer)
+		this._writer.HandleReference(DwgReferenceType.HardPointer, representation.Block);
 	}
 
 	private void writeBookColor(BookColor color)
@@ -1174,6 +1182,9 @@ internal partial class DwgObjectWriter : DwgSectionIO
 		{
 			case AcdbPlaceHolder acdbPlaceHolder:
 				this.writeAcdbPlaceHolder(acdbPlaceHolder);
+				break;
+			case BlockRepresentationData blockRepresentationData:
+				this.writeBlockRepresentationData(blockRepresentationData);
 				break;
 			case BookColor bookColor:
 				this.writeBookColor(bookColor);

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
@@ -47,6 +47,12 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 				continue;
 			}
 
+			//Skip the entries that will not be written to avoid dangling references
+			if (!this.isObjectSupported(item))
+			{
+				continue;
+			}
+
 			this._writer.Write(3, item.Name);
 			this._writer.Write(350, item.Handle);
 

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
@@ -21,6 +21,14 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 	{
 	}
 
+	protected void writeBlockRepresentationData(BlockRepresentationData representation)
+	{
+		this._writer.Write(DxfCode.Subclass, DxfSubclassMarker.BlockRepresentationData);
+
+		this._writer.Write(70, representation.Value70);
+		this._writer.WriteHandle(340, representation.Block);
+	}
+
 	protected void writeBookColor(BookColor color)
 	{
 		this._writer.Write(DxfCode.Subclass, DxfSubclassMarker.DbColor);
@@ -395,6 +403,9 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 			case AcdbPlaceHolder acdbPlaceHolder:
 				this.writeAcdbPlaceHolder(acdbPlaceHolder);
 				return;
+			case BlockRepresentationData blockRepresentationData:
+				this.writeBlockRepresentationData(blockRepresentationData);
+				break;
 			case BookColor bookColor:
 				this.writeBookColor(bookColor);
 				return;
@@ -611,7 +622,6 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 			case MultiLeaderObjectContextData:
 			case VisualStyle:
 			case ProxyObject:
-			case BlockRepresentationData:
 			case MTextAttributeObjectContextData:
 			case BlockReferenceObjectContextData:
 				this.notify($"Object not implemented : {co.GetType().FullName}", NotificationType.NotImplemented);

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
@@ -5,6 +5,7 @@ using ACadSharp.Objects.Evaluations;
 using ACadSharp.Tables;
 using CSMath;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace ACadSharp.IO.DXF;
@@ -12,6 +13,8 @@ namespace ACadSharp.IO.DXF;
 internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 {
 	public override string SectionName { get { return DxfFileToken.ObjectsSection; } }
+
+	private readonly HashSet<ulong> _writtenHandles = new();
 
 	public DxfObjectsSectionWriter(IDxfStreamWriter writer, CadDocument document, CadObjectHolder holder, DxfWriterConfiguration configuration)
 		: base(writer, document, holder, configuration)
@@ -545,6 +548,14 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 		while (this.Holder.Objects.Any())
 		{
 			CadObject item = this.Holder.Objects.Dequeue();
+
+			//An object can be enqueued multiple times, by the dictionary
+			//that owns it and by the objects that reference it (e.g. fields
+			//in a field list), write it only once
+			if (!this._writtenHandles.Add(item.Handle))
+			{
+				continue;
+			}
 
 			this.writeObject(item);
 		}

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.cs
@@ -236,6 +236,8 @@ internal abstract partial class DxfSectionWriterBase
 
 	protected void writeLongTextValue(int code, int subcode, string text)
 	{
+		text = text ?? string.Empty;
+
 		while (text.Length > 250)
 		{
 			this._writer.Write(subcode, text.Substring(0, 250));


### PR DESCRIPTION
First step toward the dynamic-block write support discussed in #1133: writing `BlockRepresentationData` (`AcDbRepData`) in both the DWG and DXF writers.

### What this does
`BlockRepresentationData` is the per-insert object (under `Insert.XDictionary → AcDbBlockRepresentation → AcDbRepData`) that links an anonymous `*U…` block instance back to its source dynamic block. Its sibling `AppDataCache → ACAD_ENHANCEDBLOCKDATA → XRecord` chain already round-trips through the existing dictionary/XRecord writers — only `AcDbRepData` itself was dropped by `skipEntry` / `isObjectSupported`.

- Removes `BlockRepresentationData` from the DWG `skipEntry` and DXF `isObjectSupported` drop-lists.
- `writeBlockRepresentationData` in both writers, mirroring the readers: `BS 70` (`Value70`) + a hard pointer (`340`) to the source `BlockRecord`.
- Adds the `AcDbBlockRepresentationData` `DxfClass` entry (values taken from AutoCAD-authored files: `ProxyFlags=1153`, `ItemClassId=499`, `DwgVersion=AC1018`, `MaintenanceVersion=58`; identical across the AC1027 and AC1032 files I checked).
- Refactors `DynamicBlockTests` asserts into a reusable `assertRepresentationChain` layer and adds unconditional DWG + DXF round-trip theories (they are **not** gated on `SELF_CHECK_OUTPUT`, so they run in CI).

### Scope / what this deliberately does NOT do
This does not write the `EvaluationGraph` (`ACAD_ENHANCEDBLOCK`) — you mentioned in #1133 you're exploring that yourself, so I've kept this PR to the representation-data half and left the graph alone.

### Validation against real AutoCAD
I ran the rewritten files through AutoCAD 2022 (via COM `AUDIT` + block-reference enumeration) on a corpus of real production dynamic-block templates: all open **without a recover prompt** and audit-clean apart from a finding that is already present in the untouched source file (an unrelated `ACAD_LAYERFILTERS` XRecord length). One honest caveat: restoring `AcDbRepData` alone does **not** make `IsDynamicBlock` return true — that needs the graph — but it adds no audit errors and is a prerequisite for it. 61/61 `DynamicBlockTests` pass.

### Note
Stacked on #1136 (the DXF objects-section writer fixes) — the round-trip tests here rely on those. I'll rebase once #1136 merges; until then this branch contains those three commits too.
