### PR TITLE
Add dwg read and write of Polyline3D.SmoothSurface

### DIFF
--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -4865,11 +4865,19 @@ namespace ACadSharp.IO.DWG
 
 			//75 0 : Splined(75 value is 5)
 			//1 : Splined(75 value is 6)
-			bool splined = ((uint)flags & 0b1) > 0;
-			//Should assign pline.SmoothSurface ??
-
 			//(If either is set, set 70 bit 2(4) to indicate splined.)
+			bool splined = ((uint)flags & 0b1) > 0;
+
 			bool splined1 = ((uint)flags & 0b10) > 0;
+
+			if (splined)
+			{
+				pline.SmoothSurface = SmoothSurfaceType.Quadratic;
+			}
+			else if (splined1)
+			{
+				pline.SmoothSurface = SmoothSurfaceType.Cubic;
+			}
 
 			if (splined | splined1)
 			{

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Entities.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Entities.cs
@@ -2086,8 +2086,18 @@ internal partial class DwgObjectWriter : DwgSectionIO
 		//Flags RC 70 NOT DIRECTLY THE 75. Bit-coded (76543210):
 		//75 0 : Splined(75 value is 5)
 		//1 : Splined(75 value is 6)
-		//Should assign pline.SmoothSurface ??
-		this._writer.WriteByte(0);
+		byte smoothSurface = 0;
+		switch (pline.SmoothSurface)
+		{
+			case SmoothSurfaceType.Quadratic:
+				smoothSurface = 0b1;
+				break;
+			case SmoothSurfaceType.Cubic:
+				smoothSurface = 0b10;
+				break;
+		}
+
+		this._writer.WriteByte(smoothSurface);
 
 		//Flags RC 70 NOT DIRECTLY THE 70. Bit-coded (76543210):
 		//0 : Closed(70 bit 0(1))


### PR DESCRIPTION
# Description

The `POLYLINE_3D` flags byte carries the curve type: bit 0 means group code 75 = 5 (quadratic), bit 1 means 75 = 6 (cubic)