### PR TITLE
Index inserts by block name in writeBlockHeader instead of rescanning per block

### DIFF
--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.cs
@@ -33,9 +33,14 @@ internal partial class DwgObjectWriter : DwgSectionIO
 
 	public bool WriteXRecords { get; }
 
+	private ILookup<string, Insert> InsertsByBlockName =>
+		this._insertsByBlockName ??= this._document.Entities.OfType<Insert>().ToLookup(i => i.Block?.Name);
+
 	private readonly Dictionary<BlockRecord, Entity[]> _blockCompatibleEntities = new();
 
 	private CadDocument _document;
+
+	private ILookup<string, Insert> _insertsByBlockName;
 
 	private MemoryStream _msmain;
 
@@ -340,8 +345,7 @@ internal partial class DwgObjectWriter : DwgSectionIO
 		if (this.R2000Plus)
 		{
 			//Insert Count RC A sequence of zero or more non-zero RC’s, followed by a terminating 0 RC.The total number of these indicates how many insert handles will be present.
-			foreach (var item in this._document.Entities.OfType<Insert>()
-				.Where(i => i.Block?.Name == record?.Name))
+			foreach (var item in this.InsertsByBlockName[record.Name])
 			{
 				this._writer.WriteByte(1);
 			}
@@ -408,8 +412,7 @@ internal partial class DwgObjectWriter : DwgSectionIO
 		//R2000+:
 		if (this.R2000Plus)
 		{
-			foreach (var item in this._document.Entities.OfType<Insert>()
-				.Where(i => i.Block?.Name == record.Name))
+			foreach (var item in this.InsertsByBlockName[record.Name])
 			{
 				this._writer.HandleReference(DwgReferenceType.SoftPointer, item);
 			}


### PR DESCRIPTION
# Description

`writeBlockHeader` ran two full scans of `_document.Entities` per `BlockRecord` to find the `Inserts` referencing it, which makes DWG writing `O(blocks × entities)`.

This replaces both scans with a single `ILookup<string, Insert>` built lazily on first use and reused for the rest of the write.

Measured on master (219e5fc), net9.0:

| blocks + inserts | before | after |
|-----------------:|-------:|------:|
|            2,500 | 0.41 s | 0.09 s |
|            5,000 | 1.55 s | 0.27 s |
|           10,000 | 6.35 s | 0.49 s |
|           20,000 | 29.47 s | 1.56 s |

# Related Issues / Pull Requests
Fixes https://github.com/DomCR/ACadSharp/issues/1167