### PR TITLE
Read the ACIS payload of 3DSOLID, REGION and BODY from DXF and DWG

### DIFF
--- a/src/ACadSharp.Tests/IO/AcisTextCodecTests.cs
+++ b/src/ACadSharp.Tests/IO/AcisTextCodecTests.cs
@@ -1,0 +1,82 @@
+using ACadSharp.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace ACadSharp.Tests.IO;
+
+public class AcisTextCodecTests
+{
+	[Fact]
+	public void DecodeIsAnInvolution()
+	{
+		string text = "400 0 1 0\nbody $-1 $1 $-1 $-1 #";
+
+		string swapped = AcisTextCodec.Decode(text);
+
+		Assert.NotEqual(text, swapped);
+		Assert.Equal(text, AcisTextCodec.Decode(swapped));
+	}
+
+	[Fact]
+	public void DecodeBytesMatchesTextDecode()
+	{
+		string text = "body $-1 $1 $-1 $-1 #";
+		byte[] swapped = Encoding.ASCII.GetBytes(AcisTextCodec.Decode(text));
+
+		byte[] decoded = AcisTextCodec.Decode(swapped);
+
+		Assert.Equal(text, Encoding.ASCII.GetString(decoded));
+	}
+
+	[Fact]
+	public void IsEncodedDetectsPlainAndSwappedSat()
+	{
+		string plain = "400 0 1 0";
+
+		Assert.False(AcisTextCodec.IsEncoded(plain));
+		Assert.True(AcisTextCodec.IsEncoded(AcisTextCodec.Decode(plain)));
+	}
+
+	[Theory]
+	[InlineData("End-of-ACIS-data")]
+	[InlineData("End-of-ASM-data")]
+	public void TrimAtAcisEndCutsAfterAsciiMarker(string marker)
+	{
+		byte[] payload = Encoding.ASCII.GetBytes("some sat content " + marker);
+		byte[] trailing = payload.Concat(new byte[] { 0x00, 0x11, 0x22, 0x33 }).ToArray();
+
+		byte[] trimmed = AcisTextCodec.TrimAtAcisEnd(trailing);
+
+		Assert.Equal(payload.Length, trimmed.Length);
+		Assert.EndsWith(marker, Encoding.ASCII.GetString(trimmed));
+	}
+
+	[Fact]
+	public void TrimAtAcisEndCutsAfterCompoundSabMarker()
+	{
+		byte[] compound = new byte[]
+		{
+			0x0E, 0x03, (byte)'E', (byte)'n', (byte)'d',
+			0x0E, 0x02, (byte)'o', (byte)'f',
+			0x0E, 0x04, (byte)'A', (byte)'C', (byte)'I', (byte)'S',
+			0x0D, 0x04, (byte)'d', (byte)'a', (byte)'t', (byte)'a'
+		};
+		byte[] payload = Encoding.ASCII.GetBytes("ACIS BinaryFile fake content ").Concat(compound).ToArray();
+		byte[] trailing = payload.Concat(new byte[] { 0xAA, 0xBB }).ToArray();
+
+		byte[] trimmed = AcisTextCodec.TrimAtAcisEnd(trailing);
+
+		Assert.Equal(payload.Length, trimmed.Length);
+	}
+
+	[Fact]
+	public void TrimAtAcisEndKeepsPayloadWithoutMarker()
+	{
+		byte[] payload = Encoding.ASCII.GetBytes("truncated sat content");
+
+		byte[] trimmed = AcisTextCodec.TrimAtAcisEnd(payload);
+
+		Assert.Same(payload, trimmed);
+	}
+}

--- a/src/ACadSharp.Tests/IO/DWG/DwgAcDsDataReaderTests.cs
+++ b/src/ACadSharp.Tests/IO/DWG/DwgAcDsDataReaderTests.cs
@@ -1,0 +1,163 @@
+using ACadSharp.IO.DWG.DwgStreamReaders;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace ACadSharp.Tests.IO.DWG;
+
+public class DwgAcDsDataReaderTests
+{
+	[Fact]
+	public void ReadRecordsExtractsInlinePayloadByHandle()
+	{
+		// One _data_ segment with two records: an ACIS payload for handle 0xAA
+		// and a non ACIS one (a thumbnail like blob) for handle 0xBB. Only the
+		// first must come back, keyed by its owner handle.
+		byte[] acis = Encoding.ASCII.GetBytes("ACIS BinaryFile-test-");
+		byte[] other = Encoding.ASCII.GetBytes("PNG!");
+
+		byte[] buffer = buildSection(writer =>
+		{
+			writeRecordDirectory(writer, (0xAA, 0u), (0xBB, (uint)(4 + acis.Length)));
+
+			writer.Write(acis.Length);
+			writer.Write(acis);
+			writer.Write(other.Length);
+			writer.Write(other);
+		});
+
+		Dictionary<ulong, byte[]> records = DwgAcDsDataReader.ReadRecords(buffer);
+
+		Assert.Single(records);
+		Assert.Equal(acis, records[0xAA]);
+	}
+
+	[Fact]
+	public void ReadRecordsExtractsBlobPayloadWithLongSizeHeader()
+	{
+		// Payloads stored in the blob01 segments use a 4 byte marker plus an
+		// 8 byte size in front of the data instead of the plain 4 byte size.
+		byte[] asm = Encoding.ASCII.GetBytes("ASM BinaryFile-test-payload");
+
+		byte[] buffer = buildSection(writer =>
+		{
+			writeRecordDirectory(writer, (0xCC, 0u));
+
+			writer.Write(1);
+			writer.Write((long)asm.Length);
+			writer.Write(asm);
+		});
+
+		Dictionary<ulong, byte[]> records = DwgAcDsDataReader.ReadRecords(buffer);
+
+		Assert.Single(records);
+		Assert.Equal(asm, records[0xCC]);
+	}
+
+	[Fact]
+	public void ReadRecordsIgnoresSectionsWithoutAcisContent()
+	{
+		byte[] buffer = buildSection(writer =>
+		{
+			writeRecordDirectory(writer, (0xAA, 0u));
+
+			byte[] other = Encoding.ASCII.GetBytes("no acis here");
+			writer.Write(other.Length);
+			writer.Write(other);
+		});
+
+		Assert.Empty(DwgAcDsDataReader.ReadRecords(buffer));
+	}
+
+	private static byte[] buildSection(System.Action<BinaryWriter> writeDataContent)
+	{
+		using MemoryStream stream = new MemoryStream();
+		using BinaryWriter writer = new BinaryWriter(stream);
+
+		const int dataSegmentOffset = 0x40;
+
+		// Section header: signature and the fields up to the segment index
+		// location (0x18) and the entry count (0x20)
+		writer.Write(0x6472616A);            // file signature
+		writer.Write(0x80);                  // file header size
+		writer.Write(2);                     // unknown, always 2
+		writer.Write(2);                     // version
+		writer.Write(0);                     // unknown
+		writer.Write(3);                     // ds version
+		writer.Write(0);                     // segidx offset, patched at the end
+		writer.Write(0);                     // segidx unknown
+		writer.Write(1);                     // num segidx
+		writer.Write(0);                     // schidx segidx
+		writer.Write(0);                     // datidx segidx
+		writer.Write(0);                     // search segidx
+		writer.Write(0);                     // prvsav segidx
+		writer.Write(0);                     // file size, unused by the reader
+
+		while (stream.Position < dataSegmentOffset)
+		{
+			writer.Write((byte)0);
+		}
+
+		// _data_ segment
+		writeSegmentHeader(writer, "_data_");
+		writeDataContent(writer);
+
+		// segidx segment
+		long segidxOffset = align(writer, 0x10);
+		writeSegmentHeader(writer, "segidx");
+		writer.Write((long)dataSegmentOffset);
+		writer.Write(0x1000);
+
+		// patch the segment sizes and the segidx location
+		byte[] buffer = stream.ToArray();
+		writeUInt(buffer, dataSegmentOffset + 16, (uint)(segidxOffset - dataSegmentOffset));
+		writeUInt(buffer, 0x18, (uint)segidxOffset);
+
+		return buffer;
+	}
+
+	private static void writeSegmentHeader(BinaryWriter writer, string name)
+	{
+		writer.Write((ushort)0xD5AC);
+		writer.Write(Encoding.ASCII.GetBytes(name));
+		for (int i = 0; i < 8; i++)
+		{
+			writer.Write(0);
+		}
+
+		for (int i = 0; i < 8; i++)
+		{
+			writer.Write((byte)0x55);
+		}
+	}
+
+	private static void writeRecordDirectory(BinaryWriter writer, params (ulong handle, uint payloadOffset)[] records)
+	{
+		foreach ((ulong handle, uint payloadOffset) in records)
+		{
+			writer.Write(0x14);
+			writer.Write(1);
+			writer.Write(handle);
+			writer.Write(payloadOffset);
+		}
+	}
+
+	private static long align(BinaryWriter writer, int boundary)
+	{
+		while (writer.BaseStream.Position % boundary != 0)
+		{
+			writer.Write((byte)0);
+		}
+
+		return writer.BaseStream.Position;
+	}
+
+	private static void writeUInt(byte[] buffer, long offset, uint value)
+	{
+		buffer[offset] = (byte)value;
+		buffer[offset + 1] = (byte)(value >> 8);
+		buffer[offset + 2] = (byte)(value >> 16);
+		buffer[offset + 3] = (byte)(value >> 24);
+	}
+}

