### PR TITLE
A dictionary entry added under a key is written with that key as its name

### DIFF
--- a/src/ACadSharp/Objects/CadDictionary.cs
+++ b/src/ACadSharp/Objects/CadDictionary.cs
@@ -225,6 +225,16 @@ public class CadDictionary : NonGraphicalObject, IObservableCadCollection<NonGra
 			throw new ArgumentNullException(nameof(value), $"NonGraphicalObject [{this.GetType().FullName}] must have a name");
 		}
 
+		//An entry added under a key of its own carries no name, and both writers put the name into
+		//the file: a DXF round trip of such an entry came back with an empty group 3 and the
+		//document could not be read. The reader already fills a missing name from the key when it
+		//builds a dictionary, so this is the same rule on the way in. A name that is already set is
+		//left alone - some collections, scales among them, use a key that differs from the name.
+		if (string.IsNullOrEmpty(value.Name))
+		{
+			value.Name = key;
+		}
+
 		this._entries.Add(key, value);
 		value.Owner = this;
 


### PR DESCRIPTION

# Description

`CadDictionary.Add(string key, NonGraphicalObject value)` stores the entry under `key` but leaves
`value.Name` alone. Both writers put `Name` into the file, so an object that has no name of its own
goes out with an empty name. This is what a DXF of an extension dictionary holding a `GeoData`
looks like on master:

```
  0
DICTIONARY
  5
60
330
58
100
AcDbDictionary
  3

350
61
```

Group 3 is empty. Reading that file back throws — the dictionary refuses a nameless entry — and the
document cannot be built:

```
System.ArgumentNullException : NonGraphicalObject [ACadSharp.Objects.CadDictionary] must have a name
   at ACadSharp.IO.Templates.CadDictionaryTemplate.build(CadDocumentBuilder builder)
```

The fix fills the name from the key when the entry has none:

```csharp
if (string.IsNullOrEmpty(value.Name))
{
    value.Name = key;
}
```

That is the rule the reader already applies when it builds a dictionary out of a file:

```csharp
//For some collections like Scales there are some cases where the key doesn't match the name
if (string.IsNullOrEmpty(entry.Name))
{
    entry.Name = item.Key;
}
```

so the two directions now agree. An entry that already carries a name keeps it, which preserves the
case that comment is about — scales, where the key and the name differ deliberately.

It shows up only for objects with no name of their own. A layout, a table style or a visual style
carries its name already, and the key matches it, which is why the DXF of a normal document is
unaffected.

# What it fixes

The two cases in `WriterSingleObjectTests` that exercise an extension dictionary — `GeoData` and
`InsertWithSpatialFilter` — fail on master at every version. On this branch, all of them pass:

| | master | this branch |
|---|---|---|
| `dotnet test` | 2312 passed / **17 failed** | 2324 passed / **5 failed** |

Those twelve are `DxfWriterSingleObjectTests.WriteCases{AC1015…AC1032}` for the two cases above.
The five that remain are unrelated to dictionaries and are untouched here.

# Testing

- `dotnet test` on this branch: **2324 passed / 5 failed**, twelve fewer failures than master and no
  new ones.
- AutoCAD 2027 AUDIT: 0 errors on all five generated files (two new documents, three round trips of
  the sample drawing to DWG AC1015, DWG AC1032 and DXF AC1032).
- Nine round trip channels of three real drawings, DWG R2018, DWG R2000 and DXF each: unchanged
  error counts, so a document whose dictionary entries already had names behaves exactly as before.
