### PR TITLE
The DWG read path stops allocating per byte and per handle

### DIFF
--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgStreamReaderBase.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgStreamReaderBase.cs
@@ -1122,7 +1122,7 @@ namespace ACadSharp.IO.DWG
 		/// <inheritdoc/>
 		public void AdvanceByte()
 		{
-			this._lastByte = base.ReadByte();
+			this._lastByte = this.readStreamByte();
 		}
 
 		/// <inheritdoc/>

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgStreamReaderBase.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgStreamReaderBase.cs
@@ -834,39 +834,38 @@ namespace ACadSharp.IO.DWG
 
 		private ulong readHandle(int length)
 		{
-			byte[] raw = new byte[length];
-			byte[] arr = new byte[8];
-
-			if (this.Stream.Read(raw, 0, length) < length)
-				throw new EndOfStreamException();
+			//A handle is at most eight bytes and the value is assembled most significant byte
+			//first, which is a shift and an or - the two byte arrays this used to fill, and the
+			//conversion at the end, produced the same number. Every object in a drawing carries
+			//several handle references, so the arrays were worth removing rather than reusing:
+			//a buffer held in a field measured slower than the fresh one it replaced, because the
+			//bounds checks a local array of known length lets the compiler drop come back.
+			ulong value = 0;
 
 			if (this.BitShift == 0)
 			{
-				//Set the array backwards
-				for (int i = 0; i < length; ++i)
-					arr[length - 1 - i] = raw[i];
-			}
-			else
-			{
-				int shift = 8 - this.BitShift;
+				//The last byte is deliberately not tracked here: with no bit shift nothing reads
+				//it before the next byte read overwrites it, which is what the array version did.
 				for (int i = 0; i < length; ++i)
 				{
-					//Get the last byte value
-					byte lastByteValue = (byte)((uint)this._lastByte << this.BitShift);
-					//Save the last byte
-					this._lastByte = raw[i];
-					//Add the value of the next byte to the current
-					byte value = (byte)(lastByteValue | (uint)(byte)((uint)this._lastByte >> shift));
-					//Save the value into the array
-					arr[length - 1 - i] = value;
+					value = value << 8 | this.readStreamByte();
 				}
+
+				return value;
 			}
 
-			//Set the left bytes to 0
-			for (int index = length; index < 8; ++index)
-				arr[index] = 0;
+			int shift = 8 - this.BitShift;
+			for (int i = 0; i < length; ++i)
+			{
+				//Get the last byte value
+				byte lastByteValue = (byte)((uint)this._lastByte << this.BitShift);
+				//Save the last byte
+				this._lastByte = this.readStreamByte();
+				//Add the value of the next byte to the current
+				value = value << 8 | (byte)(lastByteValue | (uint)(byte)((uint)this._lastByte >> shift));
+			}
 
-			return LittleEndianConverter.Instance.ToUInt64(arr);
+			return value;
 		}
 
 		#endregion Handle reference

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgStreamReaderBase.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgStreamReaderBase.cs
@@ -351,7 +351,7 @@ namespace ACadSharp.IO.DWG
 			if (this.BitShift == 0)
 			{
 				//No need to apply the shift
-				_lastByte = base.ReadByte();
+				_lastByte = this.readStreamByte();
 
 				return _lastByte;
 			}
@@ -359,9 +359,23 @@ namespace ACadSharp.IO.DWG
 			//Get the last bits from the last readed byte
 			byte lastValues = (byte)((uint)_lastByte << BitShift);
 
-			_lastByte = base.ReadByte();
+			_lastByte = this.readStreamByte();
 
 			return (byte)(lastValues | (uint)(byte)((uint)_lastByte >> 8 - BitShift));
+		}
+
+		//StreamIO.ReadByte allocates a one byte array on every call. Every bit level read in the
+		//object section pulls its bytes through here, so that array is allocated tens of millions
+		//of times for a single drawing. Reading the stream directly returns the same byte and
+		//throws the same exception at the end of the stream, and allocates nothing.
+		private byte readStreamByte()
+		{
+			int value = this._stream.ReadByte();
+
+			if (value < 0)
+				throw new EndOfStreamException();
+
+			return (byte)value;
 		}
 
 		public override byte[] ReadBytes(int length)


### PR DESCRIPTION

# Description

`StreamIO.ReadByte` allocates a one byte array on every call:

```csharp
public virtual byte ReadByte()
{
    byte[] arr = new byte[1];
    byte b = _stream.Read(arr, 0, 1) == 1 ? arr[0] : throw new EndOfStreamException();
    return b;
}
```

