### PR TITLE
Add native support for orphaned TABLE sections in DXF reader

### DIFF
--- a/samples/orphaned_tables_AC1009.dxf
+++ b/samples/orphaned_tables_AC1009.dxf
@@ -1,0 +1,52 @@
+  0
+SECTION
+  2
+HEADER
+  9
+$ACADVER
+  1
+AC1009
+  0
+ENDSEC
+  0
+TABLE
+  2
+LAYER
+ 70
+     1
+  0
+LAYER
+  2
+TestLayer
+ 70
+     0
+ 62
+     3
+  6
+CONTINUOUS
+  0
+ENDTAB
+  0
+SECTION
+  2
+ENTITIES
+  0
+LINE
+  8
+TestLayer
+ 10
+0.0
+ 20
+0.0
+ 30
+0.0
+ 11
+100.0
+ 21
+100.0
+ 31
+0.0
+  0
+ENDSEC
+  0
+EOF

--- a/src/ACadSharp.Tests/IO/DXF/DxfReaderTests.cs
+++ b/src/ACadSharp.Tests/IO/DXF/DxfReaderTests.cs
@@ -180,4 +180,26 @@ public class DxfReaderTests : CadReaderTestsBase<DxfReader>
 		Assert.NotNull(doc.Views);
 		Assert.NotNull(doc.VPorts);
 	}
+
+	[Fact]
+	public void ReadOrphanedTablesSectionTest()
+	{
+		string path = System.IO.Path.Combine(TestVariables.SamplesFolder, "orphaned_tables_AC1009.dxf");
+
+		bool notified = false;
+		CadDocument doc;
+		using (DxfReader reader = new DxfReader(path))
+		{
+			reader.OnNotification += (_, e) =>
+			{
+				if (e.NotificationType == NotificationType.Warning
+					&& e.Message.Contains("Non-standard DXF"))
+					notified = true;
+			};
+			doc = reader.Read();
+		}
+
+		Assert.True(notified, "Expected a warning notification about the orphaned TABLE section.");
+		Assert.True(doc.Layers.Contains("TestLayer"), "Layer 'TestLayer' should be imported from the orphaned TABLE section.");
+	}
 }

--- a/src/ACadSharp/IO/DXF/DxfStreamReader/DxfTablesSectionReader.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamReader/DxfTablesSectionReader.cs
@@ -44,6 +44,30 @@ internal class DxfTablesSectionReader : DxfSectionReaderBase
 		}
 	}
 
+	/// <summary>
+	/// Reads TABLE entries that appear without a SECTION/TABLES/ENDSEC wrapper (non-standard DXF).
+	/// The reader must be positioned at the first bare TABLE token on entry.
+	/// Returns with the reader positioned at the next SECTION, ENDSEC, or EOF token.
+	/// </summary>
+	internal void ReadOrphaned()
+	{
+		while (this._reader.ValueAsString != DxfFileToken.EndSection
+			&& this._reader.ValueAsString != DxfFileToken.BeginSection
+			&& this._reader.ValueAsString != DxfFileToken.EndOfFile)
+		{
+			if (this._reader.ValueAsString != DxfFileToken.TableEntry)
+			{
+				this._builder.Notify(
+					$"Unexpected token '{this._reader.ValueAsString}' while reading orphaned TABLE entries.",
+					NotificationType.Warning);
+				break;
+			}
+
+			this.readTable();
+			this._reader.ReadNext();
+		}
+	}
+
 	private void readTable()
 	{
 		Debug.Assert(this._reader.ValueAsString == DxfFileToken.TableEntry);

--- a/src/ACadSharp/IO/DxfReader.cs
+++ b/src/ACadSharp/IO/DxfReader.cs
@@ -138,6 +138,15 @@ namespace ACadSharp.IO
 
 			while (this._reader.ValueAsString != DxfFileToken.EndOfFile)
 			{
+				if (this._reader.ValueAsString == DxfFileToken.TableEntry)
+				{
+					this.triggerNotification(
+						"Non-standard DXF: TABLE entry found outside of a TABLES section. Attempting recovery.",
+						NotificationType.Warning);
+					new DxfTablesSectionReader(this._reader, this._builder).ReadOrphaned();
+					continue;
+				}
+
 				if (this._reader.ValueAsString != DxfFileToken.BeginSection)
 				{
 					this._reader.ReadNext();


### PR DESCRIPTION
# Description

Some non-standard DXF files from third-party CAD tools place TABLE records directly after the HEADER ENDSEC without the required SECTION/TABLES/ENDSEC wrapper. ACadSharp's main read loop previously skipped these bare TABLE tokens, silently producing a document with no layers.

# Tasks done in this PR
- DxfTablesSectionReader: add ReadOrphaned() that reads bare TABLE/ENDTAB blocks without expecting an ENDSEC wrapper, terminating on the next SECTION, ENDSEC, or EOF token
- DxfReader.Read(): detect TABLE tokens at the top-level loop and route them to ReadOrphaned(), with a Warning notification; zero cost on conformant files since TABLE can never appear at top-level there
- Add orphaned_tables_AC1009.dxf sample file reproducing the non-standard structure (bare LAYER table followed by an ENTITIES section)
- Add ReadOrphanedTablesSectionTest verifying the warning is fired and the layer is correctly imported

# Related Issues / Pull Requests
Fixes #1128

#Notes for reviewer
- The recovery fires only when a TABLE token is seen where the parser would otherwise expect SECTION — this is impossible in a conformant file, so there is no false-positive risk.
- A minimal [samples/orphaned_tables_AC1009.dxf](https://github.com/FriendsOfCADability/CADability/blob/claude/acadsharp-orphaned-tables-test-tthicy/samples/orphaned_tables_AC1009.dxf) fixture is included; the new ReadOrphanedTablesSectionTest verifies that (a) the warning notification is fired and (b) the layer defined in the orphaned TABLE block is present in the resulting CadDocument.