### PR TITLE
Fix the trailing chunk of binary values in ascii DXF

### DIFF
--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfAsciiWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfAsciiWriter.cs
@@ -101,8 +101,8 @@ namespace ACadSharp.IO.DXF
 					if (surp != 0)
 					{
 						byte[] array2 = new byte[surp];
-						ms.Read(array, 0, surp);
-						lines.Add(new string(array.SelectMany(b => string.Format("{0:X2}", b)).ToArray()));
+						ms.Read(array2, 0, surp);
+						lines.Add(new string(array2.SelectMany(b => string.Format("{0:X2}", b)).ToArray()));
 					}
 
 					this._stream.WriteLine(lines.First());


### PR DESCRIPTION
The ascii DXF writer splits binary values in rows of 64 bytes. The block that handles the trailing bytes allocates a buffer of the right size, but then reads into the 64 byte buffer used for the previous rows and hex-encodes that whole buffer:

```csharp
int surp = arr.Length % 64;
if (surp != 0)
{
    byte[] array2 = new byte[surp];
    ms.Read(array, 0, surp);      // reads into the wrong buffer
    lines.Add(new string(array.SelectMany(...)));  // encodes 64 bytes instead of surp
}
```

As a result the last row of every binary group whose length is not a multiple of 64 is padded with stale bytes from the previous row, and the value read back from the file is longer than the original and corrupted at the tail.

The fix reads the trailing bytes into their own buffer and encodes only those.

We hit this while round-tripping binary chunks through group 310: with payload lengths that are multiples of 64 the bug is invisible, with any other length one stray byte per value shows up at read-back.
