### PR TITLE
Add WIPEOUTVARIABLES object support

### DIFF
--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>3.7.5</Version>
+		<Version>3.7.6</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>../ACadSharp.snk</AssemblyOriginatorKeyFile>

--- a/src/ACadSharp/Classes/DxfClassCollection.cs
+++ b/src/ACadSharp/Classes/DxfClassCollection.cs
@@ -326,21 +326,6 @@ public class DxfClassCollection : ICollection<DxfClass>
 			InstanceCount = this._document.GetInstanceCount("ACDB_TEXTOBJECTCONTEXTDATA_CLASS"),
 		});
 
-		//AcDbWipeoutVariables
-		this.AddOrUpdate(new DxfClass
-		{
-			ApplicationName = "WipeOut",
-			CppClassName = "AcDbWipeoutVariables",
-			ClassNumber = (short)(500 + this.Count),
-			DwgVersion = ACadVersion.AC1015,
-			DxfName = "WIPEOUTVARIABLES",
-			ItemClassId = 499,
-			MaintenanceVersion = 0,
-			ProxyFlags = ProxyFlags.R13FormatProxy,
-			WasZombie = false,
-			InstanceCount = this._document.GetInstanceCount("WIPEOUTVARIABLES"),
-		});
-
 		//AcDbTableGeometry
 		this.AddOrUpdate(new DxfClass
 		{

--- a/src/ACadSharp/DxfFileToken.cs
+++ b/src/ACadSharp/DxfFileToken.cs
@@ -52,11 +52,11 @@ public static class DxfFileToken
 
 	public const string EntityArc = "ARC";
 
+	public const string EntityArcDimension = "ARC_DIMENSION";
+
 	public const string EntityAttribute = "ATTRIB";
 
 	public const string EntityAttributeDefinition = "ATTDEF";
-
-	public const string EntityArcDimension = "ARC_DIMENSION";
 
 	public const string EntityBody = "BODY";
 
@@ -303,6 +303,8 @@ public static class DxfFileToken
 	public const string ObjectTableStyle = "TABLESTYLE";
 
 	public const string ObjectVisualStyle = "VISUALSTYLE";
+
+	public const string ObjectWipeoutVariables = "WIPEOUTVARIABLES";
 
 	public const string ObjectXRecord = "XRECORD";
 

--- a/src/ACadSharp/DxfSubclassMarker.cs
+++ b/src/ACadSharp/DxfSubclassMarker.cs
@@ -16,8 +16,6 @@ public static class DxfSubclassMarker
 
 	public const string Angular2LineDimension = "AcDb2LineAngularDimension";
 
-	public const string ArcDimension = "AcDbArcDimension";
-
 	public const string Angular3PointDimension = "AcDb3PointAngularDimension";
 
 	public const string AnnotScaleObjectContextData = "AcDbAnnotScaleObjectContextData";
@@ -25,6 +23,8 @@ public static class DxfSubclassMarker
 	public const string ApplicationId = "AcDbRegAppTableRecord";
 
 	public const string Arc = "AcDbArc";
+
+	public const string ArcDimension = "AcDbArcDimension";
 
 	public const string Attribute = "AcDbAttribute";
 
@@ -307,6 +307,8 @@ public static class DxfSubclassMarker
 	public const string VPort = "AcDbViewportTableRecord";
 
 	public const string Wipeout = "AcDbWipeout";
+
+	public const string WipeoutVariables = "AcDbWipeoutVariables";
 
 	public const string XLine = "AcDbXline";
 

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.Objects.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.Objects.cs
@@ -1030,4 +1030,16 @@ internal partial class DwgObjectReader : DwgSectionIO
 
 		return template;
 	}
+
+	private CadTemplate readWipeoutVariables()
+	{
+		WipeoutVariables wipeoutVariables = new WipeoutVariables();
+		CadNonGraphicalObjectTemplate template = new CadNonGraphicalObjectTemplate(wipeoutVariables);
+
+		this.readCommonNonEntityData(template);
+
+		wipeoutVariables.DisplayImageFrame = this._mergedReaders.ReadBitShort() != 0;
+
+		return template;
+	}
 }

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -5782,6 +5782,9 @@ namespace ACadSharp.IO.DWG
 				case DxfFileToken.ObjectField:
 					template = this.readField();
 					break;
+				case DxfFileToken.ObjectWipeoutVariables:
+					template = this.readWipeoutVariables();
+					break;
 			}
 
 			if (template == null && c.IsAnEntity)

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
@@ -1889,6 +1889,9 @@ internal partial class DwgObjectWriter : DwgSectionIO
 			case TableStyle tableStyle:
 				this.writeTableStyle(tableStyle);
 				break;
+			case WipeoutVariables wipeoutVariables:
+				this.writeWipeoutVariables(wipeoutVariables);
+				break;
 			case Field field:
 				this.writeField(field);
 				break;
@@ -2332,6 +2335,13 @@ internal partial class DwgObjectWriter : DwgSectionIO
 				index++;
 			}
 		}
