### PR TITLE
Write the R14 file header the way AutoCAD does, and warn about R14

### DIFF
--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgFileHeaderWriterAC15.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgFileHeaderWriterAC15.cs
@@ -8,21 +8,31 @@ namespace ACadSharp.IO.DWG.DwgStreamWriters;
 
 internal class DwgFileHeaderWriterAC15 : DwgFileHeaderWriterBase<DwgFileHeaderAC15>
 {
-	public override int FileHeaderSize { get { return 0x61; } }
+	/// <summary>
+	/// R14 writes five section locator records and R2000 six, and the header is exactly that much
+	/// shorter: 21 bytes of preamble, 4 for the count, 9 per record, 2 of CRC and 16 of sentinel.
+	/// </summary>
+	public override int FileHeaderSize { get { return this.isR14 ? 0x58 : 0x61; } }
 
 	public override int HandleSectionOffset
 	{
 		get
 		{
 			return (int)(FileHeaderSize
-				+ this._records[DwgSectionDefinition.AuxHeader].Stream.Length
-				+ this._records[DwgSectionDefinition.Preview].Stream.Length
-				+ this._records[DwgSectionDefinition.Header].Stream.Length
-				+ this._records[DwgSectionDefinition.Classes].Stream.Length);
+				+ this.streamLength(DwgSectionDefinition.AuxHeader)
+				+ this.streamLength(DwgSectionDefinition.Preview)
+				+ this.streamLength(DwgSectionDefinition.Header)
+				+ this.streamLength(DwgSectionDefinition.Classes));
 		}
 	}
 
-	private const int _nRecords = 6;
+	/// <summary>
+	/// R14 has no auxiliary header and leaves the object free space empty; AutoCAD writes its record
+	/// with a seeker and a size of 0. Measured on samples/sample_AC1014.dwg.
+	/// </summary>
+	private bool isR14 { get { return this._version == ACadVersion.AC1014; } }
+
+	private int nRecords { get { return this.isR14 ? 5 : 6; } }
 
 	private byte[] _endSentinel = new byte[16]
 	{
@@ -52,7 +62,21 @@ internal class DwgFileHeaderWriterAC15 : DwgFileHeaderWriterBase<DwgFileHeaderAC
 
 	public override void AddSection(string name, MemoryStream stream, bool isCompressed, int decompsize = 29696)
 	{
+		if (this.isR14
+			&& (name == DwgSectionDefinition.AuxHeader || name == DwgSectionDefinition.ObjFreeSpace))
+		{
+			//Not part of an R14 file; leaving the stream null keeps the record at seeker 0, size 0
+			//and keeps the bytes out of the file.
+			return;
+		}
+
 		this._records[name].Stream = stream;
+	}
+
+	private long streamLength(string name)
+	{
+		MemoryStream stream = this._records[name].Stream;
+		return stream == null ? 0 : stream.Length;
 	}
 
 	public override void WriteFile()
@@ -72,6 +96,13 @@ internal class DwgFileHeaderWriterAC15 : DwgFileHeaderWriterBase<DwgFileHeaderAC
 		foreach (var kv in this._records)
 		{
 			var record = kv.Value;
+			if (record.Stream == null)
+			{
+				//A section this version does not have: AutoCAD points its record at 0.
+				record.Seeker = 0;
+				continue;
+			}
+
 			record.Seeker = currOffset;
 			currOffset += (int)record.Stream.Length;
 		}
@@ -86,7 +117,8 @@ internal class DwgFileHeaderWriterAC15 : DwgFileHeaderWriterBase<DwgFileHeaderAC
 		writer.WriteBytes(Encoding.ASCII.GetBytes(this._document.Header.VersionString), 0, 6);
 		//The next 7 starting at offset 0x06 are to be six bytes of 0
 		//(in R14, 5 0’s and the ACADMAINTVER variable) and a byte of 1.
-		writer.WriteBytes(new byte[7] { 0, 0, 0, 0, 0, 15, 1 });
+		//The maintenance version byte: AutoCAD writes 10 in R14 and 15 in R2000.
+		writer.WriteBytes(new byte[7] { 0, 0, 0, 0, 0, (byte)(this.isR14 ? 10 : 15), 1 });
 		//At 0x0D is a seeker (4 byte long absolute address) for the beginning sentinel of the image data.
 		writer.WriteRawLong(this._records[DwgSectionDefinition.Preview].Seeker);
 
@@ -95,14 +127,18 @@ internal class DwgFileHeaderWriterAC15 : DwgFileHeaderWriterBase<DwgFileHeaderAC
 
 		//Bytes at 0x13 and 0x14 are a raw short indicating the value of the code page for this drawing file.
 		writer.WriteBytes(LittleEndianConverter.Instance.GetBytes(this.getFileCodePage()));
-		writer.WriteBytes(LittleEndianConverter.Instance.GetBytes(_nRecords), 0, 4);
+		writer.WriteBytes(LittleEndianConverter.Instance.GetBytes(this.nRecords), 0, 4);
 
 		this.writeRecord(writer, this._records[DwgSectionDefinition.Header]);
 		this.writeRecord(writer, this._records[DwgSectionDefinition.Classes]);
 		this.writeRecord(writer, this._records[DwgSectionDefinition.Handles]);
 		this.writeRecord(writer, this._records[DwgSectionDefinition.ObjFreeSpace]);
 		this.writeRecord(writer, this._records[DwgSectionDefinition.Template]);
-		this.writeRecord(writer, this._records[DwgSectionDefinition.AuxHeader]);
+
+		if (!this.isR14)
+		{
+			this.writeRecord(writer, this._records[DwgSectionDefinition.AuxHeader]);
+		}
 
 		//CRC
 		writer.WriteSpearShift();
@@ -119,7 +155,7 @@ internal class DwgFileHeaderWriterAC15 : DwgFileHeaderWriterBase<DwgFileHeaderAC
 		//Record number (raw byte) | Seeker (raw long) | Size (raw long)
 		writer.WriteByte((byte)record.Number.Value);
 		writer.WriteRawLong(record.Seeker);
-		writer.WriteRawLong(record.Stream.Length);
+		writer.WriteRawLong(record.Stream == null ? 0 : record.Stream.Length);
 	}
 
 	private void writeRecordStreams()