--- a/src/ACadSharp.Tests/IO/DXF/DxfAcdsDataSectionTests.cs
+++ b/src/ACadSharp.Tests/IO/DXF/DxfAcdsDataSectionTests.cs
@@ -1,0 +1,83 @@
+using ACadSharp.Entities;
+using ACadSharp.IO;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace ACadSharp.Tests.IO.DXF;
+
+public class DxfAcdsDataSectionTests
+{
+	[Fact]
+	public void ReadAcdsDataAttachesAcisPayloadToOwnerEntity()
+	{
+		// Minimal R2013+ style layout: the REGION entity carries no geometry codes,
+		// the SAB payload lives in the ACDSDATA section and points back to the
+		// entity through the AcDbDs::ID handle at group code 320.
+		// The payload here is just the "ACIS BinaryFile" signature (15 bytes).
+		string dxf = string.Join("\n",
+			"0", "SECTION",
+			"2", "ENTITIES",
+			"0", "REGION",
+			"5", "1FF0",
+			"100", "AcDbEntity",
+			"8", "0",
+			"100", "AcDbModelerGeometry",
+			"70", "1",
+			"0", "ENDSEC",
+			"0", "SECTION",
+			"2", "ACDSDATA",
+			"70", "2",
+			"71", "2",
+			"0", "ACDSSCHEMA",
+			"90", "1",
+			"1", "AcDb3DSolid_ASM_Data",
+			"2", "AcDbDs::ID",
+			"280", "10",
+			"91", "0",
+			"2", "ASM_Data",
+			"280", "15",
+			"91", "0",
+			"0", "ACDSRECORD",
+			"90", "1",
+			"2", "AcDbDs::ID",
+			"280", "10",
+			"320", "1FF0",
+			"2", "ASM_Data",
+			"280", "15",
+			"94", "15",
+			"310", "414349532042696E61727946696C65",
+			"0", "ENDSEC",
+			"0", "EOF");
+
+		CadDocument doc;
+		using (MemoryStream stream = new MemoryStream(Encoding.ASCII.GetBytes(dxf)))
+		using (DxfReader reader = new DxfReader(stream))
+		{
+			doc = reader.Read();
+		}
+
+		Region region = doc.Entities.OfType<Region>().Single();
+
+		Assert.NotNull(region.AcisData);
+		Assert.Equal(15, region.AcisData.Length);
+		Assert.True(region.IsBinaryAcisData);
+		Assert.Null(region.GetAcisText());
+		Assert.Equal("ACIS BinaryFile", Encoding.ASCII.GetString(region.AcisData));
+	}
+
+	[Fact]
+	public void AcisDataTextHelpers()
+	{
+		Region region = new Region();
+
+		Assert.False(region.IsBinaryAcisData);
+		Assert.Null(region.GetAcisText());
+
+		region.AcisData = Encoding.ASCII.GetBytes("400 0 1 0\nbody $-1 $1 $-1 $-1 #\n");
+
+		Assert.False(region.IsBinaryAcisData);
+		Assert.StartsWith("400 0 1 0", region.GetAcisText());
+	}
+}

--- a/src/ACadSharp.Tests/IO/DXF/DxfAcisSatTextTests.cs
+++ b/src/ACadSharp.Tests/IO/DXF/DxfAcisSatTextTests.cs
@@ -1,0 +1,96 @@
+using ACadSharp.Entities;
+using ACadSharp.IO;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace ACadSharp.Tests.IO.DXF;
+
+public class DxfAcisSatTextTests
+{
+	[Fact]
+	public void ReadCharacterSwappedSatFromCodes1And3()
+	{
+		// Pre-2013 files store the SAT text of the modeler geometry entities with
+		// the documented character swap (0x9F minus the character, above space).
+		// Group code 1 starts a SAT line, group code 3 continues the previous one.
+		string line1 = "400 0 1 0";
+		string line2 = "body $-1 $1 $-1 $-1 #";
+
+		// Split the second line between codes 1 and 3 to check the join.
+		string chunkA = line2.Substring(0, 10);
+		string chunkB = line2.Substring(10);
+
+		string dxf = string.Join("\n",
+			"0", "SECTION",
+			"2", "ENTITIES",
+			"0", "REGION",
+			"5", "A1",
+			"100", "AcDbEntity",
+			"8", "0",
+			"100", "AcDbModelerGeometry",
+			"70", "1",
+			"1", encode(line1),
+			"1", encode(chunkA),
+			"3", encode(chunkB),
+			"0", "ENDSEC",
+			"0", "EOF");
+
+		Region region = readSingleRegion(dxf);
+
+		Assert.NotNull(region.AcisData);
+		Assert.False(region.IsBinaryAcisData);
+		Assert.Equal(line1 + "\n" + line2, region.GetAcisText());
+	}
+
+	[Fact]
+	public void ReadPlainSatFromCodes1And3()
+	{
+		// A payload that already starts with the numeric SAT header must pass
+		// through untouched.
+		string line1 = "400 0 1 0";
+		string line2 = "body $-1 $1 $-1 $-1 #";
+
+		string dxf = string.Join("\n",
+			"0", "SECTION",
+			"2", "ENTITIES",
+			"0", "REGION",
+			"5", "A1",
+			"100", "AcDbEntity",
+			"8", "0",
+			"100", "AcDbModelerGeometry",
+			"70", "1",
+			"1", line1,
+			"1", line2,
+			"0", "ENDSEC",
+			"0", "EOF");
+
+		Region region = readSingleRegion(dxf);
+
+		Assert.Equal(line1 + "\n" + line2, region.GetAcisText());
+	}
+
+	private static Region readSingleRegion(string dxf)
+	{
+		CadDocument doc;
+		using (MemoryStream stream = new MemoryStream(Encoding.ASCII.GetBytes(dxf)))
+		using (DxfReader reader = new DxfReader(stream))
+		{
+			doc = reader.Read();
+		}
+
+		return doc.Entities.OfType<Region>().Single();
+	}
+
+	private static string encode(string text)
+	{
+		StringBuilder sb = new StringBuilder(text.Length);
+		foreach (char c in text)
+		{
+			sb.Append(c > ' ' ? (char)(0x9F - c) : c);
+		}
+
+		return sb.ToString();
+	}
+}

