### PR TITLE
Keep the colour "none" of a CMC value

### DIFF
--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgMergedReader.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgMergedReader.cs
@@ -180,6 +180,12 @@ namespace ACadSharp.IO.DWG
 			{
 				color = Color.ByLayer;
 			}
+			else if ((rgb & 0xFF000000) == 0xC8000000)
+			{
+				//AutoCAD marks "none" (index 257, ByEntity) with 0xC8; without this branch the value
+				//decodes as the true colour black and the original color cannot be written back.
+				color = Color.ByEntity;
+			}
 			else if ((rgb & 0b0000_0001_0000_0000_0000_0000_0000_0000) != 0)
 			{
 				//Indexed color

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgStreamReaderAC18.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgStreamReaderAC18.cs
@@ -24,6 +24,12 @@ namespace ACadSharp.IO.DWG
 			{
 				color = Color.ByLayer;
 			}
+			else if ((rgb & 0xFF000000) == 0xC8000000)
+			{
+				//AutoCAD marks "none" (index 257, ByEntity) with 0xC8; without this branch the value
+				//decodes as the true colour black and the original color cannot be written back.
+				color = Color.ByEntity;
+			}
 			else if ((rgb & 0b0000_0001_0000_0000_0000_0000_0000_0000) != 0)
 			{
 				//Indexed color

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgMergedStreamWriter.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgMergedStreamWriter.cs
@@ -171,6 +171,11 @@ namespace ACadSharp.IO.DWG
 			{
 				arr[3] = 0b11000000;
 			}
+			else if (value.Index == 257)
+			{
+				//"none" (ByEntity), AutoCAD marks it with 0xC8 and an empty rgb value.
+				arr[3] = 0b1100_1000;
+			}
 			else
 			{
 				arr[3] = 0b1100_0011;

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgStreamWriterAC18.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgStreamWriterAC18.cs
@@ -29,6 +29,11 @@ namespace ACadSharp.IO.DWG
 			{
 				arr[3] = 0b11000000;
 			}
+			else if (value.Index == 257)
+			{
+				//"none" (ByEntity), AutoCAD marks it with 0xC8 and an empty rgb value.
+				arr[3] = 0b1100_1000;
+			}
 			else
 			{
 				arr[3] = 0b1100_0011;


### PR DESCRIPTION
# Description

AutoCAD marks the colour "none" - the index 257 an entity colour can carry - with the high byte `0xC8` of a CMC value. `ReadCmColor` took that byte for the marker of a true colour and produced black, and `WriteCmColor` had no way back, so a drawing that was read and written again lost the distinction.

# Tasks done in this PR

* [x] Decode `0xC8` into `Color.ByEntity` in `DwgStreamReaderAC18` and `DwgMergedReader`.
* [x] Encode it back in `DwgStreamWriterAC18` and `DwgMergedStreamWriter`.

# Related Issues / Pull Requests

- None; this one stands on its own and is cut straight from `master`.

# Notes for reviewer

**Testing**

`dotnet test` on this branch: **2312 passed / 17 failed**, the same as master.

- This is a prerequisite rather than a fix on its own: the two red `SingleMLeader` tests that fail because of this colour only turn green once the visual style objects are read and written too, which is the next pull request.
- The byte is what AutoCAD writes; it shows up in the DWG of every sample once the raw value is dumped.

---

_Checked against AutoCAD 2027 through `accoreconsole`: AUDIT for "does it open cleanly", and SAVEAS DXF for the oracle comparisons quoted above._