### PR TITLE
Add support for DynamicBlockPurgePreventer object

### DIFF
--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>3.6.43</Version>
+		<Version>3.6.44</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>../ACadSharp.snk</AssemblyOriginatorKeyFile>

--- a/src/ACadSharp/DxfFileToken.cs
+++ b/src/ACadSharp/DxfFileToken.cs
@@ -214,6 +214,8 @@ public static class DxfFileToken
 
 	public const string ObjectDimensionAssociation = "DIMASSOC";
 
+	public const string ObjectDynamicBlockPurgePreventer = "ACDB_DYNAMICBLOCKPURGEPREVENTER_VERSION";
+
 	public const string ObjectEvalGraph = "ACAD_EVALUATION_GRAPH";
 
 	public const string ObjectField = "FIELD";

--- a/src/ACadSharp/DxfSubclassMarker.cs
+++ b/src/ACadSharp/DxfSubclassMarker.cs
@@ -2,6 +2,8 @@
 
 public static class DxfSubclassMarker
 {
+	public const string AcDbDynamicBlockPurgePreventer = "AcDbDynamicBlockPurgePreventer";
+
 	public const string AcDbPlaceHolder = "AcDbPlaceHolder";
 
 	public const string AecDbCleanupGroupDef = "AecDbCleanupGroupDef";

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.Objects.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.Objects.cs
@@ -2,7 +2,6 @@
 using ACadSharp.Objects;
 using ACadSharp.Objects.Evaluations;
 using System;
-using System.Runtime.InteropServices;
 
 namespace ACadSharp.IO.DWG;
 
@@ -373,6 +372,18 @@ internal partial class DwgObjectReader : DwgSectionIO
 			//Value String TV 302
 			value.FormattedValue = this._mergedReaders.ReadVariableText();
 		}
+
+		return template;
+	}
+
+	private CadTemplate readDynamicBlockPurgePreventer()
+	{
+		var purgePreventer = new DynamicBlockPurgePreventer();
+		var template = new CadNonGraphicalObjectTemplate(purgePreventer);
+
+		this.readCommonNonEntityData(template);
+
+		purgePreventer.Version = this._mergedReaders.ReadBitShort();
 
 		return template;
 	}

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -5556,6 +5556,9 @@ namespace ACadSharp.IO.DWG
 				case DxfFileToken.AcmPartList:
 					template = this.readAcmPartList();
 					break;
+				case DxfFileToken.ObjectDynamicBlockPurgePreventer:
+					template = this.readDynamicBlockPurgePreventer();
+					break;
 				case DxfFileToken.EntityAecWall:
 					template = this.readAecWall();
 					break;

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
@@ -40,6 +40,7 @@ internal partial class DwgObjectWriter : DwgSectionIO
 			case AecCleanupGroup:
 			case AecBinRecord:
 			case DimensionAssociation:
+			case DynamicBlockPurgePreventer:
 			case EvaluationGraph:
 			case UnknownNonGraphicalObject:
 			case VisualStyle:

--- a/src/ACadSharp/IO/DXF/DxfStreamReader/DxfObjectsSectionReader.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamReader/DxfObjectsSectionReader.cs
@@ -118,6 +118,8 @@ internal class DxfObjectsSectionReader : DxfSectionReaderBase
 				return this.readObjectCodes<TableStyle>(new CadTableStyleTemplate(), this.readTableStyle);
 			case DxfFileToken.ObjectXRecord:
 				return this.readObjectCodes<XRecord>(new CadXRecordTemplate(), this.readXRecord);
+			case DxfFileToken.ObjectDynamicBlockPurgePreventer:
+				return this.readObjectCodes<DynamicBlockPurgePreventer>(new CadNonGraphicalObjectTemplate(new DynamicBlockPurgePreventer()), this.readObjectSubclassMap);
 			case DxfFileToken.ObjectBlockRepresentationData:
 				return this.readObjectCodes<BlockRepresentationData>(new CadBlockRepresentationDataTemplate(), this.readBlockRepresentationData);
 			case DxfFileToken.ObjectBlockGripLocationComponent:

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
@@ -606,6 +606,7 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 			case AecCleanupGroup:
 			case AecBinRecord:
 			case DimensionAssociation:
