### PR TITLE
MText dynamic columns and the DXF TILEMODE variable

### DIFF
--- a/src/ACadSharp.Tests/Entities/MTextTests.cs
+++ b/src/ACadSharp.Tests/Entities/MTextTests.cs
@@ -18,6 +18,59 @@ public class MTextTests : CommonEntityTests<MText>
 		Assert.Equal(pt, box.Center);
 	}
 
+	/// <summary>
+	/// The column height count (group code 72) is followed by one height per count. Writing a
+	/// different number of heights than the count shifts every following bit of the file, and
+	/// AutoCAD refuses to open the result, so the two have to stay in sync through a round trip.
+	/// </summary>
+	[Fact]
+	public void DwgRoundTripKeepsDynamicColumns()
+	{
+		//The column block is only written from R2018 on, see writeMText.
+		CadDocument doc = new CadDocument(ACadVersion.AC1032);
+
+		MText mtext = new MText
+		{
+			Value = @"first column\Psecond column",
+			InsertPoint = new XYZ(1, 2, 0),
+			Height = 1,
+		};
+		mtext.ColumnData.ColumnType = ColumnType.DynamicColumns;
+		mtext.ColumnData.AutoHeight = false;
+		mtext.ColumnData.Width = 15.5;
+		mtext.ColumnData.Gutter = 0.5;
+		mtext.ColumnData.Heights.Add(-2.5);
+		mtext.ColumnData.Heights.Add(3.25);
+		doc.Entities.Add(mtext);
+
+		System.IO.MemoryStream ms = new System.IO.MemoryStream();
+		ACadSharp.IO.DwgWriter.Write(ms, doc);
+		using System.IO.MemoryStream readStream = new System.IO.MemoryStream(ms.ToArray());
+		CadDocument rt = ACadSharp.IO.DwgReader.Read(readStream);
+
+		MText result = null;
+		foreach (Entity e in rt.Entities)
+		{
+			if (e is MText m)
+			{
+				result = m;
+				break;
+			}
+		}
+
+		Assert.NotNull(result);
+		Assert.Equal(ColumnType.DynamicColumns, result.ColumnData.ColumnType);
+		Assert.Equal(mtext.ColumnData.Heights.Count, result.ColumnData.Heights.Count);
+		Assert.Equal(mtext.ColumnData.Heights.Count, result.ColumnData.ColumnCount);
+		for (int i = 0; i < mtext.ColumnData.Heights.Count; i++)
+		{
+			Assert.Equal(mtext.ColumnData.Heights[i], result.ColumnData.Heights[i], 9);
+		}
+
+		Assert.Equal(mtext.ColumnData.Width, result.ColumnData.Width, 9);
+		Assert.Equal(mtext.ColumnData.Gutter, result.ColumnData.Gutter, 9);
+	}
+
 	[Fact]
 	public void PlainTextTest()
 	{

--- a/src/ACadSharp.Tests/Entities/MTextTests.cs
+++ b/src/ACadSharp.Tests/Entities/MTextTests.cs
@@ -8,6 +8,59 @@ namespace ACadSharp.Tests.Entities
 {
 	public class MTextTests : CommonEntityTests<MText>
 	{
+		/// <summary>
+		/// The column height count (group code 72) is followed by one height per count. Writing a
+		/// different number of heights than the count shifts every following bit of the file, and
+		/// AutoCAD refuses to open the result, so the two have to stay in sync through a round trip.
+		/// </summary>
+		[Fact]
+		public void DwgRoundTripKeepsDynamicColumns()
+		{
+			//The column block is only written from R2018 on, see writeMText.
+			CadDocument doc = new CadDocument(ACadVersion.AC1032);
+
+			MText mtext = new MText
+			{
+				Value = @"first column\Psecond column",
+				InsertPoint = new XYZ(1, 2, 0),
+				Height = 1,
+			};
+			mtext.ColumnData.ColumnType = ColumnType.DynamicColumns;
+			mtext.ColumnData.AutoHeight = false;
+			mtext.ColumnData.Width = 15.5;
+			mtext.ColumnData.Gutter = 0.5;
+			mtext.ColumnData.Heights.Add(-2.5);
+			mtext.ColumnData.Heights.Add(3.25);
+			doc.Entities.Add(mtext);
+
+			System.IO.MemoryStream ms = new System.IO.MemoryStream();
+			ACadSharp.IO.DwgWriter.Write(ms, doc);
+			using System.IO.MemoryStream readStream = new System.IO.MemoryStream(ms.ToArray());
+			CadDocument rt = ACadSharp.IO.DwgReader.Read(readStream);
+
+			MText result = null;
+			foreach (Entity e in rt.Entities)
+			{
+				if (e is MText m)
+				{
+					result = m;
+					break;
+				}
+			}
+
+			Assert.NotNull(result);
+			Assert.Equal(ColumnType.DynamicColumns, result.ColumnData.ColumnType);
+			Assert.Equal(mtext.ColumnData.Heights.Count, result.ColumnData.Heights.Count);
+			Assert.Equal(mtext.ColumnData.Heights.Count, result.ColumnData.ColumnCount);
+			for (int i = 0; i < mtext.ColumnData.Heights.Count; i++)
+			{
+				Assert.Equal(mtext.ColumnData.Heights[i], result.ColumnData.Heights[i], 9);
+			}
+
+			Assert.Equal(mtext.ColumnData.Width, result.ColumnData.Width, 9);
+			Assert.Equal(mtext.ColumnData.Gutter, result.ColumnData.Gutter, 9);
+		}
+
 		public override void GetBoundingBoxTest()
 		{
 			XYZ pt = this._random.NextXYZ();

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -3794,6 +3794,7 @@ namespace ACadSharp.IO.DWG
 				{
 					//Column height count BL 72
 					int count = this._objectReader.ReadBitLong();
+					mtext.ColumnData.ColumnCount = count;
 					//Columnn width BD 44
 					mtext.ColumnData.Width = this._objectReader.ReadBitDouble();
 					//Gutter BD 45

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Entities.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Entities.cs
@@ -1586,7 +1586,11 @@ internal partial class DwgObjectWriter : DwgSectionIO
 		if (mtext.ColumnData.ColumnType != ColumnType.NoColumns)
 		{
 			//Column height count BL 72
-			this._writer.WriteBitLong(mtext.ColumnData.ColumnCount);
+			//The heights that follow are written one per count, so the count has to match the list;
+			//writing ColumnCount while writing Heights.Count values shifts every following bit and
+			//produces a file that AutoCAD refuses to open.
+			bool writeHeights = !mtext.ColumnData.AutoHeight && mtext.ColumnData.ColumnType == ColumnType.DynamicColumns;
+			this._writer.WriteBitLong(writeHeights ? mtext.ColumnData.Heights.Count : mtext.ColumnData.ColumnCount);
 			//Columnn width BD 44
 			this._writer.WriteBitDouble(mtext.ColumnData.Width);
 			//Gutter BD 45
@@ -1597,7 +1601,7 @@ internal partial class DwgObjectWriter : DwgSectionIO
 			this._writer.WriteBit(mtext.ColumnData.FlowReversed);
 
 			//IF not auto height and column type is dynamic columns
-			if (!mtext.ColumnData.AutoHeight && mtext.ColumnData.ColumnType == ColumnType.DynamicColumns)
+			if (writeHeights)
 			{
 				foreach (double h in mtext.ColumnData.Heights)
 				{

--- a/src/ACadSharp/IO/DxfWriterConfiguration.cs
+++ b/src/ACadSharp/IO/DxfWriterConfiguration.cs
@@ -72,6 +72,8 @@ public class DxfWriterConfiguration : CadWriterConfiguration
 		"$LUPREC",
 		"$MIRRTEXT",
 		"$EXTNAMES",
+		//Without TILEMODE the drawing opens in paper space instead of model space.
+		"$TILEMODE",
 		"$INSBASE",
 		"$INSUNITS",
 		"$MEASUREMENT",


### PR DESCRIPTION
# Description

Two independent defects that both end with the drawing being wrong or unopenable.

1. **MTEXT with dynamic columns**: the reader read the column height count into a local it never stored, and the writer then wrote `ColumnCount` (0) followed by `Heights.Count` values. Everything after that point in the file is shifted by those bits and AutoCAD refuses the drawing.
2. **`$TILEMODE`** was missing from the default header variables of the DXF writer, so the file opened in paper space.

> A third defect travelled with these two until 3.7.4: `Wipeout.IsValid` demanded an
> `ImageDefinition`, while AutoCAD writes 340 and 360 as null for a wipeout, so valid wipeouts were
> dropped. **3.7.4 fixes it upstream** by moving that check down into `RasterImage`, so this branch
> no longer carries it.

# Tasks done in this PR

* [x] Reader stores the column height count in `ColumnData.ColumnCount`; the writer writes the number of values it is about to write.
* [x] `$TILEMODE` added to `DxfWriterConfiguration`.

# Related Issues / Pull Requests

- None; this one stands on its own and is cut straight from `master`.

# Notes for reviewer

**Testing**

`dotnet test` on this branch: **2313 passed / 17 failed**, the same failures as master.

AutoCAD 2027: before this change the round trip of `samples/sample_AC1032.dwg` could not be opened in any configuration. It was narrowed down by bisection to a single MTEXT, the 32nd, which has `HasColumns` and `DynamicColumns`.

- The two fixes travel together because they were found in one bisection run; happy to split them if you prefer.
- The MTEXT one is the heavy part: it is what makes AutoCAD reject the repository's own sample drawing after a round trip.

---

_Checked against AutoCAD 2027 through `accoreconsole`: AUDIT for "does it open cleanly", and SAVEAS DXF for the oracle comparisons quoted above._