### PR TITLE
Add net10.0 to the target frameworks

### DIFF
--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net5.0;net6.0;net7.0;net8.0;net9.0;net48;netstandard2.1;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net5.0;net6.0;net7.0;net8.0;net9.0;net10.0;net48;netstandard2.1;netstandard2.0</TargetFrameworks>
 		<Authors>DomCr</Authors>
 		<PackageId>ACadSharp</PackageId>
 		<PackageTags>C# Dwg Dxf</PackageTags>


### PR DESCRIPTION
This adds net10.0 to the target frameworks so the library can be referenced from net10.0 projects.

No code changes are needed: the existing sources and the shared CSMath and CSUtilities projects build under net10.0 with no errors. I verified a clean net10.0 build locally.

Unrelated question while I'm here: net5.0, net6.0 and net7.0 are all past their end of support now. Would you want to drop them from the target list to keep the build lighter? I can do it in this PR or leave it as a separate one, whichever you prefer.