+			case DynamicBlockPurgePreventer:
 			case EvaluationGraph:
 			case Material:
 			case MultiLeaderObjectContextData:

--- a/src/ACadSharp/Objects/AcdbPlaceHolder.cs
+++ b/src/ACadSharp/Objects/AcdbPlaceHolder.cs
@@ -1,25 +1,24 @@
 ﻿using ACadSharp.Attributes;
 
-namespace ACadSharp.Objects
+namespace ACadSharp.Objects;
+
+/// <summary>
+/// Represents a <see cref="AcdbPlaceHolder"/> object.
+/// </summary>
+/// <remarks>
+/// Object name <see cref="DxfFileToken.ObjectPlaceholder"/> <br/>
+/// Dxf class name <see cref="DxfSubclassMarker.AcDbPlaceHolder"/>
+/// </remarks>
+[DxfName(DxfFileToken.ObjectPlaceholder)]
+[DxfSubClass(DxfSubclassMarker.AcDbPlaceHolder)]
+public class AcdbPlaceHolder : NonGraphicalObject
 {
-	/// <summary>
-	/// Represents a <see cref="AcdbPlaceHolder"/> object.
-	/// </summary>
-	/// <remarks>
-	/// Object name <see cref="DxfFileToken.ObjectPlaceholder"/> <br/>
-	/// Dxf class name <see cref="DxfSubclassMarker.AcDbPlaceHolder"/>
-	/// </remarks>
-	[DxfName(DxfFileToken.ObjectPlaceholder)]
-	[DxfSubClass(DxfSubclassMarker.AcDbPlaceHolder)]
-	public class AcdbPlaceHolder : NonGraphicalObject
-	{
-		/// <inheritdoc/>
-		public override ObjectType ObjectType { get { return ObjectType.ACDBPLACEHOLDER; } }
+	/// <inheritdoc/>
+	public override string ObjectName => DxfFileToken.ObjectPlaceholder;
 
-		/// <inheritdoc/>
-		public override string ObjectName => DxfFileToken.ObjectPlaceholder;
+	/// <inheritdoc/>
+	public override ObjectType ObjectType { get { return ObjectType.ACDBPLACEHOLDER; } }
 
-		/// <inheritdoc/>
-		public override string SubclassMarker => DxfSubclassMarker.AcDbPlaceHolder;
-	}
+	/// <inheritdoc/>
+	public override string SubclassMarker => DxfSubclassMarker.AcDbPlaceHolder;
 }

--- a/src/ACadSharp/Objects/DynamicBlockPurgePreventer.cs
+++ b/src/ACadSharp/Objects/DynamicBlockPurgePreventer.cs
@@ -1,0 +1,30 @@
+﻿using ACadSharp.Attributes;
+
+namespace ACadSharp.Objects;
+
+/// <summary>
+/// Represents a <see cref="DynamicBlockPurgePreventer"/> object.
+/// </summary>
+/// <remarks>
+/// Object name <see cref="DxfFileToken.ObjectDynamicBlockPurgePreventer"/> <br/>
+/// Dxf class name <see cref="DxfSubclassMarker.AcDbDynamicBlockPurgePreventer"/>
+/// </remarks>
+[DxfName(DxfFileToken.ObjectDynamicBlockPurgePreventer)]
+[DxfSubClass(DxfSubclassMarker.AcDbDynamicBlockPurgePreventer)]
+public class DynamicBlockPurgePreventer : NonGraphicalObject
+{
+	/// <inheritdoc/>
+	public override string ObjectName => DxfFileToken.ObjectDynamicBlockPurgePreventer;
+
+	/// <inheritdoc/>
+	public override ObjectType ObjectType { get { return ObjectType.UNLISTED; } }
+
+	/// <inheritdoc/>
+	public override string SubclassMarker => DxfSubclassMarker.AcDbDynamicBlockPurgePreventer;
+
+	/// <summary>
+	/// Gets or sets the version of the dynamic block purge preventer.
+	/// </summary>
+	[DxfCodeValue(70)]
+	public short Version { get; set; }
+}


### PR DESCRIPTION
# Description

Introduced the DynamicBlockPurgePreventer class with DXF integration, including new file tokens and subclass markers. Implemented reading logic for this object in both DWG and DXF readers. Refactored AcdbPlaceHolder for consistency.