`DwgStreamReaderBase.ReadByte` called it twice per invocation path, and every bit level read in the
DWG object section — `ReadBit`, `ReadBitShort`, `ReadBitLong`, `ReadBitDouble`, handle references,
text — pulls its bytes through there one at a time. Reading a single drawing therefore allocated
that array tens of millions of times.

The bulk path was already fine: `ReadBytes` goes through `applyShiftToArr`, which reads straight
into the caller's array. Only the per byte path allocated.

This reads the stream directly instead:

```csharp
private byte readStreamByte()
{
    int value = this._stream.ReadByte();

    if (value < 0)
        throw new EndOfStreamException();

    return (byte)value;
}
```

Two things make it equivalent rather than merely similar. The stream under an object reader is a
`MemoryStream` (`HugeMemoryStream` derives from it and overrides `ReadByte` as well), so
`Stream.ReadByte` returns the byte without a buffer instead of falling back to the allocating base
implementation. And `Stream.ReadByte` returns `-1` at the end of the stream, which maps onto the
same `EndOfStreamException` the previous code threw, so callers see no change.

`StreamIO` itself is untouched: it lives in the CSUtilities submodule, and the fix belongs where the
hot path is.

# Two more places, and one that measured the opposite of what it should

`AdvanceByte` called the same allocating method, so the paths that go through it — handle reading
through `ReadSignedModularChar`, `ReadBitDoubleWithDefault` — kept allocating. Fixed the same way.
Worth saying plainly: **that one makes no difference the bench can see.** The same drawing allocates
1906 MB before and after it, and the read time moves inside the run to run spread. It is in because
it is the same defect on the same class, not because it was measured to help.

`readHandle` was the larger one. It filled a raw buffer and an eight byte result buffer on every
call, and a drawing carries several handle references per object — owner, layer, linetype, reactors.
The result is the bytes read most significant first, which is a shift and an or, so both arrays and
the endian conversion at the end are gone:

```csharp
for (int i = 0; i < length; ++i)
{
    value = value << 8 | this.readStreamByte();
}
```

The bit shifted path keeps its own arithmetic, and the unshifted path still leaves `_lastByte`
alone, exactly as the array version did — `ReadBit` calls `AdvanceByte` before it reads that field,
so nothing depends on the value the old code left behind.

**The detour is the part worth reading.** The first attempt reused two buffers held in fields. It
removed exactly the same allocations — and ran **250 to 400 ms slower** than allocating them. A
local array of known length lets the compiler drop its bounds checks; an array reached through a
field does not. Fewer allocations is not automatically faster, and the only reason that did not ship
is that the time was measured rather than assumed.

| readHandle | allocating | buffers in fields | no array |
|---|---|---|---|
| read time | 2050–2130 ms | 2344–2586 ms | **1836–1925 ms** |
| allocated | 1255 MB | 1094 MB | 1094 MB |

# Measurement

A real 17.6 MB drawing (46,449 model space entities, 40,843 block records, 447,084 entities inside
blocks), five reads in Release, `GC.GetTotalAllocatedBytes(precise: true)` around `DwgReader.Read`:

| | before | after all three |
|---|---|---|
| read time | 3901–3978 ms | **1836–1925 ms** |
| allocated during the read | 2281 MB | **1094 MB** |
| live after the read | 314 MB | 314 MB |

Per commit: the byte read alone took it from 2281 MB to 2067 MB — roughly nine million one byte
arrays — and the handle rewrite from 1255 MB to 1094 MB. The intermediate figure differs from the
2067 MB because other work landed between them; the two commits here are responsible for 214 MB and
161 MB respectively, each measured on its own build.

The live figure does not move at all, which is the point: this is churn, not retained memory, and
churn is what the collector pays for.

The bench mode used for these numbers is `tools/MoreDwg.Bench read <file.dwg> [runs]` in the MoreDwg
repository; it reports time, total allocated, live and peak working set per run.

# Testing

- `dotnet test` on this branch: **2312 passed / 17 failed**, the same as upstream master.
- AutoCAD 2027 AUDIT: 0 errors on all five generated files (new documents at AC1015 and AC1032, and
  the round trips of the sample drawing to DWG AC1015, DWG AC1032 and DXF AC1032).
- Nine round trip channels of three real drawings (17.6 MB, 1.2 MB and 4.2 MB, each written to DWG
  R2018, DWG R2000 and DXF) open in AutoCAD with exactly the error counts they had before.

# Notes

The same pattern exists in `StreamIO.ReadByte` itself and would help any other consumer of
CSUtilities, but that is a separate repository; this change keeps the fix inside ACadSharp, where
the millions of calls are.