--- a/src/ACadSharp/DxfFileToken.cs
+++ b/src/ACadSharp/DxfFileToken.cs
@@ -2,6 +2,12 @@
 
 public static class DxfFileToken
 {
+	public const string AcdsDataSection = "ACDSDATA";
+
+	public const string AcdsRecord = "ACDSRECORD";
+
+	public const string AcdsSchema = "ACDSSCHEMA";
+
 	public const string BeginSection = "SECTION";
 
 	public const string BlkRefObjectContextData = "ACDB_BLKREFOBJECTCONTEXTDATA_CLASS";

--- a/src/ACadSharp/Entities/ModelerGeometry.cs
+++ b/src/ACadSharp/Entities/ModelerGeometry.cs
@@ -34,6 +34,61 @@ namespace ACadSharp.Entities
 		//[DxfCodeValue(3)]
 		public StringBuilder ProprietaryData { get; } = new();
 
+		/// <summary>
+		/// Raw ACIS payload that describes the geometry of this entity.
+		/// </summary>
+		/// <remarks>
+		/// The payload is binary SAB when it starts with the "ACIS BinaryFile" signature
+		/// (check <see cref="IsBinaryAcisData"/>), plain SAT text bytes otherwise.
+		/// In R2013+ files the modeler geometry is stored apart from the entity
+		/// (ACDSDATA section in DXF, AcDs data section in DWG) and this property is
+		/// the only carrier of the geometry; older versions embed it in the entity
+		/// itself.
+		/// </remarks>
+		public byte[] AcisData { get; set; }
+
+		/// <summary>
+		/// Flag that indicates if <see cref="AcisData"/> contains a binary SAB
+		/// payload instead of SAT text.
+		/// </summary>
+		public bool IsBinaryAcisData
+		{
+			get
+			{
+				if (this.AcisData == null || this.AcisData.Length < _acisBinarySignature.Length)
+				{
+					return false;
+				}
+
+				for (int i = 0; i < _acisBinarySignature.Length; i++)
+				{
+					if (this.AcisData[i] != _acisBinarySignature[i])
+					{
+						return false;
+					}
+				}
+
+				return true;
+			}
+		}
+
+		/// <summary>
+		/// Gets the SAT text carried by <see cref="AcisData"/>.
+		/// </summary>
+		/// <returns>The SAT content as a string, or null when the payload is empty or binary SAB.</returns>
+		public string GetAcisText()
+		{
+			if (this.AcisData == null || this.AcisData.Length == 0 || this.IsBinaryAcisData)
+			{
+				return null;
+			}
+
+			return Encoding.ASCII.GetString(this.AcisData);
+		}
+
+		//Signature that marks the start of a binary SAB payload
+		private static readonly byte[] _acisBinarySignature = Encoding.ASCII.GetBytes("ACIS BinaryFile");
+
 		/// <inheritdoc/>
 		public override void ApplyTransform(Transform transform)
 		{

--- a/src/ACadSharp/IO/AcisTextCodec.cs
+++ b/src/ACadSharp/IO/AcisTextCodec.cs
@@ -1,0 +1,69 @@
+using System.Text;
+
+namespace ACadSharp.IO
+{
+	/// <summary>
+	/// Codec for the character swap applied to the SAT text carried by the
+	/// modeler geometry entities (3DSOLID, REGION, BODY) in pre-2013 files.
+	/// </summary>
+	/// <remarks>
+	/// Each character above the space is stored as 0x9F minus its code, the rest
+	/// pass through unchanged. The transformation is an involution: applying it
+	/// twice returns the original text, so the same method encodes and decodes.
+	/// </remarks>
+	internal static class AcisTextCodec
+	{
+		/// <summary>
+		/// Decodes (or encodes) a chunk of character-swapped SAT text.
+		/// </summary>
+		public static string Decode(string text)
+		{
+			if (string.IsNullOrEmpty(text))
+			{
+				return text;
+			}
+
+			StringBuilder sb = new StringBuilder(text.Length);
+			foreach (char c in text)
+			{
+				if (c > ' ' && c < (char)0x9F)
+				{
+					sb.Append((char)(0x9F - c));
+				}
+				else
+				{
+					sb.Append(c);
+				}
+			}
+
+			return sb.ToString();
+		}
+
+		/// <summary>
+		/// Detects if a SAT chunk is character-swapped.
+		/// </summary>
+		/// <remarks>
+		/// Plain SAT starts with the numeric header line (for example "400 0 1 0"),
+		/// so a first printable character that is not a digit marks a swapped payload.
+		/// </remarks>
+		public static bool IsEncoded(string text)
+		{
+			if (string.IsNullOrEmpty(text))
+			{
+				return false;
+			}
+
+			foreach (char c in text)
+			{
+				if (c <= ' ')
+				{
+					continue;
+				}
+
+				return !char.IsDigit(c);
+			}
+
+			return false;
+		}
+	}
+}

--- a/src/ACadSharp/IO/AcisTextCodec.cs
+++ b/src/ACadSharp/IO/AcisTextCodec.cs
@@ -77,33 +77,9 @@ namespace ACadSharp.IO
 				return data;
 			}
 
-			//The marker spells "ACIS" or "ASM" depending on the kernel that wrote
-			//the payload, as plain ASCII (SAT text and single-tag SAB records) or
-			//as a compound SAB entity name split in tagged chunks:
-			//0x0E "End" 0x0E "of" 0x0E "ACIS" 0x0D "data"
-			byte[][] markers = new byte[][]
+			foreach (byte[] marker in _endMarkers)
 			{
-				Encoding.ASCII.GetBytes("End-of-ACIS-data"),
-				Encoding.ASCII.GetBytes("End-of-ASM-data"),
-				new byte[]
-				{
-					0x0E, 0x03, (byte)'E', (byte)'n', (byte)'d',
-					0x0E, 0x02, (byte)'o', (byte)'f',
-					0x0E, 0x04, (byte)'A', (byte)'C', (byte)'I', (byte)'S',
-					0x0D, 0x04, (byte)'d', (byte)'a', (byte)'t', (byte)'a'
-				},
-				new byte[]
-				{
-					0x0E, 0x03, (byte)'E', (byte)'n', (byte)'d',
-					0x0E, 0x02, (byte)'o', (byte)'f',
-					0x0E, 0x03, (byte)'A', (byte)'S', (byte)'M',
-					0x0D, 0x04, (byte)'d', (byte)'a', (byte)'t', (byte)'a'
-				}
-			};
-
-			foreach (byte[] marker in markers)
-			{
-				int index = indexOf(data, marker);
+				int index = indexOf(data, marker, 0);
 				if (index >= 0)
 				{
 					return cutAfter(data, index + marker.Length);
@@ -112,6 +88,29 @@ namespace ACadSharp.IO
 
 			return data;
 		}
+
+		//End-of-ACIS-data / End-of-ASM-data markers: the name depends on the kernel
+		//that wrote the payload, spelled as plain ASCII (SAT text and single-tag SAB
+		//records) or as a compound SAB entity name split in tagged chunks.
+		private static readonly byte[][] _endMarkers = new byte[][]
+		{
+			Encoding.ASCII.GetBytes("End-of-ACIS-data"),
+			Encoding.ASCII.GetBytes("End-of-ASM-data"),
+			new byte[]
+			{
+				0x0E, 0x03, (byte)'E', (byte)'n', (byte)'d',
+				0x0E, 0x02, (byte)'o', (byte)'f',
+				0x0E, 0x04, (byte)'A', (byte)'C', (byte)'I', (byte)'S',
+				0x0D, 0x04, (byte)'d', (byte)'a', (byte)'t', (byte)'a'
+			},
+			new byte[]
+			{
+				0x0E, 0x03, (byte)'E', (byte)'n', (byte)'d',
+				0x0E, 0x02, (byte)'o', (byte)'f',
+				0x0E, 0x03, (byte)'A', (byte)'S', (byte)'M',
+				0x0D, 0x04, (byte)'d', (byte)'a', (byte)'t', (byte)'a'
+			}
+		};
 
 		private static byte[] cutAfter(byte[] data, int end)
 		{
@@ -125,9 +124,9 @@ namespace ACadSharp.IO
 			return result;
 		}
 
-		private static int indexOf(byte[] haystack, byte[] needle)
+		private static int indexOf(byte[] haystack, byte[] needle, int start)
 		{
-			for (int i = 0; i <= haystack.Length - needle.Length; i++)
+			for (int i = start; i <= haystack.Length - needle.Length; i++)
 			{
 				bool match = true;
 				for (int j = 0; j < needle.Length; j++)

--- a/src/ACadSharp/IO/AcisTextCodec.cs
+++ b/src/ACadSharp/IO/AcisTextCodec.cs
@@ -40,6 +40,115 @@ namespace ACadSharp.IO
 		}
 
 		/// <summary>
+		/// Decodes (or encodes) a buffer of character-swapped SAT text.
+		/// </summary>
+		public static byte[] Decode(byte[] data)
+		{
+			if (data == null || data.Length == 0)
+			{
+				return data;
+			}
+
+			byte[] result = new byte[data.Length];
+			for (int i = 0; i < data.Length; i++)
+			{
+				byte b = data[i];
+				result[i] = b > 0x20 && b < 0x9F ? (byte)(0x9F - b) : b;
+			}
+
+			return result;
+		}
+
+		/// <summary>
+		/// Trims an ACIS payload at its end marker.
+		/// </summary>
+		/// <remarks>
+		/// The DWG entity stream gives no length for the payload, so the caller
+		/// reads up to the end of the object data and this method cuts the result
+		/// right after the End-of-ACIS-data marker. SAT text and single-tag SAB
+		/// records spell the marker as plain ASCII; older SAB writers emit it as a
+		/// compound entity name split in tagged chunks. The payload is returned
+		/// unchanged when no marker is found.
+		/// </remarks>
+		public static byte[] TrimAtAcisEnd(byte[] data)
+		{
+			if (data == null || data.Length == 0)
+			{
+				return data;
+			}
+
+			//The marker spells "ACIS" or "ASM" depending on the kernel that wrote
+			//the payload, as plain ASCII (SAT text and single-tag SAB records) or
+			//as a compound SAB entity name split in tagged chunks:
+			//0x0E "End" 0x0E "of" 0x0E "ACIS" 0x0D "data"
+			byte[][] markers = new byte[][]
+			{
+				Encoding.ASCII.GetBytes("End-of-ACIS-data"),
+				Encoding.ASCII.GetBytes("End-of-ASM-data"),
+				new byte[]
+				{
+					0x0E, 0x03, (byte)'E', (byte)'n', (byte)'d',
+					0x0E, 0x02, (byte)'o', (byte)'f',
+					0x0E, 0x04, (byte)'A', (byte)'C', (byte)'I', (byte)'S',
+					0x0D, 0x04, (byte)'d', (byte)'a', (byte)'t', (byte)'a'
+				},
+				new byte[]
+				{
+					0x0E, 0x03, (byte)'E', (byte)'n', (byte)'d',
+					0x0E, 0x02, (byte)'o', (byte)'f',
+					0x0E, 0x03, (byte)'A', (byte)'S', (byte)'M',
+					0x0D, 0x04, (byte)'d', (byte)'a', (byte)'t', (byte)'a'
+				}
+			};
+
+			foreach (byte[] marker in markers)
+			{
+				int index = indexOf(data, marker);
+				if (index >= 0)
+				{
+					return cutAfter(data, index + marker.Length);
+				}
+			}
+
+			return data;
+		}
+
+		private static byte[] cutAfter(byte[] data, int end)
+		{
+			if (end >= data.Length)
+			{
+				return data;
+			}
+
+			byte[] result = new byte[end];
+			System.Array.Copy(data, result, end);
+			return result;
+		}
+
+		private static int indexOf(byte[] haystack, byte[] needle)
+		{
+			for (int i = 0; i <= haystack.Length - needle.Length; i++)
+			{
+				bool match = true;
+				for (int j = 0; j < needle.Length; j++)
+				{
+					if (haystack[i + j] != needle[j])
+					{
+						match = false;
+						break;
+					}
+				}
+
+				if (match)
+				{
+					return i;
+				}
+			}
+
+			return -1;
+		}
+
+		/// <summary>
 		/// Detects if a SAT chunk is character-swapped.
 		/// </summary>
 		/// <remarks>

--- a/src/ACadSharp/IO/DWG/DwgDocumentBuilder.cs
+++ b/src/ACadSharp/IO/DWG/DwgDocumentBuilder.cs
@@ -6,6 +6,13 @@ namespace ACadSharp.IO.DWG;
 
 internal class DwgDocumentBuilder : CadDocumentBuilder
 {
+	/// <summary>
+	/// Modeler geometry entities (R2013+) whose "has DS binary data" flag is set:
+	/// their ACIS payload lives in the AcDs data section and is attached to them
+	/// once that section is read.
+	/// </summary>
+	public List<ModelerGeometry> AcisDsEntities { get; } = new();
+
 	public DwgReaderConfiguration Configuration { get; }
 
 	public DwgHeaderHandlesCollection HeaderHandles { get; set; } = new();

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgAcDsDataReader.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgAcDsDataReader.cs
@@ -1,0 +1,332 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ACadSharp.IO.DWG.DwgStreamReaders
+{
+	/// <summary>
+	/// Reads the ACIS payloads stored in the AcDs data section of R2013+ files
+	/// (AcDb:AcDsPrototype_1b).
+	/// </summary>
+	/// <remarks>
+	/// The section is a small container format: a header with a segment index,
+	/// followed by named segments. Each "_data_" segment starts with a directory
+	/// of fixed size records that carry the owner handle and the offset of the
+	/// record payload. Every payload is its byte size followed by the bytes; the
+	/// ones that carry a SAB stream start with the "ACIS BinaryFile" signature
+	/// ("ASM BinaryFile" for the newer modeler versions), the other schemas
+	/// stored in the section are ignored. Small payloads sit in the same segment
+	/// after the directory, large ones move to the "blob01" segments; in both
+	/// cases the payload area starts at an aligned position that varies between
+	/// producers, so the base is anchored on the signatures themselves and every
+	/// record is validated against it before it is accepted.
+	/// </remarks>
+	internal static class DwgAcDsDataReader
+	{
+		private const uint SegmentSignature = 0xD5AC;
+
+		private const uint RecordSize = 0x14;
+
+		private static readonly byte[] _acisSignature = Encoding.ASCII.GetBytes("ACIS BinaryFile");
+
+		private static readonly byte[] _asmSignature = Encoding.ASCII.GetBytes("ASM BinaryFile");
+
+		private class DataRecord
+		{
+			public ulong Handle;
+
+			public uint PayloadOffset;
+
+			public long DirectoryEnd;
+
+			public long SegmentEnd;
+		}
+
+		/// <summary>
+		/// Extracts the ACIS payloads of the section keyed by their owner handle.
+		/// </summary>
+		public static Dictionary<ulong, byte[]> ReadRecords(byte[] buffer, Action<string> onNotification = null)
+		{
+			Dictionary<ulong, byte[]> result = new Dictionary<ulong, byte[]>();
+
+			//Section header: 14 raw longs, the segment index location is at
+			//offset 0x18 and the number of index entries at 0x20
+			if (buffer == null || buffer.Length < 0x38)
+			{
+				return result;
+			}
+
+			uint segidxOffset = readUInt(buffer, 0x18);
+			uint numSegidx = readUInt(buffer, 0x20);
+
+			if (segidxOffset == 0 || segidxOffset >= buffer.Length || numSegidx == 0)
+			{
+				onNotification?.Invoke("AcDs data section with an empty or invalid segment index");
+				return result;
+			}
+
+			//Collect the record directories of all the _data_ segments. The
+			//segment index area starts with its own segment header (48 bytes),
+			//followed by an entry for each segment: offset (8) + size (4)
+			List<DataRecord> records = new List<DataRecord>();
+			long entry = segidxOffset + 48;
+			for (int i = 0; i < numSegidx && entry + 12 <= buffer.Length; i++, entry += 12)
+			{
+				ulong segmentOffset = readULong(buffer, entry);
+				if (segmentOffset == 0 || segmentOffset + 48 > (ulong)buffer.Length)
+				{
+					continue;
+				}
+
+				readDirectory(buffer, (long)segmentOffset, records);
+			}
+
+			if (records.Count == 0)
+			{
+				return result;
+			}
+
+			//All the signature positions in the section, used to anchor the
+			//payload areas
+			List<long> signatures = findSignatures(buffer);
+			if (signatures.Count == 0)
+			{
+				return result;
+			}
+
+			//Resolve each segment group on its own: try the payload bases implied
+			//by pairing the first signatures of the segment with the smallest
+			//record offsets, keep the base that validates the most records
+			foreach (IGrouping<long, DataRecord> group in records.GroupBy(r => r.DirectoryEnd))
+			{
+				List<DataRecord> pending = group.OrderBy(r => r.PayloadOffset).ToList();
+				long segmentEnd = pending[0].SegmentEnd;
+
+				List<long> local = signatures
+					.Where(s => s >= group.Key && s < segmentEnd)
+					.ToList();
+
+				//Large payloads move to the blob01 segments: when the segment has
+				//no signatures of its own, anchor on the whole section instead
+				long limit = segmentEnd;
+				if (local.Count == 0)
+				{
+					local = signatures;
+					limit = buffer.Length;
+				}
+
+				resolveRecords(buffer, pending, local, limit, result);
+			}
+
+			return result;
+		}
+
+		private static void resolveRecords(byte[] buffer, List<DataRecord> records, List<long> signatures, long limit, Dictionary<ulong, byte[]> result)
+		{
+			//Candidate bases from the first signatures paired with the smallest
+			//record offsets; the right pair anchors every record of the group.
+			//Inline payloads put a 4 byte size before the data, the ones stored
+			//in the blob01 segments use a 12 byte header instead, so each pair
+			//yields two candidates.
+			HashSet<long> candidates = new HashSet<long>();
+			foreach (long signature in signatures.Take(4))
+			{
+				foreach (DataRecord record in records.Take(4))
+				{
+					candidates.Add(signature - 4 - record.PayloadOffset);
+					candidates.Add(signature - 12 - record.PayloadOffset);
+				}
+			}
+
+			//Score every candidate base: the ACIS signatures it explains come
+			//first, the records of other schemas (thumbnails and the like) that
+			//land on a payload with a plausible size break the ties, since only
+			//the true base gives the whole directory a coherent layout
+			long bestBase = 0;
+			long bestScore = 0;
+			foreach (long candidate in candidates)
+			{
+				long score = 0;
+				foreach (DataRecord record in records)
+				{
+					if (validate(buffer, candidate, record, limit, out _, out _, out bool isAcis))
+					{
+						score += isAcis ? 1000 : 1;
+					}
+				}
+
+				//On equal score prefer the lowest base: the payload area starts
+				//right after the record directory, spurious anchors sit past it
+				if (score > bestScore || (score == bestScore && score > 0 && candidate < bestBase))
+				{
+					bestScore = score;
+					bestBase = candidate;
+				}
+			}
+
+			if (bestScore < 1000)
+			{
+				//No candidate explains a single ACIS payload
+				return;
+			}
+
+			foreach (DataRecord record in records)
+			{
+				if (!validate(buffer, bestBase, record, limit, out long dataStart, out long dataSize, out bool isAcis)
+					|| !isAcis)
+				{
+					continue;
+				}
+
+				byte[] payload = new byte[dataSize];
+				Array.Copy(buffer, dataStart, payload, 0, dataSize);
+				result[record.Handle] = payload;
+			}
+		}
+
+		private static bool validate(byte[] buffer, long payloadBase, DataRecord record, long limit, out long dataStart, out long dataSize, out bool isAcis)
+		{
+			dataStart = 0;
+			dataSize = 0;
+			isAcis = false;
+
+			long position = payloadBase + record.PayloadOffset;
+			if (position < 0 || position + 12 > limit)
+			{
+				return false;
+			}
+
+			//Two payload layouts: inline records put a 4 byte size before the
+			//data, the ones stored in the blob01 segments a 4 byte marker plus an
+			//8 byte size. Check both and let the one that lands on an ACIS
+			//signature win, a small marker value reads as a plausible inline size
+			//and would shadow the blob01 layout otherwise.
+			uint size = readUInt(buffer, position);
+			bool inlinePlausible = size > 0 && position + 4 + size <= limit;
+
+			ulong longSize = readULong(buffer, position + 4);
+			bool blobPlausible = longSize > 0 && position + 12 + (long)longSize <= limit;
+
+			if (inlinePlausible && matchesSignature(buffer, position + 4))
+			{
+				dataStart = position + 4;
+				dataSize = size;
+				isAcis = true;
+				return true;
+			}
+
+			if (blobPlausible && matchesSignature(buffer, position + 12))
+			{
+				dataStart = position + 12;
+				dataSize = (long)longSize;
+				isAcis = true;
+				return true;
+			}
+
+			if (inlinePlausible)
+			{
+				dataStart = position + 4;
+				dataSize = size;
+				return true;
+			}
+
+			if (blobPlausible)
+			{
+				dataStart = position + 12;
+				dataSize = (long)longSize;
+				return true;
+			}
+
+			return false;
+		}
+
+		private static void readDirectory(byte[] buffer, long offset, List<DataRecord> records)
+		{
+			//Segment header: signature (2), name (6), segment_idx, is_blob01,
+			//segment size, unknown, ds version, unknown, alignment offsets (4 each),
+			//padding (8)
+			if ((readUInt(buffer, offset) & 0xFFFF) != SegmentSignature)
+			{
+				return;
+			}
+
+			string name = Encoding.ASCII.GetString(buffer, (int)offset + 2, 6);
+			if (name != "_data_")
+			{
+				return;
+			}
+
+			uint segmentSize = readUInt(buffer, offset + 16);
+			long segmentEnd = Math.Min(offset + segmentSize, buffer.Length);
+
+			//Record directory: fixed 20 byte entries with the owner handle and the
+			//offset of the record payload
+			long cursor = offset + 48;
+			List<DataRecord> directory = new List<DataRecord>();
+			while (cursor + RecordSize <= segmentEnd && readUInt(buffer, cursor) == RecordSize)
+			{
+				directory.Add(new DataRecord
+				{
+					Handle = readULong(buffer, cursor + 8),
+					PayloadOffset = readUInt(buffer, cursor + 16),
+					SegmentEnd = segmentEnd,
+				});
+				cursor += RecordSize;
+			}
+
+			foreach (DataRecord record in directory)
+			{
+				record.DirectoryEnd = cursor;
+				records.Add(record);
+			}
+		}
+
+		private static List<long> findSignatures(byte[] buffer)
+		{
+			List<long> positions = new List<long>();
+			for (long i = 0; i < buffer.Length - _asmSignature.Length; i++)
+			{
+				if (matchesSignature(buffer, i))
+				{
+					positions.Add(i);
+				}
+			}
+
+			return positions;
+		}
+
+		private static bool matchesSignature(byte[] buffer, long position)
+		{
+			return matches(buffer, position, _acisSignature) || matches(buffer, position, _asmSignature);
+		}
+
+		private static bool matches(byte[] buffer, long position, byte[] pattern)
+		{
+			if (position + pattern.Length > buffer.Length)
+			{
+				return false;
+			}
+
+			for (int i = 0; i < pattern.Length; i++)
+			{
+				if (buffer[position + i] != pattern[i])
+				{
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		private static uint readUInt(byte[] buffer, long offset)
+		{
+			return (uint)(buffer[offset] | buffer[offset + 1] << 8 | buffer[offset + 2] << 16 | buffer[offset + 3] << 24);
+		}
+
+		private static ulong readULong(byte[] buffer, long offset)
+		{
+			return readUInt(buffer, offset) | (ulong)readUInt(buffer, offset + 4) << 32;
+		}
+	}
+}

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -75,6 +75,11 @@ namespace ACadSharp.IO.DWG
 		/// <summary>
 		/// Needed to handle some items like colors or some text data that may not be present.
 		/// </summary>
+		//Has DS binary data flag of the object being read (R2013+): set while the
+		//common data is processed, consumed by the modeler geometry reader to
+		//register the entities whose ACIS payload lives in the AcDs data section.
+		private bool _hasDsBinaryData;
+
 		private IDwgStreamReader _mergedReaders;
 
 		private long _objectInitialPos = 0;
@@ -677,7 +682,7 @@ namespace ACadSharp.IO.DWG
 			if (this.R2013Plus)
 			{
 				//Has DS binary data B If 1 then this object has associated binary data stored in the data store
-				this._objectReader.ReadBit();
+				this._hasDsBinaryData = this._objectReader.ReadBit();
 			}
 		}
 
@@ -3515,6 +3520,12 @@ namespace ACadSharp.IO.DWG
 					this.readModelerGeometryData(template);
 					return template;
 				}
+			}
+			else if (this._hasDsBinaryData)
+			{
+				//R2013+ stores the ACIS payload in the AcDs data section: register
+				//the entity so the section reader can attach the matching blob.
+				this._builder.AcisDsEntities.Add(geometry);
 			}
 
 			//Common:

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -3616,16 +3616,46 @@ namespace ACadSharp.IO.DWG
 				//to get the real character.If it's a tab, we
 				//convert to a space.
 				case 1:
+					using (MemoryStream stream = new MemoryStream())
+					{
+						int blockSize = this._mergedReaders.ReadBitLong();
+						while (blockSize > 0)
+						{
+							byte[] block = AcisTextCodec.Decode(this._mergedReaders.ReadBytes(blockSize));
+							stream.Write(block, 0, block.Length);
+
+							blockSize = this._mergedReaders.ReadBitLong();
+						}
+
+						if (stream.Length > 0)
+						{
+							template.CadObject.AcisData = stream.ToArray();
+						}
+					}
 					break;
 				//Version == 2:
 				//Immediately following will be an acis file.Header value of “ACIS BinaryFile” indicates
 				//SAB, otherwise it is a text SAT file. No length is given.SAB files will end with
 				//“End\x0E\x02of\x0E\x04ACIS\x0D\x04data”. SAT files must be parsed to find the end.
 				case 2:
+					//The stream gives no payload length: read up to the end of the
+					//object data and cut at the End-of-ACIS-data marker. Anything
+					//after the marker (wireframe data, handles) is discarded with
+					//the rest of the object, the caller returns right away.
+					long currentPos = this._mergedReaders.PositionInBits();
+					long endPos = this._objectInitialPos + (this._size * 8);
+					int remainingBytes = (int)((endPos - currentPos) / 8);
+
+					if (remainingBytes > 0)
+					{
+						byte[] data = this._mergedReaders.ReadBytes(remainingBytes);
+						template.CadObject.AcisData = AcisTextCodec.TrimAtAcisEnd(data);
+					}
+					break;
+				default:
+					this.notify($"Modeler geometry data version {version} not recognized for {template.CadObject.ObjectName}", NotificationType.Warning);
 					break;
 			}
-
-			this.notify($"Stream data reader hasn't been implemented for {template.CadObject.ObjectName}", NotificationType.NotImplemented);
 		}
 
 		private CadTemplate readMText()

--- a/src/ACadSharp/IO/DWG/FileHeaders/DwgSectionDefinition.cs
+++ b/src/ACadSharp/IO/DWG/FileHeaders/DwgSectionDefinition.cs
@@ -6,6 +6,8 @@ namespace ACadSharp.IO.DWG
 	{
 		public const string AcDbObjects = "AcDb:AcDbObjects";
 
+		public const string AcDsPrototype = "AcDb:AcDsPrototype_1b";
+
 		public const string AppInfo = "AcDb:AppInfo";
 
 		public const string AuxHeader = "AcDb:AuxHeader";

--- a/src/ACadSharp/IO/DXF/DxfDocumentBuilder.cs
+++ b/src/ACadSharp/IO/DXF/DxfDocumentBuilder.cs
@@ -9,6 +9,13 @@ namespace ACadSharp.IO.DXF;
 
 internal class DxfDocumentBuilder : CadDocumentBuilder
 {
+	/// <summary>
+	/// ACIS payloads read from the ACDSDATA section, keyed by the handle of the
+	/// owner entity. Applied to the matching <see cref="ModelerGeometry"/>
+	/// entities when the document is built.
+	/// </summary>
+	public Dictionary<ulong, byte[]> AcdsDataRecords { get; } = new();
+
 	public DxfReaderConfiguration Configuration { get; }
 
 	public override bool IgnoreProxyGraphics => true;
@@ -56,9 +63,26 @@ internal class DxfDocumentBuilder : CadDocumentBuilder
 
 		base.BuildDocument();
 
+		this.applyAcdsData();
+
 		if (this.Configuration.CreateDefaults)
 		{
 			this.DocumentToBuild.CreateDefaults();
+		}
+	}
+
+	private void applyAcdsData()
+	{
+		foreach (KeyValuePair<ulong, byte[]> record in this.AcdsDataRecords)
+		{
+			if (this.TryGetCadObject(record.Key, out ModelerGeometry geometry))
+			{
+				geometry.AcisData = record.Value;
+			}
+			else
+			{
+				this.Notify($"ACDSDATA record owner {record.Key} is not a ModelerGeometry entity in the document", NotificationType.Warning);
+			}
 		}
 	}
 

--- a/src/ACadSharp/IO/DXF/DxfStreamReader/DxfAcdsDataSectionReader.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamReader/DxfAcdsDataSectionReader.cs
@@ -1,0 +1,71 @@
+using System.IO;
+
+namespace ACadSharp.IO.DXF.DxfStreamReader;
+
+internal class DxfAcdsDataSectionReader : DxfSectionReaderBase
+{
+	public DxfAcdsDataSectionReader(IDxfStreamReader reader, DxfDocumentBuilder builder)
+		: base(reader, builder)
+	{
+	}
+
+	public override void Read()
+	{
+		//Advance to the first value in the section
+		this._reader.ReadNext();
+
+		//The section contains ACDSSCHEMA entries (schema definitions, skipped) and
+		//ACDSRECORD entries. A data record associates an owner entity with its
+		//ASM/ACIS payload:
+		//  2   AcDbDs::ID
+		//  320 <owner entity handle>
+		//  2   ASM_Data
+		//  94  <payload length in bytes>
+		//  310 <hex chunks with the binary payload>
+		//Schema definitions also nest records introduced by group code 101; those
+		//carry no 320/310 pairs so the accumulation below ignores them naturally.
+		bool inRecord = false;
+		ulong currentHandle = 0;
+		MemoryStream payload = null;
+
+		while (this._reader.ValueAsString != DxfFileToken.EndSection)
+		{
+			if (this._reader.DxfCode == DxfCode.Start)
+			{
+				this.storeCurrentRecord(currentHandle, payload);
+
+				inRecord = this._reader.ValueAsString == DxfFileToken.AcdsRecord;
+				currentHandle = 0;
+				payload = null;
+			}
+			else if (inRecord)
+			{
+				switch (this._reader.Code)
+				{
+					case 320:
+						currentHandle = this._reader.ValueAsHandle;
+						break;
+					case 310:
+						payload = payload ?? new MemoryStream();
+						byte[] chunk = this._reader.ValueAsBinaryChunk;
+						payload.Write(chunk, 0, chunk.Length);
+						break;
+				}
+			}
+
+			this._reader.ReadNext();
+		}
+
+		this.storeCurrentRecord(currentHandle, payload);
+	}
+
+	private void storeCurrentRecord(ulong handle, MemoryStream payload)
+	{
+		if (handle == 0 || payload == null || payload.Length == 0)
+		{
+			return;
+		}
+
+		this._builder.AcdsDataRecords[handle] = payload.ToArray();
+	}
+}

--- a/src/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
@@ -161,7 +161,7 @@ internal abstract class DxfSectionReaderBase
 			case DxfFileToken.EntityArc:
 				return this.readEntityCodes<Arc>(new CadEntityTemplate<Arc>(), this.readArc);
 			case DxfFileToken.EntityBody:
-				return this.readEntityCodes<CadBody>(new CadEntityTemplate<CadBody>(), this.readEntitySubclassMap);
+				return this.readEntityCodes<CadBody>(new CadModelerGeometryTemplate<CadBody>(), this.readModelerGeometry);
 			case DxfFileToken.EntityCircle:
 				return this.readEntityCodes<Circle>(new CadEntityTemplate<Circle>(), this.readCircle);
 			case DxfFileToken.EntityDimension:
@@ -226,7 +226,7 @@ internal abstract class DxfSectionReaderBase
 			case DxfFileToken.Entity3DSolid:
 				return this.readEntityCodes<Solid3D>(new CadSolid3DTemplate(), this.readSolid3d);
 			case DxfFileToken.EntityRegion:
-				return this.readEntityCodes<Region>(new CadEntityTemplate<Region>(), this.readModelerGeometry);
+				return this.readEntityCodes<Region>(new CadModelerGeometryTemplate<Region>(), this.readModelerGeometry);
 			case DxfFileToken.EntityImage:
 				return this.readEntityCodes<RasterImage>(new CadWipeoutBaseTemplate(new RasterImage()), this.readWipeoutBase);
 			case DxfFileToken.EntityWipeout:
@@ -1560,7 +1560,14 @@ internal abstract class DxfSectionReaderBase
 		switch (this._reader.Code)
 		{
 			case 1:
+				//New SAT line: decoded into the template accumulator, raw into
+				//ProprietaryData to preserve the previous behavior.
+				(template as IAcisDataTemplate)?.AppendAcisLine(this._reader.ValueAsString);
+				geometry.ProprietaryData.AppendLine(this._reader.ValueAsString);
+				return true;
 			case 3:
+				//Continuation of the previous SAT line.
+				(template as IAcisDataTemplate)?.AppendAcisContinuation(this._reader.ValueAsString);
 				geometry.ProprietaryData.AppendLine(this._reader.ValueAsString);
 				return true;
 			case 2:

--- a/src/ACadSharp/IO/DwgReader.cs
+++ b/src/ACadSharp/IO/DwgReader.cs
@@ -124,6 +124,9 @@ public class DwgReader : CadReaderBase<DwgReaderConfiguration>
 		//Read all the objects in the file
 		this.readObjects();
 
+		//Attach the ACIS payloads stored in the AcDs data section (R2013+)
+		this.readAcDsData();
+
 		//Build the document
 		this._builder.BuildDocument();
 
@@ -454,6 +457,54 @@ public class DwgReader : CadReaderBase<DwgReaderConfiguration>
 		memoryStream.Position = 0L;
 
 		return memoryStream;
+	}
+
+	/// <summary>
+	/// Read the AcDs data section and attach the ACIS payloads to the modeler
+	/// geometry entities that flagged their data as stored there.
+	/// </summary>
+	/// <remarks>
+	/// Refers to AcDb:AcDsPrototype_1b data section (R2013+).
+	/// </remarks>
+	private void readAcDsData()
+	{
+		if (this._builder.AcisDsEntities.Count == 0)
+		{
+			return;
+		}
+
+		IDwgStreamReader sreader = this.getSectionStream(DwgSectionDefinition.AcDsPrototype);
+		if (sreader == null)
+		{
+			this.triggerNotification($"AcDs data section not found, the ACIS payload of {this._builder.AcisDsEntities.Count} modeler geometry entities is not available", NotificationType.Warning);
+			return;
+		}
+
+		sreader.Stream.Position = 0;
+		byte[] buffer = new byte[sreader.Stream.Length];
+		sreader.Stream.Read(buffer, 0, buffer.Length);
+
+		Dictionary<ulong, byte[]> records = DwgAcDsDataReader.ReadRecords(
+			buffer,
+			message => this.triggerNotification(message, NotificationType.Warning));
+
+		int missing = 0;
+		foreach (Entities.ModelerGeometry entity in this._builder.AcisDsEntities)
+		{
+			if (records.TryGetValue(entity.Handle, out byte[] payload))
+			{
+				entity.AcisData = payload;
+			}
+			else
+			{
+				missing++;
+			}
+		}
+
+		if (missing > 0)
+		{
+			this.triggerNotification($"AcDs data section has no ACIS payload for {missing} of {this._builder.AcisDsEntities.Count} modeler geometry entities", NotificationType.Warning);
+		}
 	}
 
 	private IDwgStreamReader getSectionStream(string sectionName)

--- a/src/ACadSharp/IO/DxfReader.cs
+++ b/src/ACadSharp/IO/DxfReader.cs
@@ -170,6 +170,9 @@ namespace ACadSharp.IO
 					case DxfFileToken.ObjectsSection:
 						this.readObjects();
 						break;
+					case DxfFileToken.AcdsDataSection:
+						this.readAcdsData();
+						break;
 					default:
 						this.triggerNotification(($"Section not implemented {this._reader.ValueAsString}"), NotificationType.NotImplemented);
 						break;
@@ -461,6 +464,24 @@ namespace ACadSharp.IO
 			this._reader = this.goToSection(DxfFileToken.ObjectsSection);
 
 			DxfObjectsSectionReader reader = new DxfObjectsSectionReader(this._reader, this._builder);
+
+			reader.Read();
+		}
+
+		/// <summary>
+		/// Read the ACDSDATA section of the DXF file.
+		/// </summary>
+		/// <remarks>
+		/// R2013+ files store the ACIS payload of the modeler geometry entities
+		/// (3DSOLID, REGION, BODY) in this section instead of embedding it in the
+		/// entity codes.
+		/// </remarks>
+		private void readAcdsData()
+		{
+			//Get the needed handler
+			this._reader = this.goToSection(DxfFileToken.AcdsDataSection);
+
+			DxfAcdsDataSectionReader reader = new DxfAcdsDataSectionReader(this._reader, this._builder);
 
 			reader.Read();
 		}

--- a/src/ACadSharp/IO/Templates/CadModelerGeometryTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadModelerGeometryTemplate.cs
@@ -1,0 +1,86 @@
+using ACadSharp.Entities;
+using System.Text;
+
+namespace ACadSharp.IO.Templates
+{
+	/// <summary>
+	/// Collects the SAT text chunks of a modeler geometry entity while it is read.
+	/// </summary>
+	internal interface IAcisDataTemplate
+	{
+		/// <summary>
+		/// Appends a chunk that starts a new SAT line (DXF group code 1).
+		/// </summary>
+		void AppendAcisLine(string chunk);
+
+		/// <summary>
+		/// Appends a chunk that continues the previous SAT line (DXF group code 3).
+		/// </summary>
+		void AppendAcisContinuation(string chunk);
+	}
+
+	internal class CadModelerGeometryTemplate<T> : CadEntityTemplate<T>, IAcisDataTemplate
+		where T : ModelerGeometry, new()
+	{
+		private readonly StringBuilder _acisText = new();
+
+		private bool? _isEncoded;
+
+		public CadModelerGeometryTemplate() : base(new T())
+		{
+		}
+
+		public CadModelerGeometryTemplate(T entity) : base(entity)
+		{
+		}
+
+		/// <inheritdoc/>
+		public void AppendAcisLine(string chunk)
+		{
+			if (this._acisText.Length > 0)
+			{
+				this._acisText.Append('\n');
+			}
+
+			this.append(chunk);
+		}
+
+		/// <inheritdoc/>
+		public void AppendAcisContinuation(string chunk)
+		{
+			this.append(chunk);
+		}
+
+		protected override void build(CadDocumentBuilder builder)
+		{
+			base.build(builder);
+
+			//The ACDSDATA section (R2013+) may carry the payload for the same
+			//entity; in that case the section data is applied after the build and
+			//takes precedence over anything accumulated here.
+			if (this._acisText.Length > 0 && this.CadObject is ModelerGeometry geometry && geometry.AcisData == null)
+			{
+				geometry.AcisData = Encoding.ASCII.GetBytes(this._acisText.ToString());
+			}
+		}
+
+		private void append(string chunk)
+		{
+			if (string.IsNullOrEmpty(chunk))
+			{
+				return;
+			}
+
+			//Pre-2013 writers store the SAT text with the documented character
+			//swap; the payload is plain when it comes from other sources. Decide
+			//once, on the first chunk: plain SAT always starts with the numeric
+			//header line.
+			if (!this._isEncoded.HasValue)
+			{
+				this._isEncoded = AcisTextCodec.IsEncoded(chunk);
+			}
+
+			this._acisText.Append(this._isEncoded.Value ? AcisTextCodec.Decode(chunk) : chunk);
+		}
+	}
+}

--- a/src/ACadSharp/IO/Templates/CadSolid3DTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadSolid3DTemplate.cs
@@ -2,7 +2,7 @@
 
 namespace ACadSharp.IO.Templates
 {
-	internal class CadSolid3DTemplate : CadEntityTemplate<Solid3D>
+	internal class CadSolid3DTemplate : CadModelerGeometryTemplate<Solid3D>
 	{
 		public ulong? HistoryHandle { get; set; }
 


### PR DESCRIPTION
Follows up on #935 and #822. This adds the read path for the ACIS payload of the modeler geometry entities across all the container variants, one commit per slice so they can be reviewed on their own.

**API and DXF ACDSDATA section (R2013+)**. `ModelerGeometry.AcisData` (byte[]) carries the raw payload: binary SAB when it starts with the "ACIS BinaryFile" signature, SAT text bytes otherwise. `IsBinaryAcisData` and `GetAcisText()` are the helpers. The new section reader collects the ASM_Data records (owner handle at group 320, hex chunks at group 310) and attaches the blobs by handle. `ProprietaryData` is untouched for compatibility.

**DXF codes 1 and 3 (pre-2013)**. The character swap (0x9F minus the code, above space) is decoded and the chunks are joined with the right semantics: group 1 starts a SAT line, group 3 continues the previous one, so payloads split at the 255 character limit reassemble without spurious breaks. BODY now routes through the modeler geometry reader like REGION and 3DSOLID, before this it lost its codes entirely.

**DWG entity stream**. `readModelerGeometryData` stopped right after the version field. Version 1 (R2000 and older) reads the size-prefixed swapped SAT blocks; version 2 (R2004+) reads the raw ACIS file up to the end marker, which spells "ACIS" or "ASM" depending on the kernel that wrote the payload, in plain ASCII or as a tagged compound name.

**DWG AcDs data section (R2013+)**. The "has DS binary data" flag is now captured and the new AcDb:AcDsPrototype_1b reader parses the segment index and the record directories of the "_data_" segments, which carry the owner handle of every payload, so the association is exact. Payloads sit inline (4 byte size prefix) or in the blob01 segments (4 byte marker plus 8 byte size); the payload area base is anchored on the SAB signatures and each record is validated before it is accepted. Files written since 2018 use the "ASM BinaryFile" signature.

Validated against a collection of 306 real files (R14 to R2018, several producers) and against the sample files already in the repository: more than 16000 payloads extracted, every one of them tokenizes cleanly to its End-of-data marker, and the only entities left empty are the ones whose ACIS empty flag is set in the stream. Known limit: a payload split across multiple blob01 segments is not stitched back (about 0.5% of the collection); the reader notifies the entities left without data.

Read only: writing the payload back and parsing the SAT/SAB content are out of scope, as discussed in #935.

Closes #935