+	}
+
+	private void writeWipeoutVariables(WipeoutVariables wipeoutVariables)
+	{
+		//Common:
+		//Dispfrm BS 70 display image frame
+		this._writer.WriteBitShort(wipeoutVariables.DisplayImageFrame ? (short)1 : (short)0);
 	}
 
 	private void writeXRecord(XRecord xrecord)

--- a/src/ACadSharp/IO/DXF/DxfStreamReader/DxfObjectsSectionReader.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamReader/DxfObjectsSectionReader.cs
@@ -2259,6 +2259,8 @@ internal class DxfObjectsSectionReader : DxfSectionReaderBase
 				return this.readObjectCodes<ProxyObject>(new CadProxyObjectTemplate(), this.readProxyObject);
 			case DxfFileToken.ObjectRasterVariables:
 				return this.readObjectCodes<RasterVariables>(new CadNonGraphicalObjectTemplate(new RasterVariables()), this.readObjectSubclassMap);
+			case DxfFileToken.ObjectWipeoutVariables:
+				return this.readObjectCodes<WipeoutVariables>(new CadNonGraphicalObjectTemplate(new WipeoutVariables()), this.readObjectSubclassMap);
 			case DxfFileToken.ObjectGroup:
 				return this.readObjectCodes<Group>(new CadGroupTemplate(), this.readGroup);
 			case DxfFileToken.ObjectGeoData:

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
@@ -554,6 +554,9 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 			case TableStyle tableStyle:
 				this.writeTableStyle(tableStyle);
 				break;
+			case WipeoutVariables wipeoutVariables:
+				this.writeWipeoutVariables(wipeoutVariables);
+				break;
 			case XRecord record:
 				this.writeXRecord(record);
 				break;
@@ -658,6 +661,15 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 
 			this.writeObject(item);
 		}
+	}
+
+	protected void writeWipeoutVariables(WipeoutVariables variables)
+	{
+		DxfClassMap map = DxfClassMap.Create<WipeoutVariables>();
+
+		this._writer.Write(100, DxfSubclassMarker.WipeoutVariables);
+
+		this._writer.Write(70, variables.DisplayImageFrame ? 1 : 0, map);
 	}
 
 	protected void writeXRecord(XRecord record)

--- a/src/ACadSharp/Objects/NonGraphicalObject.cs
+++ b/src/ACadSharp/Objects/NonGraphicalObject.cs
@@ -1,8 +1,5 @@
 ﻿using ACadSharp.Attributes;
-using ACadSharp.Extensions;
-using ACadSharp.IO;
 using System;
-using System.Collections.Generic;
 
 namespace ACadSharp.Objects;
 

--- a/src/ACadSharp/Objects/WipeoutVariables.cs
+++ b/src/ACadSharp/Objects/WipeoutVariables.cs
@@ -1,0 +1,47 @@
+﻿using ACadSharp.Attributes;
+using ACadSharp.Classes;
+
+namespace ACadSharp.Objects;
+
+/// <summary>
+/// Represents a <see cref="WipeoutVariables"/> object.
+/// </summary>
+/// <remarks>
+/// Object name <see cref="DxfFileToken.ObjectWipeoutVariables"/> <br/>
+/// Dxf class name <see cref="DxfSubclassMarker.WipeoutVariables"/>
+/// </remarks>
+[DxfName(DxfFileToken.ObjectWipeoutVariables)]
+[DxfSubClass(DxfSubclassMarker.WipeoutVariables)]
+public class WipeoutVariables : NonGraphicalObject, IDxfClassDefined
+{
+	/// <summary>
+	/// Gets or sets a value indicating whether the image frame is displayed.
+	/// </summary>
+	[DxfCodeValue(70)]
+	public bool DisplayImageFrame { get; set; }
+
+	/// <inheritdoc/>
+	public override string ObjectName => DxfFileToken.ObjectWipeoutVariables;
+
+	/// <inheritdoc/>
+	public override ObjectType ObjectType { get { return ObjectType.UNLISTED; } }
+
+	/// <inheritdoc/>
+	public override string SubclassMarker => DxfSubclassMarker.WipeoutVariables;
+
+	/// <inheritdoc/>
+	public DxfClass GetDxfClass()
+	{
+		return new DxfClass
+		{
+			ApplicationName = "\"WipeOut|Product Desc:     WipeOut Dbx Application|Company:          Autodesk, Inc.|WEB Address:      www.autodesk.com\"",
+			CppClassName = DxfSubclassMarker.WipeoutVariables,
+			DwgVersion = ACadVersion.AC1018,
+			DxfName = DxfFileToken.ObjectWipeoutVariables,
+			ItemClassId = 499,
+			MaintenanceVersion = 0,
+			ProxyFlags = ProxyFlags.None,
+			WasZombie = false,
+		};
+	}
+}


### PR DESCRIPTION
# Description

Implemented WipeoutVariables class with DisplayImageFrame property and DXF mapping. Registered WIPEOUTVARIABLES in DxfFileToken and DxfSubclassMarker. Added read/write logic for DWG and DXF object readers/writers. Removed hardcoded AcDbWipeoutVariables entry from DxfClassCollection for improved extensibility.