### PR TITLE
Fix the visual style and sun handle reference types on the viewport

### DIFF
--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.cs
@@ -1368,9 +1368,9 @@ internal partial class DwgObjectWriter : DwgSectionIO
 			//Background handle H 332 soft pointer
 			this._writer.HandleReference(DwgReferenceType.SoftPointer, 0);
 			//Visual Style handle H 348 hard pointer
-			this._writer.HandleReference(DwgReferenceType.SoftPointer, 0);
+			this._writer.HandleReference(DwgReferenceType.HardPointer, 0);
 			//Sun handle H 361 hard owner
-			this._writer.HandleReference(DwgReferenceType.SoftPointer, 0);
+			this._writer.HandleReference(DwgReferenceType.HardOwnership, 0);
 		}
 
 		//R2000+:


### PR DESCRIPTION
When writing a viewport to DWG, the visual style handle (code 348) and the sun handle (code 361) were emitted as soft pointers. They should be a hard pointer and a hard owner. This aligns the two reference types with the reference files.

The change is two lines in the DWG object writer.
