### PR TITLE
Write drawings AutoCAD can open for R2000 and R2004

### DIFF
--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Entities.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Entities.cs
@@ -583,8 +583,12 @@ internal partial class DwgObjectWriter : DwgSectionIO
 				{
 					case PolyfaceMesh faceMesh:
 						this.writePolyfaceMesh(faceMesh);
-						children.AddRange(faceMesh.Faces);
+						//The vertices come first and the faces after them, which is the order the
+						//owned object list and the first/last vertex handles of writePolyfaceMesh
+						//describe; writing the faces first leaves those handles pointing at the
+						//wrong ends of the sequence and AutoCAD cannot walk it.
 						children.AddRange(faceMesh.Vertices);
+						children.AddRange(faceMesh.Faces);
 						seqend = faceMesh.Vertices.Seqend;
 						break;
 					case Polyline2D pline2d:
@@ -1995,7 +1999,7 @@ internal partial class DwgObjectWriter : DwgSectionIO
 
 		//Common:
 		//H SEQEND(hard owner)
-		this._writer.HandleReference(DwgReferenceType.SoftPointer, fm.Vertices.Seqend);
+		this._writer.HandleReference(DwgReferenceType.HardOwnership, fm.Vertices.Seqend);
 	}
 
 	private void writePolygonMesh(PolygonMesh pline)
@@ -2232,10 +2236,18 @@ internal partial class DwgObjectWriter : DwgSectionIO
 		}
 		else
 		{
-			scenario = (spline.FitPoints.Count <= 0) ? 1 : 2;
-			if (scenario == 2 && spline.KnotParametrization != 0)
+			//Before R2013 the knot parameterization is not stored, so a spline that is defined by fit
+			//points and uses one cannot keep it. It still has to be written as fit points: falling
+			//back to the control point scenario writes a spline with no knots and no control points,
+			//which leaves AutoCAD unable to open the file.
+			bool hasControlPoints = spline.ControlPoints.Count > 0 && spline.Knots.Count > 0;
+			if (hasControlPoints)
 			{
 				scenario = 1;
+			}
+			else
+			{
+				scenario = spline.FitPoints.Count > 0 ? 2 : 1;
 			}
 
 			//Scenario BL a flag which is 2 for fitpts only, 1 for ctrlpts/knots.

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.cs
@@ -148,6 +148,9 @@ internal partial class DwgObjectWriter : DwgSectionIO
 			case Shape:
 				return this.WriteShapes;
 			case TableEntity when !this.R2010Plus:
+			//MULTILEADER was introduced with AutoCAD 2008 (AC1021) and the writer only implements
+			//the R2010 layout; writing one into an older file leaves AutoCAD unable to open it.
+			case MultiLeader when !this.R2010Plus:
 			case Wall:
 			case MechanicalEntity:
 			case ProxyEntity:


### PR DESCRIPTION
# Description

Three independent writer defects, each of which makes AutoCAD refuse an R2000 or R2004 drawing.

1. **Spline with fit points only**: below R2013 the writer forced scenario 1, so a spline with fit points and a knot parametrisation was written empty - no knots, no control points.
2. **PolyfaceMesh**: the children were written faces first and vertices second, the opposite of the owned list and of the first and last vertex handles.
3. **MULTILEADER**: the entity only exists from AutoCAD 2008 but was written into R2000 and R2004 as well.

# Tasks done in this PR

* [x] Keep the fit-point scenario when a spline has no control points.
* [x] Write the vertices of a polyface mesh before its faces.
* [x] Skip MULTILEADER below R2010, the way TableEntity is already skipped.

# Related Issues / Pull Requests

- None; this one stands on its own and is cut straight from `master`.

# Notes for reviewer

**Testing**

`dotnet test` on this branch: **2314 passed / 15 failed**, against 2312 / 17 on master - the two `SingleMLeader` cases for AC1015 and AC1018 turn green.

AutoCAD 2027: with these three fixes the round trip of `samples/sample_AC1032.dwg` opens as AC1015 and AC1018; before it did not.

- Found by a binary search over the number of entities written, one defect at a time.

---

_Checked against AutoCAD 2027 through `accoreconsole`: AUDIT for "does it open cleanly", and SAVEAS DXF for the oracle comparisons quoted above._