### PR TITLE
Fix InvalidCastException in ReadHeader() when header variable omits group 30 (Z)

### DIFF
--- a/src/ACadSharp/IO/DxfReader.cs
+++ b/src/ACadSharp/IO/DxfReader.cs
@@ -222,7 +222,7 @@ namespace ACadSharp.IO
 				{
 					this._reader.ReadNext();
 
-					if (this._reader.DxfCode == DxfCode.CLShapeText)
+					if (this._reader.DxfCode == DxfCode.CLShapeText || this._reader.DxfCode == DxfCode.Start)
 					{
 						//Irregular dxf files may not follow the header type
 						int c = data.DxfCodes[i];
@@ -236,9 +236,11 @@ namespace ACadSharp.IO
 							case GroupCodeValueType.Int16:
 							case GroupCodeValueType.Int32:
 							case GroupCodeValueType.Int64:
+								parameters[i] = 0;
+								break;
 							case GroupCodeValueType.Double:
 							case GroupCodeValueType.Point3D:
-								parameters[i] = 0;
+								parameters[i] = 0d;
 								break;
 							case GroupCodeValueType.None:
 							case GroupCodeValueType.String:
@@ -263,7 +265,7 @@ namespace ACadSharp.IO
 					this.triggerNotification($"Invalid value for header variable {currVar} | {parameters.FirstOrDefault()}", NotificationType.Warning, ex);
 				}
 
-				if (this._reader.DxfCode != DxfCode.CLShapeText)
+				if (this._reader.DxfCode != DxfCode.CLShapeText && this._reader.DxfCode != DxfCode.Start)
 				{
 					this._reader.ReadNext();
 				}

--- a/src/ACadSharp/IO/DxfReader.cs
+++ b/src/ACadSharp/IO/DxfReader.cs
@@ -236,8 +236,6 @@ namespace ACadSharp.IO
 							case GroupCodeValueType.Int16:
 							case GroupCodeValueType.Int32:
 							case GroupCodeValueType.Int64:
-								parameters[i] = 0;
-								break;
 							case GroupCodeValueType.Double:
 							case GroupCodeValueType.Point3D:
 								parameters[i] = 0d;


### PR DESCRIPTION
# Description

Some DXF files omit group code 30 (Z coordinate) for 2D-only header
variables such as `$EXTMIN` and `$EXTMAX`. When such a variable appears
immediately before `ENDSEC`, `ReadHeader()` reads the `ENDSEC` token (group
code 0, `DxfCode.Start`) as the missing Z parameter and passes the string
`"ENDSEC"` to `CadHeader.SetValue()`. That method calls
`Convert.ChangeType("ENDSEC", typeof(XYZ))`, which throws
`InvalidCastException` and aborts the entire import.

The fix extends the two existing "irregular file" guards in `ReadHeader()` to
also break/skip on `DxfCode.Start` (group 0), not just `DxfCode.CLShapeText`
(group 9). A related type mismatch is fixed at the same time: integer types
(`Int16`/`Int32`/`Int64`) default to `0` (int) while `Double` and `Point3D`
types default to `0d` (double), matching the `XYZ(double, double, double)`
constructor resolved by `SetValue()` via reflection.

# Tasks done in this PR
* [x] An evil bug has been defeated.

# Related Issues / Pull Requests
- Fixes #1143

# Notes for reviewer
- Only `src/ACadSharp/IO/DxfReader.cs` is changed (3 lines).
- Group code 0 is reserved exclusively for entity/section type identifiers
  by the DXF spec and never appears as a parameter code inside a header
  variable, so extending the guard to `DxfCode.Start` cannot cause early
  exits in well-formed files.
- The `0` vs `0d` split makes the existing `CLShapeText` path more correct
  as well, though that path was not the source of the reported crash.