### PR TITLE
Issue-1127 DxfClass instance count fix

### DIFF
--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>3.6.37</Version>
+		<Version>3.6.38</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>../ACadSharp.snk</AssemblyOriginatorKeyFile>

--- a/src/ACadSharp/CadDocument.cs
+++ b/src/ACadSharp/CadDocument.cs
@@ -573,12 +573,16 @@ public class CadDocument : IHandledCadObject
 		this.Classes.UpdateDxfClasses();
 	}
 
+	/// <summary>
+	/// Gets the number of instances of a specific DXF object type in the document.
+	/// </summary>
+	/// <param name="dxfName">The name of the DXF object type.</param>
+	/// <returns>The number of instances of the specified DXF object type.</returns>
 	public int GetInstanceCount(string dxfName)
 	{
 		return this._cadObjects.Values
 			.OfType<CadObject>()
-			.Where(c => c.ObjectName == dxfName)
-			.Count();
+			.Count(c => c.ObjectName == dxfName);
 	}
 
 	/// <summary>

--- a/src/ACadSharp/Classes/DxfClassCollection.cs
+++ b/src/ACadSharp/Classes/DxfClassCollection.cs
@@ -5,6 +5,9 @@ using System.Linq;
 
 namespace ACadSharp.Classes;
 
+/// <summary>
+/// Represents a collection of <see cref="DxfClass"/> objects.
+/// </summary>
 public class DxfClassCollection : ICollection<DxfClass>
 {
 	/// <inheritdoc/>
@@ -17,29 +20,33 @@ public class DxfClassCollection : ICollection<DxfClass>
 
 	private readonly Dictionary<string, DxfClass> _entries = new Dictionary<string, DxfClass>(StringComparer.OrdinalIgnoreCase);
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="DxfClassCollection"/> class.
+	/// </summary>
+	/// <param name="document">The CAD document associated with this collection.</param>
 	public DxfClassCollection(CadDocument document)
 	{
 		this._document = document;
 	}
 
 	/// <summary>
-	/// Add a dxf class to the collection if the <see cref="DxfClass.DxfName"/> is not present
+	/// Add a dxf class to the collection if the <see cref="DxfClass.DxfName"/> is not present.
 	/// </summary>
-	/// <param name="item"></param>
+	/// <param name="item">The dxf class to add.</param>
 	public void Add(DxfClass item)
 	{
 		this._entries.Add(item.DxfName, item);
 	}
 
 	/// <summary>
-	/// Add a dxf class to the collection or updates the existing one if the <see cref="DxfClass.DxfName"/> is already in the collection
+	/// Add a dxf class to the collection or updates the existing one if the <see cref="DxfClass.DxfName"/> is already in the collection.
 	/// </summary>
-	/// <param name="item"></param>
+	/// <param name="item">The dxf class to add or update.</param>
 	public void AddOrUpdate(DxfClass item)
 	{
 		if (this._entries.TryGetValue(item.DxfName, out DxfClass result))
 		{
-			result.InstanceCount = result.InstanceCount;
+			result.InstanceCount = this._document.GetInstanceCount(item.DxfName);
 		}
 		else
 		{
@@ -50,14 +57,14 @@ public class DxfClassCollection : ICollection<DxfClass>
 	/// <inheritdoc/>
 	public void Clear()
 	{
-		_entries.Clear();
+		this._entries.Clear();
 	}
 
 	/// <summary>
 	/// Determines whether the Collection contains a specific <see cref="DxfClass.DxfName"/>.
 	/// </summary>
-	/// <param name="dxfname"></param>
-	/// <returns></returns>
+	/// <param name="dxfname">The name of the dxf class to check.</param>
+	/// <returns>true if the Collection contains an element with the specified name; otherwise, false.</returns>
 	public bool Contains(string dxfname)
 	{
 		return this._entries.ContainsKey(dxfname);
@@ -66,7 +73,7 @@ public class DxfClassCollection : ICollection<DxfClass>
 	/// <inheritdoc/>
 	public bool Contains(DxfClass item)
 	{
-		return _entries.Values.Contains(item);
+		return this._entries.Values.Contains(item);
 	}
 
 	/// <inheritdoc/>
@@ -105,7 +112,7 @@ public class DxfClassCollection : ICollection<DxfClass>
 	/// <inheritdoc/>
 	public IEnumerator<DxfClass> GetEnumerator()
 	{
-		return _entries.Values.GetEnumerator();
+		return this._entries.Values.GetEnumerator();
 	}
 
 	/// <inheritdoc/>

--- a/src/ACadSharp/Entities/RasterImage.cs
+++ b/src/ACadSharp/Entities/RasterImage.cs
@@ -2,58 +2,57 @@
 using ACadSharp.Objects;
 using System;
 
-namespace ACadSharp.Entities
+namespace ACadSharp.Entities;
+
+/// <summary>
+/// Represents a <see cref="RasterImage"/> entity.
+/// </summary>
+/// <remarks>
+/// Object name <see cref="DxfFileToken.EntityImage"/> <br/>
+/// Dxf class name <see cref="DxfSubclassMarker.RasterImage"/>
+/// </remarks>
+[DxfName(DxfFileToken.EntityImage)]
+[DxfSubClass(DxfSubclassMarker.RasterImage)]
+public class RasterImage : CadWipeoutBase
 {
-	/// <summary>
-	/// Represents a <see cref="RasterImage"/> entity.
-	/// </summary>
-	/// <remarks>
-	/// Object name <see cref="DxfFileToken.EntityImage"/> <br/>
-	/// Dxf class name <see cref="DxfSubclassMarker.RasterImage"/>
-	/// </remarks>
-	[DxfName(DxfFileToken.EntityImage)]
-	[DxfSubClass(DxfSubclassMarker.RasterImage)]
-	public class RasterImage : CadWipeoutBase
+	/// <inheritdoc/>
+	public override ImageDefinition Definition
 	{
-		/// <inheritdoc/>
-		public override string ObjectName => DxfFileToken.EntityImage;
-
-		/// <inheritdoc/>
-		public override ObjectType ObjectType => ObjectType.UNLISTED;
-
-		/// <inheritdoc/>
-		public override string SubclassMarker => DxfSubclassMarker.RasterImage;
-
-		/// <inheritdoc/>
-		public override ImageDefinition Definition
+		get
 		{
-			get
+			return base.Definition;
+		}
+
+		set
+		{
+			if (value == null)
 			{
-				return base.Definition;
+				throw new ArgumentNullException(nameof(value));
 			}
 
-			set
-			{
-				if (value == null)
-				{
-					throw new ArgumentNullException(nameof(value));
-				}
-
-				base.Definition = value;
-			}
+			base.Definition = value;
 		}
+	}
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="RasterImage" /> class.
-		/// </summary>
-		/// <param name="definition"></param>
-		public RasterImage(ImageDefinition definition)
-		{
-			this.Definition = definition;
-		}
+	/// <inheritdoc/>
+	public override string ObjectName => DxfFileToken.EntityImage;
 
-		internal RasterImage() : base()
-		{
-		}
+	/// <inheritdoc/>
+	public override ObjectType ObjectType => ObjectType.UNLISTED;
+
+	/// <inheritdoc/>
+	public override string SubclassMarker => DxfSubclassMarker.RasterImage;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="RasterImage" /> class.
+	/// </summary>
+	/// <param name="definition"></param>
+	public RasterImage(ImageDefinition definition)
+	{
+		this.Definition = definition;
+	}
+
+	internal RasterImage() : base()
+	{
 	}
 }


### PR DESCRIPTION
# Description

Refactored GetInstanceCount for clarity.
Updated DxfClassCollection to use consistent code style and correct InstanceCount updates.
Improved RasterImage class structure, documentation, and property logic.
Removed redundant code and reorganized constructors for clarity.