### PR TITLE
Keep the handle entries of an XRecord in their place in the record

### DIFF
--- a/src/ACadSharp.Tests/Objects/XRecordTests.cs
+++ b/src/ACadSharp.Tests/Objects/XRecordTests.cs
@@ -1,0 +1,76 @@
+using ACadSharp.IO;
+using ACadSharp.Objects;
+using ACadSharp.Tables;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace ACadSharp.Tests.Objects;
+
+public class XRecordTests
+{
+	/// <summary>
+	/// The entries of an XRecord are positional: AutoCAD reads them in the order they were written.
+	/// A handle entry has to keep the place it had in the file instead of being appended at the end,
+	/// otherwise a record such as ADSK_XREC_VTRVIEWINFO becomes unreadable and AutoCAD refuses to
+	/// open the drawing.
+	/// </summary>
+	[Theory]
+	[InlineData(ACadVersion.AC1018)]
+	[InlineData(ACadVersion.AC1032)]
+	public void DwgRoundTripKeepsTheEntryOrderWithHandles(ACadVersion version)
+	{
+		CadDocument doc = new CadDocument(version);
+		Layer layer = doc.Layers[Layer.DefaultName];
+
+		XRecord xrecord = new XRecord("MOREDWG_ORDER");
+		xrecord.CreateEntry(300, "before");
+		xrecord.CreateEntry(330, layer);
+		xrecord.CreateEntry(294, false);
+		xrecord.CreateEntry(90, 7);
+
+		CadDictionary dictionary = new CadDictionary("MOREDWG_TEST");
+		dictionary.Add(xrecord);
+		doc.RootDictionary.Add(dictionary);
+
+		MemoryStream ms = new MemoryStream();
+		DwgWriter.Write(ms, doc);
+		using MemoryStream readStream = new MemoryStream(ms.ToArray());
+		CadDocument rt = DwgReader.Read(readStream);
+
+		Assert.True(rt.RootDictionary.TryGetEntry("MOREDWG_TEST", out CadDictionary rtDictionary));
+		Assert.True(rtDictionary.TryGetEntry("MOREDWG_ORDER", out XRecord result));
+
+		int[] codes = result.Entries.Select(e => e.Code).ToArray();
+		Assert.Equal(new[] { 300, 330, 294, 90 }, codes);
+
+		Assert.Equal("before", result.Entries.ElementAt(0).Value);
+		Assert.Equal(Layer.DefaultName, ((Layer)result.Entries.ElementAt(1).Value).Name);
+		Assert.False(System.Convert.ToBoolean(result.Entries.ElementAt(2).Value));
+		Assert.Equal(7, System.Convert.ToInt32(result.Entries.ElementAt(3).Value));
+	}
+
+	/// <summary>
+	/// Reading a drawing written by AutoCAD must give the same entry order the file has; this
+	/// record has its handle in the middle (300, 302, 330, 294).
+	/// </summary>
+	[Fact]
+	public void ReadsTheEntriesOfAnAutoCadFileInFileOrder()
+	{
+		string path = Path.Combine(TestVariables.SamplesFolder, "sample_AC1032.dwg");
+		CadDocument doc = DwgReader.Read(path);
+
+		XRecord record = null;
+		foreach (View view in doc.Views)
+		{
+			if (view.XDictionary != null && view.XDictionary.TryGetEntry("ADSK_XREC_VTRVIEWINFO", out XRecord found))
+			{
+				record = found;
+				break;
+			}
+		}
+
+		Assert.NotNull(record);
+		Assert.Equal(new[] { 300, 302, 330, 294 }, record.Entries.Select(e => e.Code).ToArray());
+	}
+}

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -7367,7 +7367,7 @@ namespace ACadSharp.IO.DWG
 						string hex = this._objectReader.ReadTextUnicode();
 						if (ulong.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out ulong result))
 						{
-							template.AddHandleReference(code, result);
+							template.AddHandleReference(code, result, xRecord.CreateEntry(code, null));
 						}
 						else
 						{
@@ -7383,7 +7383,10 @@ namespace ACadSharp.IO.DWG
 						break;
 					case GroupCodeValueType.ObjectId:
 					case GroupCodeValueType.ExtendedDataHandle:
-						template.AddHandleReference(code, this._objectReader.ReadRawULong());
+						//The entry is created here, in the position it has in the file, and its value is
+						//filled in when the template is built; adding it afterwards would move every
+						//handle to the end of the record and change the order AutoCAD expects.
+						template.AddHandleReference(code, this._objectReader.ReadRawULong(), xRecord.CreateEntry(code, null));
 						break;
 					default:
 						this.notify($"Unidentified GroupCodeValueType {code} for XRecord [{xRecord.Handle}]", NotificationType.Warning);

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
@@ -668,6 +668,13 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 
 		foreach (var e in record.Entries)
 		{
+			//An entry whose handle could not be resolved when the file was read keeps its place in
+			//the record with a null value; there is nothing to write for it.
+			if (e.Value == null)
+			{
+				continue;
+			}
+
 			switch (e.GroupCode)
 			{
 				case GroupCodeValueType.None:

--- a/src/ACadSharp/IO/Templates/CadXRecordTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadXRecordTemplate.cs
@@ -5,15 +5,25 @@ namespace ACadSharp.IO.Templates
 {
 	internal class CadXRecordTemplate : CadTemplate<XRecord>
 	{
-		private readonly System.Collections.Generic.List<Tuple<int, ulong>> _entries = new();
+		private readonly System.Collections.Generic.List<Tuple<int, ulong, XRecord.Entry>> _entries = new();
 
 		public CadXRecordTemplate() : base(new XRecord()) { }
 
 		public CadXRecordTemplate(XRecord cadObject) : base(cadObject) { }
 
-		public void AddHandleReference(int code, ulong handle)
+		/// <summary>
+		/// Registers a handle that has to be resolved once the document is built.
+		/// </summary>
+		/// <param name="code">Group code of the entry.</param>
+		/// <param name="handle">Handle of the referenced object.</param>
+		/// <param name="entry">
+		/// Entry already created in the position the record has in the file, its value is filled in
+		/// by <see cref="build"/>. When it is null the entry is appended instead, which changes the
+		/// order of the record and should only be used when the position is not known.
+		/// </param>
+		public void AddHandleReference(int code, ulong handle, XRecord.Entry entry = null)
 		{
-			_entries.Add(new Tuple<int, ulong>(code, handle));
+			_entries.Add(new Tuple<int, ulong, XRecord.Entry>(code, handle, entry));
 		}
 
 		protected override void build(CadDocumentBuilder builder)
@@ -24,7 +34,14 @@ namespace ACadSharp.IO.Templates
 			{
 				if (builder.TryGetCadObject<CadObject>(entry.Item2, out CadObject obj))
 				{
-					this.CadObject.CreateEntry(entry.Item1, obj);
+					if (entry.Item3 == null)
+					{
+						this.CadObject.CreateEntry(entry.Item1, obj);
+					}
+					else
+					{
+						entry.Item3.Value = obj;
+					}
 				}
 				else
 				{

--- a/src/ACadSharp/Objects/XRecrod.cs
+++ b/src/ACadSharp/Objects/XRecrod.cs
@@ -74,8 +74,10 @@ public partial class XRecord : NonGraphicalObject
 	/// </summary>
 	/// <param name="code">The integer code that identifies the entry. The value should be unique within the collection.</param>
 	/// <param name="value">The value to associate with the entry. Can be any object, including <see langword="null"/>.</param>
-	public void CreateEntry(int code, object value)
+	public Entry CreateEntry(int code, object value)
 	{
-		this._entries.Add(new Entry(code, value, this));
+		Entry entry = new Entry(code, value, this);
+		this._entries.Add(entry);
+		return entry;
 	}
 }


### PR DESCRIPTION
# Description

An XRecord is positional data: the entries are identified by where they sit. The reader stored handle-typed entries in the template and `build()` appended them at the **end** of the list, so a record AutoCAD wrote as `300, 302, 330, 294` came back as `300, 302, 294, 330`. AutoCAD refuses a drawing whose XRecord has been reordered like that.

# Tasks done in this PR

* [x] `XRecord.CreateEntry` returns the entry it created.
* [x] The reader creates the entry in the right position with a null value and registers the handle against that entry; `build()` only fills the value in.
* [x] The DXF writer skips an entry whose value is still null.
* [x] `XRecordTests`, 2 cases.

# Related Issues / Pull Requests

- None; this one stands on its own and is cut straight from `master`.

# Notes for reviewer

**Testing**

`dotnet test` on this branch: **2315 passed / 17 failed**, the same failures as master.

AutoCAD 2027: found by bisection with a temporary hook that limited how many XRecords were written - 0, 1, 2 and 5 opened, 6 and above did not. The sixth is `ADSK_XREC_VTRVIEWINFO` in the extension dictionary of a view, and its entry order is exactly the case above.

- Signature change: `XRecord.CreateEntry` returns `Entry` instead of `void`. Source compatible - existing calls keep compiling.

---

_Checked against AutoCAD 2027 through `accoreconsole`: AUDIT for "does it open cleanly", and SAVEAS DXF for the oracle comparisons quoted above._