--- a/src/ACadSharp/IO/DwgWriter.cs
+++ b/src/ACadSharp/IO/DwgWriter.cs
@@ -149,6 +149,15 @@ public class DwgWriter : CadWriterBase<DwgWriterConfiguration>
 			case ACadVersion.AC1012:
 				throw new CadNotSupportedException(this._document.Header.Version);
 			case ACadVersion.AC1014:
+				//The file header of R14 is written correctly - five section locator records, no
+				//auxiliary header, an empty object free space - but AutoCAD still refuses to open
+				//the result, so the rest of an R14 file is not right yet. Say so instead of handing
+				//back a drawing that looks fine and is not: AC1015 is the oldest version that works.
+				this.triggerNotification(
+					$"A DWG written as {ACadVersion.AC1014} is not accepted by AutoCAD; the oldest version that opens is {ACadVersion.AC1015}",
+					NotificationType.Warning);
+				this._fileHeaderWriter = new DwgFileHeaderWriterAC15(this._stream, this._encoding, this._document);
+				break;
 			case ACadVersion.AC1015:
 				this._fileHeaderWriter = new DwgFileHeaderWriterAC15(this._stream, this._encoding, this._document);
 				break;


### PR DESCRIPTION
# Description

`DwgFileHeaderWriterAC15` serves both AC1014 and AC1015 and wrote the R2000 shape for both. Compared with `samples/sample_AC1014.dwg`:

| | AutoCAD R14 | what we wrote | AutoCAD R2000 |
|---|---|---|---|
| section locator records | 5 | 6 | 6 |
| auxiliary header | absent | written | written |
| object free space | 0 / 0 | a real section | a real section |
| header size | 0x58 | 0x61 | 0x61 |
| maintenance byte | 10 | 15 | 15 |

# Tasks done in this PR

* [x] For AC1014 only: five section locator records, no auxiliary header, an object free space record of 0 / 0, a header of 0x58 bytes and the maintenance byte AutoCAD uses.
* [x] `DwgWriter` warns when the version is AC1014 and says AC1015 is the oldest that opens.

# Related Issues / Pull Requests

- None; this one stands on its own and is cut straight from `master`.

# Notes for reviewer

**Testing**

`dotnet test` on this branch: **2312 passed / 17 failed**, the same as master.

AutoCAD 2027, empty document per version: AC1015, AC1018, AC1024, AC1027 and AC1032 audit with **0 errors**; AC1014 is still refused.

- The header is now identical in shape to AutoCAD's, and R2000 is untouched, but AutoCAD still refuses an R14 file, so something further in that format is wrong. That is why the warning is part of this pull request.
- It is a warning and not an exception on purpose: the test suite writes AC1014 and the reader side works, so refusing would break more than it helps.
- The two bytes at 0x11 and 0x12 differ from AutoCAD in R2000 as well (`1b 19` against `21 ff`) and R2000 opens fine, so they are left alone.

---

_Checked against AutoCAD 2027 through `accoreconsole`: AUDIT for "does it open cleanly", and SAVEAS DXF for the oracle comparisons quoted above._