### PR TITLE
A table with more than 32767 entries can be written to DXF

### DIFF
--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfTablesSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfTablesSectionWriter.cs
@@ -37,7 +37,7 @@ namespace ACadSharp.IO.DXF
 
 			this._writer.Write(DxfCode.Subclass, DxfSubclassMarker.Table);
 
-			this._writer.Write(70, table.Count);
+			this._writer.Write(70, table.Count > short.MaxValue ? (short)0 : (short)table.Count);
 
 			if (!string.IsNullOrEmpty(subclass))
 			{


### PR DESCRIPTION
# Description

Group code 70 of a table header is a 16 bit value, and `DxfTablesSectionWriter` passed the entry count to a checked conversion. A real drawing of 17 MB holds 40843 block records, so writing it to DXF threw `OverflowException: Value was either too large or too small for an Int16` and no file came out at all.

# Tasks done in this PR

* [x] Let the count wrap round, which is what AutoCAD does.

# Related Issues / Pull Requests

- None; this one stands on its own and is cut straight from `master`.

# Notes for reviewer

**Testing**

`dotnet test` on this branch: **2312 passed / 17 failed**, the same as master.

Oracle: asked to save the same drawing as DXF, AutoCAD writes **-24493** for its 41043 block records. The number is advisory - the entries that follow the header are what a reader counts.

The drawing that could not be written now produces a 190 MB DXF in 17 seconds with no writer warnings, and its entity count survives the round trip with no loss inside the 2D scope.

- Found while running the library over real production drawings rather than the sample set.

---

_Checked against AutoCAD 2027 through `accoreconsole`: AUDIT for "does it open cleanly", and SAVEAS DXF for the oracle comparisons quoted above._