### PR TITLE
Add DWG reading for Mechanical BOM objects

### DIFF
--- a/src/ACadSharp.Tests/Objects/Mechanical/AcmBomTests.cs
+++ b/src/ACadSharp.Tests/Objects/Mechanical/AcmBomTests.cs
@@ -1,0 +1,82 @@
+using ACadSharp.Objects.Mechanical;
+using Xunit;
+
+namespace ACadSharp.Tests.Objects.Mechanical;
+
+public class AcmBomTests
+{
+	[Fact]
+	public void MechanicalBomObjectsHaveExpectedClassNames()
+	{
+		AssertClassNames(new AcmBom(), DxfFileToken.AcmBom, DxfSubclassMarker.Bom);
+		AssertClassNames(new AcmBomRow(), DxfFileToken.AcmBomRow, DxfSubclassMarker.BomRow);
+		AssertClassNames(new AcmDataEntryBlock(), DxfFileToken.AcmDataEntryBlock, DxfSubclassMarker.DataEntryBlock);
+		AssertClassNames(new AcmDataEntryPart(), DxfFileToken.AcmDataEntryPart, DxfSubclassMarker.DataEntryPart);
+	}
+
+	[Fact]
+	public void MechanicalBomObjectsHaveEmptyCollectionsByDefault()
+	{
+		AcmBom bom = new AcmBom();
+		AcmBomRow row = new AcmBomRow();
+		AcmDataEntryBlock blockData = new AcmDataEntryBlock();
+		AcmDataEntryPart partData = new AcmDataEntryPart();
+
+		Assert.Empty(bom.Rows);
+		Assert.Empty(bom.RowNames);
+		Assert.Empty(bom.PartLists);
+		Assert.Empty(row.RawValues);
+		Assert.Empty(row.PartReferences);
+		Assert.Empty(row.Balloons);
+		Assert.Empty(blockData.Attributes);
+		Assert.Empty(blockData.RawValues);
+		Assert.Empty(blockData.References);
+		Assert.Empty(partData.Attributes);
+		Assert.Empty(partData.RawAttributeValues);
+		Assert.Empty(partData.PartReferences);
+		Assert.Empty(partData.BomRows);
+	}
+
+	[Fact]
+	public void MechanicalBomObjectGraphStoresRowData()
+	{
+		AcmDataEntryPart partData = new AcmDataEntryPart
+		{
+			EntryId = 42,
+		};
+		partData.Attributes.Add(new AcmDataEntryAttribute
+		{
+			Name = "PARTNO",
+			Value = "P-100",
+		});
+
+		AcmBomRow row = new AcmBomRow
+		{
+			ItemName = "1",
+			DataEntry = partData,
+		};
+		partData.BomRows.Add(row);
+
+		AcmBom bom = new AcmBom
+		{
+			Name = "MAIN",
+			ItemNumberStart = "1",
+			ItemNumberStep = 1,
+		};
+		bom.RowNames.Add("1");
+		bom.Rows.Add(row);
+
+		Assert.Same(row, Assert.Single(bom.Rows));
+		Assert.Same(partData, row.DataEntry);
+		Assert.Same(row, Assert.Single(partData.BomRows));
+		AcmDataEntryAttribute attribute = Assert.Single(partData.Attributes);
+		Assert.Equal("PARTNO", attribute.Name);
+		Assert.Equal("P-100", attribute.Value);
+	}
+
+	private static void AssertClassNames(CadObject cadObject, string objectName, string subclassMarker)
+	{
+		Assert.Equal(objectName, cadObject.ObjectName);
+		Assert.Equal(subclassMarker, cadObject.SubclassMarker);
+	}
+}

--- a/src/ACadSharp/DxfFileToken.cs
+++ b/src/ACadSharp/DxfFileToken.cs
@@ -10,6 +10,14 @@ public static class DxfFileToken
 
 	public const string AcmBalloon = "ACMBALLOON";
 
+	public const string AcmBom = "ACMBOM";
+
+	public const string AcmBomRow = "ACMBOMROW";
+
+	public const string AcmDataEntryBlock = "ACMDATAENTRYBLOCK";
+
+	public const string AcmDataEntryPart = "ACMDATAENTRYPART";
+
 	public const string AcmPartList = "ACMPARTLIST";
 
 	public const string AcmPartRef = "ACMPARTREF";

--- a/src/ACadSharp/DxfSubclassMarker.cs
+++ b/src/ACadSharp/DxfSubclassMarker.cs
@@ -32,6 +32,14 @@ public static class DxfSubclassMarker
 
 	public const string Balloon = "AcmBalloon";
 
+	public const string Bom = "AcmBom";
+
+	public const string BomRow = "AcmBomRow";
+
+	public const string DataEntryBlock = "AcmDataEntryBlock";
+
+	public const string DataEntryPart = "AcmDataEntryPart";
+
 	public const string BinRecord = "BinRecord";
 
 	public const string BlkRefObjectContextData = "AcDbBlkRefObjectContextData";

--- a/src/ACadSharp/Entities/Mechanical/AcmBalloon.cs
+++ b/src/ACadSharp/Entities/Mechanical/AcmBalloon.cs
@@ -1,4 +1,5 @@
 ﻿using ACadSharp.Attributes;
+using ACadSharp.Objects.Mechanical;
 using ACadSharp.Tables;
 using CSMath;
 
@@ -16,6 +17,11 @@ namespace ACadSharp.Entities.Mechanical;
 public class AcmBalloon : MechanicalEntity
 {
 	public BlockRecord Block { get; set; }
+
+	/// <summary>
+	/// Gets the BOM row referenced by this balloon.
+	/// </summary>
+	public AcmBomRow BomRow { get; internal set; }
 
 	/// <inheritdoc/>
 	public override string ObjectName => DxfFileToken.AcmBalloon;

--- a/src/ACadSharp/Entities/Mechanical/AcmPartList.cs
+++ b/src/ACadSharp/Entities/Mechanical/AcmPartList.cs
@@ -1,5 +1,7 @@
 ﻿using ACadSharp.Attributes;
+using ACadSharp.Objects.Mechanical;
 using CSMath;
+using System.Collections.Generic;
 
 namespace ACadSharp.Entities.Mechanical;
 
@@ -14,6 +16,26 @@ namespace ACadSharp.Entities.Mechanical;
 [DxfSubClass(DxfSubclassMarker.PartList)]
 public class AcmPartList : MechanicalEntity
 {
+	/// <summary>
+	/// Gets the BOM displayed by this part list.
+	/// </summary>
+	public AcmBom Bom { get; internal set; }
+
+	/// <summary>
+	/// Gets the BOM rows displayed by this part list.
+	/// </summary>
+	public List<AcmBomRow> Rows { get; } = new();
+
+	/// <summary>
+	/// Gets the custom item filter object, when present.
+	/// </summary>
+	public CadObject ItemFilterCustom { get; internal set; }
+
+	/// <summary>
+	/// Gets additional Mechanical objects referenced by the part list.
+	/// </summary>
+	public List<CadObject> RelatedObjects { get; } = new();
+
 	/// <inheritdoc/>
 	public override string ObjectName => DxfFileToken.AcmPartList;
 

--- a/src/ACadSharp/Entities/Mechanical/AcmPartRef.cs
+++ b/src/ACadSharp/Entities/Mechanical/AcmPartRef.cs
@@ -1,4 +1,5 @@
 ﻿using ACadSharp.Attributes;
+using ACadSharp.Objects.Mechanical;
 using CSMath;
 
 namespace ACadSharp.Entities.Mechanical;
@@ -14,6 +15,11 @@ namespace ACadSharp.Entities.Mechanical;
 [DxfSubClass(DxfSubclassMarker.PartRef)]
 public class AcmPartRef : MechanicalEntity
 {
+	/// <summary>
+	/// Gets the Mechanical part data referenced by this entity.
+	/// </summary>
+	public AcmDataEntryPart DataEntry { get; internal set; }
+
 	/// <inheritdoc/>
 	public override string ObjectName => DxfFileToken.AcmPartRef;
 

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -7,6 +7,7 @@ using ACadSharp.IO.Templates;
 using ACadSharp.Objects;
 using ACadSharp.Objects.AEC;
 using ACadSharp.Objects.Evaluations;
+using ACadSharp.Objects.Mechanical;
 using ACadSharp.Tables;
 using ACadSharp.Tables.Collections;
 using ACadSharp.Types.Units;
@@ -5550,6 +5551,18 @@ namespace ACadSharp.IO.DWG
 
 			switch (c.DxfName)
 			{
+				case DxfFileToken.AcmBom:
+					template = this.readAcmBom();
+					break;
+				case DxfFileToken.AcmBomRow:
+					template = this.readAcmBomRow();
+					break;
+				case DxfFileToken.AcmDataEntryBlock:
+					template = this.readAcmDataEntryBlock();
+					break;
+				case DxfFileToken.AcmDataEntryPart:
+					template = this.readAcmDataEntryPart();
+					break;
 				case DxfFileToken.AcmPartRef:
 					template = this.readAcmPartRef();
 					break;
@@ -6238,6 +6251,166 @@ namespace ACadSharp.IO.DWG
 
 		#endregion Insert methods
 
+		private List<ulong> readRemainingHandleReferences()
+		{
+			List<ulong> handles = new();
+			long endPosition = this._objectInitialPos + (long)(this._size * 8U) - 7L;
+
+			while (this._handlesReader.PositionInBits() < endPosition)
+			{
+				handles.Add(this.handleReference());
+			}
+
+			return handles;
+		}
+
+		private CadTemplate readAcmBom()
+		{
+			AcmBom bom = new AcmBom();
+			CadAcmBomTemplate template = new CadAcmBomTemplate(bom);
+
+			this.readCommonNonEntityData(template);
+
+			int rowCount = this._mergedReaders.ReadBitLong();
+			if (rowCount < 0)
+			{
+				throw new InvalidDataException($"Invalid ACMBOM row count: {rowCount}.");
+			}
+
+			bom.ItemNumberStep = this._mergedReaders.ReadBitLong();
+			bom.IsExpanded = this._mergedReaders.ReadBit();
+
+			for (int i = 0; i < rowCount; i++)
+			{
+				bom.RowNames.Add(this._textReader.ReadVariableText());
+			}
+
+			bom.Name = this._textReader.ReadVariableText();
+			bom.ItemNumberSeparator = this._textReader.ReadVariableText();
+			bom.ItemNumberStart = this._textReader.ReadVariableText();
+
+			for (int i = 0; i < rowCount; i++)
+			{
+				template.RowHandles.Add(this.handleReference());
+			}
+
+			template.PartListHandle = this.handleReference();
+			template.DataEntryHandle = this.handleReference();
+			template.UnknownHandle = this.handleReference();
+
+			return template;
+		}
+
+		private CadTemplate readAcmBomRow()
+		{
+			AcmBomRow row = new AcmBomRow();
+			CadAcmBomRowTemplate template = new CadAcmBomRowTemplate(row);
+
+			this.readCommonNonEntityData(template);
+
+			row.Version = this._mergedReaders.ReadBitLong();
+			row.SortPriority = this._mergedReaders.ReadBitLong();
+			for (int i = 0; i < 6; i++)
+			{
+				row.RawValues.Add(this._mergedReaders.ReadBitLong());
+			}
+
+			row.ItemName = this._textReader.ReadVariableText();
+
+			template.DataEntryHandle = this.handleReference();
+			template.PartReferenceHandles.Add(this.handleReference());
+			template.PartReferenceHandles.Add(this.handleReference());
+			template.BalloonHandles.Add(this.handleReference());
+			template.BalloonHandles.Add(this.handleReference());
+			template.UnknownHandles.Add(this.handleReference());
+			template.UnknownHandles.Add(this.handleReference());
+
+			return template;
+		}
+
+		private CadTemplate readAcmDataEntryPart()
+		{
+			AcmDataEntryPart dataEntry = new AcmDataEntryPart();
+			CadAcmDataEntryPartTemplate template = new CadAcmDataEntryPartTemplate(dataEntry);
+
+			this.readCommonNonEntityData(template);
+
+			dataEntry.Signature = this._mergedReaders.ReadBitLong();
+			dataEntry.Version = this._mergedReaders.ReadBitLong();
+			dataEntry.EntryId = this._mergedReaders.ReadBitLong();
+			int attributeCount = this._mergedReaders.ReadBitLong();
+			if (attributeCount < 0)
+			{
+				throw new InvalidDataException($"Invalid ACMDATAENTRYPART attribute count: {attributeCount}.");
+			}
+
+			int rawAttributeValueCount = 1 + attributeCount * 3;
+			for (int i = 0; i < rawAttributeValueCount; i++)
+			{
+				dataEntry.RawAttributeValues.Add(this._mergedReaders.ReadBitLong());
+			}
+
+			for (int i = 0; i < attributeCount; i++)
+			{
+				dataEntry.Attributes.Add(new AcmDataEntryAttribute
+				{
+					Name = this._textReader.ReadVariableText(),
+					Value = this._textReader.ReadVariableText(),
+					Metadata = this._textReader.ReadVariableText(),
+				});
+			}
+
+			template.PartReferenceHandles.Add(this.handleReference());
+			template.BomRowHandles.Add(this.handleReference());
+			template.PartReferenceHandles.Add(this.handleReference());
+			template.UnknownHandles.Add(this.handleReference());
+			template.UnknownHandles.Add(this.handleReference());
+
+			return template;
+		}
+
+		private CadTemplate readAcmDataEntryBlock()
+		{
+			AcmDataEntryBlock dataEntry = new AcmDataEntryBlock();
+			CadAcmDataEntryBlockTemplate template = new CadAcmDataEntryBlockTemplate(dataEntry);
+
+			this.readCommonNonEntityData(template);
+
+			dataEntry.Signature = this._mergedReaders.ReadBitLong();
+			dataEntry.Version = this._mergedReaders.ReadBitLong();
+			dataEntry.EntryId = this._mergedReaders.ReadBitLong();
+			int attributeCount = this._mergedReaders.ReadBitLong();
+			if (attributeCount < 0)
+			{
+				throw new InvalidDataException($"Invalid ACMDATAENTRYBLOCK attribute count: {attributeCount}.");
+			}
+
+			int rawValueCount = 1 + attributeCount * 3;
+			for (int i = 0; i < rawValueCount; i++)
+			{
+				dataEntry.RawValues.Add(this._mergedReaders.ReadBitLong());
+			}
+
+			for (int i = 0; i < attributeCount; i++)
+			{
+				dataEntry.Attributes.Add(new AcmDataEntryAttribute
+				{
+					Name = this._textReader.ReadVariableText(),
+					Value = this._textReader.ReadVariableText(),
+					Metadata = this._textReader.ReadVariableText(),
+				});
+			}
+
+			dataEntry.DisplayName = this._textReader.ReadVariableText();
+
+			for (int i = 0; i < 3; i++)
+			{
+				template.ReferenceHandles.Add(this.handleReference());
+			}
+
+			return template;
+		}
+
 		private CadTemplate readAcmPartRef()
 		{
 			AcmPartRef partref = new AcmPartRef();
@@ -6247,11 +6420,18 @@ namespace ACadSharp.IO.DWG
 
 			this.readMechanicalEntity(template);
 
-			template.LineResHandle = this.handleReference();
-			template.UnknownHandle1 = this.handleReference();        // 0x0
-			template.DataEntryPartHandle = this.handleReference();
+			List<ulong> handles = this.readRemainingHandleReferences();
+			if (handles.Count >= 2)
+			{
+				template.DataEntryPartHandle = handles[handles.Count - 2];
+				template.LayerHandle = handles[handles.Count - 1];
+			}
 
-			template.LayerHandle = this.handleReference();
+			if (handles.Count >= 4)
+			{
+				template.LineResHandle = handles[0];
+				template.UnknownHandle1 = handles[1];
+			}
 
 			return template;
 		}
@@ -6265,26 +6445,21 @@ namespace ACadSharp.IO.DWG
 
 			this.readMechanicalEntity(template);
 
-			template.BomHandle = this.handleReference();           // ACMBOM:*A1 (AcmBom)
-			template.ItemFilterCustomHandle = this.handleReference();
-
-			// Handles to each data row (excluding the headers) of the BOM table follow.
-			// Then seemingly always 3 handles of value 0x0 follow 
-
-			ulong handle;
-			while (true)
+			List<ulong> handles = this.readRemainingHandleReferences();
+			if (handles.Count > 0)
 			{
-				handle = this.handleReference();
-				if (handle == 0)
-				{
-					break;
-				}
-				template.RowHandles.Add(handle);
+				template.BomHandle = handles[0];
 			}
 
-			// ulong handle: 0x0
-			template.UnknownHandle1 = this.handleReference();        // 0x0
-			template.UnknownHandle2 = this.handleReference();        // 0x0
+			if (handles.Count > 1)
+			{
+				template.ItemFilterCustomHandle = handles[1];
+			}
+
+			for (int i = 2; i < handles.Count; i++)
+			{
+				template.RelatedHandles.Add(handles[i]);
+			}
 
 			return template;
 		}
@@ -6311,10 +6486,17 @@ namespace ACadSharp.IO.DWG
 			var unknown_position1 = this._mergedReaders.Read3BitDouble();
 			var unknown_position2 = this._mergedReaders.Read3BitDouble();
 
-			template.BomRowHandle = this.handleReference();
-			template.BlockHandle = this.handleReference();
-
-			var unknownHandle1 = this.handleReference();        // 0x0
+			List<ulong> handles = this.readRemainingHandleReferences();
+			if (handles.Count >= 4)
+			{
+				template.BomRowHandle = handles[1];
+				template.BlockHandle = handles[2];
+			}
+			else if (handles.Count >= 2)
+			{
+				template.BomRowHandle = handles[0];
+				template.BlockHandle = handles[1];
+			}
 
 			return template;
 		}

--- a/src/ACadSharp/IO/Templates/CadAcmBalloonTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadAcmBalloonTemplate.cs
@@ -1,4 +1,5 @@
 ﻿using ACadSharp.Entities.Mechanical;
+using ACadSharp.Objects.Mechanical;
 using ACadSharp.Tables;
 
 namespace ACadSharp.IO.Templates;
@@ -20,6 +21,15 @@ internal class CadAcmBalloonTemplate : CadMechanicalEntityTemplate<AcmBalloon>
 		if (this.getTableReference(builder, this.BlockHandle, null, out BlockRecord record))
 		{
 			this.CadObject.Block = record;
+		}
+
+		if (builder.TryGetCadObject(this.BomRowHandle, out AcmBomRow row))
+		{
+			this.CadObject.BomRow = row;
+			if (!row.Balloons.Contains(this.CadObject))
+			{
+				row.Balloons.Add(this.CadObject);
+			}
 		}
 	}
 }

--- a/src/ACadSharp/IO/Templates/CadAcmBomRowTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadAcmBomRowTemplate.cs
@@ -1,0 +1,52 @@
+using ACadSharp.Entities.Mechanical;
+using ACadSharp.Objects.Mechanical;
+using System.Collections.Generic;
+
+namespace ACadSharp.IO.Templates;
+
+internal class CadAcmBomRowTemplate : CadTemplate<AcmBomRow>
+{
+	public ulong? DataEntryHandle { get; set; }
+
+	public List<ulong> PartReferenceHandles { get; } = new();
+
+	public List<ulong> BalloonHandles { get; } = new();
+
+	public List<ulong> UnknownHandles { get; } = new();
+
+	public CadAcmBomRowTemplate(AcmBomRow row) : base(row)
+	{
+	}
+
+	protected override void build(CadDocumentBuilder builder)
+	{
+		base.build(builder);
+
+		if (builder.TryGetCadObject(this.DataEntryHandle, out AcmDataEntryPart dataEntry))
+		{
+			this.CadObject.DataEntry = dataEntry;
+			if (!dataEntry.BomRows.Contains(this.CadObject))
+			{
+				dataEntry.BomRows.Add(this.CadObject);
+			}
+		}
+
+		foreach (ulong handle in this.PartReferenceHandles)
+		{
+			if (builder.TryGetCadObject(handle, out AcmPartRef partReference) &&
+				!this.CadObject.PartReferences.Contains(partReference))
+			{
+				this.CadObject.PartReferences.Add(partReference);
+			}
+		}
+
+		foreach (ulong handle in this.BalloonHandles)
+		{
+			if (builder.TryGetCadObject(handle, out AcmBalloon balloon) &&
+				!this.CadObject.Balloons.Contains(balloon))
+			{
+				this.CadObject.Balloons.Add(balloon);
+			}
+		}
+	}
+}

--- a/src/ACadSharp/IO/Templates/CadAcmBomTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadAcmBomTemplate.cs
@@ -1,0 +1,45 @@
+using ACadSharp.Entities.Mechanical;
+using ACadSharp.Objects.Mechanical;
+using System.Collections.Generic;
+
+namespace ACadSharp.IO.Templates;
+
+internal class CadAcmBomTemplate : CadTemplate<AcmBom>
+{
+	public List<ulong> RowHandles { get; } = new();
+
+	public ulong? PartListHandle { get; set; }
+
+	public ulong? DataEntryHandle { get; set; }
+
+	public ulong? UnknownHandle { get; set; }
+
+	public CadAcmBomTemplate(AcmBom bom) : base(bom)
+	{
+	}
+
+	protected override void build(CadDocumentBuilder builder)
+	{
+		base.build(builder);
+
+		foreach (ulong handle in this.RowHandles)
+		{
+			if (builder.TryGetCadObject(handle, out AcmBomRow row) &&
+				!this.CadObject.Rows.Contains(row))
+			{
+				this.CadObject.Rows.Add(row);
+			}
+		}
+
+		if (builder.TryGetCadObject(this.PartListHandle, out AcmPartList partList) &&
+			!this.CadObject.PartLists.Contains(partList))
+		{
+			this.CadObject.PartLists.Add(partList);
+		}
+
+		if (builder.TryGetCadObject(this.DataEntryHandle, out AcmDataEntryBlock dataEntry))
+		{
+			this.CadObject.DataEntry = dataEntry;
+		}
+	}
+}

--- a/src/ACadSharp/IO/Templates/CadAcmDataEntryBlockTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadAcmDataEntryBlockTemplate.cs
@@ -1,0 +1,28 @@
+using ACadSharp.Objects;
+using ACadSharp.Objects.Mechanical;
+using System.Collections.Generic;
+
+namespace ACadSharp.IO.Templates;
+
+internal class CadAcmDataEntryBlockTemplate : CadTemplate<AcmDataEntryBlock>
+{
+	public List<ulong> ReferenceHandles { get; } = new();
+
+	public CadAcmDataEntryBlockTemplate(AcmDataEntryBlock dataEntry) : base(dataEntry)
+	{
+	}
+
+	protected override void build(CadDocumentBuilder builder)
+	{
+		base.build(builder);
+
+		foreach (ulong handle in this.ReferenceHandles)
+		{
+			if (builder.TryGetCadObject(handle, out CadObject reference) &&
+				!this.CadObject.References.Contains(reference))
+			{
+				this.CadObject.References.Add(reference);
+			}
+		}
+	}
+}

--- a/src/ACadSharp/IO/Templates/CadAcmDataEntryPartTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadAcmDataEntryPartTemplate.cs
@@ -1,0 +1,41 @@
+using ACadSharp.Entities.Mechanical;
+using ACadSharp.Objects.Mechanical;
+using System.Collections.Generic;
+
+namespace ACadSharp.IO.Templates;
+
+internal class CadAcmDataEntryPartTemplate : CadTemplate<AcmDataEntryPart>
+{
+	public List<ulong> PartReferenceHandles { get; } = new();
+
+	public List<ulong> BomRowHandles { get; } = new();
+
+	public List<ulong> UnknownHandles { get; } = new();
+
+	public CadAcmDataEntryPartTemplate(AcmDataEntryPart dataEntry) : base(dataEntry)
+	{
+	}
+
+	protected override void build(CadDocumentBuilder builder)
+	{
+		base.build(builder);
+
+		foreach (ulong handle in this.PartReferenceHandles)
+		{
+			if (builder.TryGetCadObject(handle, out AcmPartRef partReference) &&
+				!this.CadObject.PartReferences.Contains(partReference))
+			{
+				this.CadObject.PartReferences.Add(partReference);
+			}
+		}
+
+		foreach (ulong handle in this.BomRowHandles)
+		{
+			if (builder.TryGetCadObject(handle, out AcmBomRow row) &&
+				!this.CadObject.BomRows.Contains(row))
+			{
+				this.CadObject.BomRows.Add(row);
+			}
+		}
+	}
+}

--- a/src/ACadSharp/IO/Templates/CadAcmPartListTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadAcmPartListTemplate.cs
@@ -1,4 +1,6 @@
 ﻿using ACadSharp.Entities.Mechanical;
+using ACadSharp.Objects;
+using ACadSharp.Objects.Mechanical;
 using System.Collections.Generic;
 
 namespace ACadSharp.IO.Templates;
@@ -11,11 +13,57 @@ internal class CadAcmPartListTemplate : CadMechanicalEntityTemplate<AcmPartList>
 
 	public List<ulong> RowHandles { get; set; } = new List<ulong>();
 
+	public List<ulong> RelatedHandles { get; } = new();
+
 	public ulong? UnknownHandle1 { get; set; }
 
 	public ulong? UnknownHandle2 { get; set; }
 
 	public CadAcmPartListTemplate(AcmPartList partList) : base(partList)
 	{
+	}
+
+	protected override void build(CadDocumentBuilder builder)
+	{
+		base.build(builder);
+
+		if (builder.TryGetCadObject(this.BomHandle, out AcmBom bom))
+		{
+			this.CadObject.Bom = bom;
+			if (!bom.PartLists.Contains(this.CadObject))
+			{
+				bom.PartLists.Add(this.CadObject);
+			}
+		}
+
+		if (builder.TryGetCadObject(this.ItemFilterCustomHandle, out CadObject itemFilter))
+		{
+			this.CadObject.ItemFilterCustom = itemFilter;
+		}
+
+		foreach (ulong handle in this.RowHandles)
+		{
+			if (builder.TryGetCadObject(handle, out AcmBomRow row) &&
+				!this.CadObject.Rows.Contains(row))
+			{
+				this.CadObject.Rows.Add(row);
+			}
+		}
+
+		foreach (ulong handle in this.RelatedHandles)
+		{
+			if (builder.TryGetCadObject(handle, out AcmBomRow row))
+			{
+				if (!this.CadObject.Rows.Contains(row))
+				{
+					this.CadObject.Rows.Add(row);
+				}
+			}
+			else if (builder.TryGetCadObject(handle, out CadObject related) &&
+				!this.CadObject.RelatedObjects.Contains(related))
+			{
+				this.CadObject.RelatedObjects.Add(related);
+			}
+		}
 	}
 }

--- a/src/ACadSharp/IO/Templates/CadAcmPartRefTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadAcmPartRefTemplate.cs
@@ -13,4 +13,18 @@ internal class CadAcmPartRefTemplate : CadMechanicalEntityTemplate<AcmPartRef>
 	public CadAcmPartRefTemplate(AcmPartRef partRef) : base(partRef)
 	{
 	}
+
+	protected override void build(CadDocumentBuilder builder)
+	{
+		base.build(builder);
+
+		if (builder.TryGetCadObject(this.DataEntryPartHandle, out Objects.Mechanical.AcmDataEntryPart dataEntry))
+		{
+			this.CadObject.DataEntry = dataEntry;
+			if (!dataEntry.PartReferences.Contains(this.CadObject))
+			{
+				dataEntry.PartReferences.Add(this.CadObject);
+			}
+		}
+	}
 }

--- a/src/ACadSharp/Objects/Mechanical/AcmBom.cs
+++ b/src/ACadSharp/Objects/Mechanical/AcmBom.cs
@@ -1,0 +1,57 @@
+using ACadSharp.Attributes;
+using ACadSharp.Entities.Mechanical;
+using System.Collections.Generic;
+
+namespace ACadSharp.Objects.Mechanical;
+
+/// <summary>
+/// Represents an AutoCAD Mechanical bill of materials.
+/// </summary>
+[DxfName(DxfFileToken.AcmBom)]
+[DxfSubClass(DxfSubclassMarker.Bom)]
+public class AcmBom : NonGraphicalObject
+{
+	public override string ObjectName => DxfFileToken.AcmBom;
+
+	public override string SubclassMarker => DxfSubclassMarker.Bom;
+
+	/// <summary>
+	/// Gets whether this is an expanded BOM rather than a structured BOM.
+	/// </summary>
+	public bool IsExpanded { get; set; }
+
+	/// <summary>
+	/// Gets the increment used to generate item numbers.
+	/// </summary>
+	public int ItemNumberStep { get; set; }
+
+	/// <summary>
+	/// Gets the first generated item number.
+	/// </summary>
+	public string ItemNumberStart { get; set; } = string.Empty;
+
+	/// <summary>
+	/// Gets the separator used in generated item numbers.
+	/// </summary>
+	public string ItemNumberSeparator { get; set; } = string.Empty;
+
+	/// <summary>
+	/// Gets the data container associated with this BOM.
+	/// </summary>
+	public AcmDataEntryBlock DataEntry { get; set; }
+
+	/// <summary>
+	/// Gets the BOM rows in storage order.
+	/// </summary>
+	public List<AcmBomRow> Rows { get; } = new();
+
+	/// <summary>
+	/// Gets the dictionary names corresponding to <see cref="Rows"/>.
+	/// </summary>
+	public List<string> RowNames { get; } = new();
+
+	/// <summary>
+	/// Gets the part-list entities that display this BOM.
+	/// </summary>
+	public List<AcmPartList> PartLists { get; } = new();
+}

--- a/src/ACadSharp/Objects/Mechanical/AcmBomRow.cs
+++ b/src/ACadSharp/Objects/Mechanical/AcmBomRow.cs
@@ -1,0 +1,52 @@
+using ACadSharp.Attributes;
+using ACadSharp.Entities.Mechanical;
+using System.Collections.Generic;
+
+namespace ACadSharp.Objects.Mechanical;
+
+/// <summary>
+/// Represents an item in an AutoCAD Mechanical bill of materials.
+/// </summary>
+[DxfName(DxfFileToken.AcmBomRow)]
+[DxfSubClass(DxfSubclassMarker.BomRow)]
+public class AcmBomRow : NonGraphicalObject
+{
+	public override string ObjectName => DxfFileToken.AcmBomRow;
+
+	public override string SubclassMarker => DxfSubclassMarker.BomRow;
+
+	/// <summary>
+	/// Gets the Mechanical serialization version.
+	/// </summary>
+	public int Version { get; set; }
+
+	/// <summary>
+	/// Gets the item name displayed by the BOM.
+	/// </summary>
+	public string ItemName { get; set; } = string.Empty;
+
+	/// <summary>
+	/// Gets the row sort priority.
+	/// </summary>
+	public int SortPriority { get; set; }
+
+	/// <summary>
+	/// Gets numeric fields whose semantics are not documented by the public Mechanical API.
+	/// </summary>
+	public List<int> RawValues { get; } = new();
+
+	/// <summary>
+	/// Gets the part data associated with this row.
+	/// </summary>
+	public AcmDataEntryPart DataEntry { get; set; }
+
+	/// <summary>
+	/// Gets the part references associated with this row.
+	/// </summary>
+	public List<AcmPartRef> PartReferences { get; } = new();
+
+	/// <summary>
+	/// Gets the balloons associated with this row.
+	/// </summary>
+	public List<AcmBalloon> Balloons { get; } = new();
+}

--- a/src/ACadSharp/Objects/Mechanical/AcmDataEntryAttribute.cs
+++ b/src/ACadSharp/Objects/Mechanical/AcmDataEntryAttribute.cs
@@ -1,0 +1,16 @@
+namespace ACadSharp.Objects.Mechanical;
+
+/// <summary>
+/// A named value stored by an AutoCAD Mechanical data entry.
+/// </summary>
+public class AcmDataEntryAttribute
+{
+	public string Name { get; set; } = string.Empty;
+
+	public string Value { get; set; } = string.Empty;
+
+	/// <summary>
+	/// Gets the optional third string stored with the name and value.
+	/// </summary>
+	public string Metadata { get; set; } = string.Empty;
+}

--- a/src/ACadSharp/Objects/Mechanical/AcmDataEntryBlock.cs
+++ b/src/ACadSharp/Objects/Mechanical/AcmDataEntryBlock.cs
@@ -1,0 +1,30 @@
+using ACadSharp.Attributes;
+using System.Collections.Generic;
+
+namespace ACadSharp.Objects.Mechanical;
+
+/// <summary>
+/// Contains table-level data for an AutoCAD Mechanical BOM.
+/// </summary>
+[DxfName(DxfFileToken.AcmDataEntryBlock)]
+[DxfSubClass(DxfSubclassMarker.DataEntryBlock)]
+public class AcmDataEntryBlock : NonGraphicalObject
+{
+	public override string ObjectName => DxfFileToken.AcmDataEntryBlock;
+
+	public override string SubclassMarker => DxfSubclassMarker.DataEntryBlock;
+
+	public int Signature { get; set; }
+
+	public int Version { get; set; }
+
+	public int EntryId { get; set; }
+
+	public string DisplayName { get; set; } = string.Empty;
+
+	public List<AcmDataEntryAttribute> Attributes { get; } = new();
+
+	public List<int> RawValues { get; } = new();
+
+	public List<CadObject> References { get; } = new();
+}

--- a/src/ACadSharp/Objects/Mechanical/AcmDataEntryPart.cs
+++ b/src/ACadSharp/Objects/Mechanical/AcmDataEntryPart.cs
@@ -1,0 +1,31 @@
+using ACadSharp.Attributes;
+using ACadSharp.Entities.Mechanical;
+using System.Collections.Generic;
+
+namespace ACadSharp.Objects.Mechanical;
+
+/// <summary>
+/// Contains the attribute values for an AutoCAD Mechanical part.
+/// </summary>
+[DxfName(DxfFileToken.AcmDataEntryPart)]
+[DxfSubClass(DxfSubclassMarker.DataEntryPart)]
+public class AcmDataEntryPart : NonGraphicalObject
+{
+	public override string ObjectName => DxfFileToken.AcmDataEntryPart;
+
+	public override string SubclassMarker => DxfSubclassMarker.DataEntryPart;
+
+	public int Signature { get; set; }
+
+	public int Version { get; set; }
+
+	public int EntryId { get; set; }
+
+	public List<AcmDataEntryAttribute> Attributes { get; } = new();
+
+	public List<int> RawAttributeValues { get; } = new();
+
+	public List<AcmPartRef> PartReferences { get; } = new();
+
+	public List<AcmBomRow> BomRows { get; } = new();
+}


### PR DESCRIPTION
# Description

Adds DWG read support for AutoCAD Mechanical BOM data. It registers and reads `ACMBOM`, `ACMBOMROW`, `ACMDATAENTRYBLOCK`, and `ACMDATAENTRYPART`, then resolves their relationships with part references, balloons, and part lists.

This follows the Mechanical entity support introduced in #1123 and exposes structured BOM data instead of leaving these objects unread.

# Tasks done in this PR

* [x] Added public object models and DXF class metadata for Mechanical BOM and data-entry objects.
* [x] Added DWG reader templates and relationship resolution for BOM rows, part references, balloons, and part lists.
* [x] Made Mechanical entity handle parsing consume the complete handle section.
* [x] Added model and metadata tests for the new objects.

# Related Issues / Pull Requests

- Follow-up to #1123.

# Notes for reviewer

- The decoded layout was validated with a private AC1032 AutoCAD Mechanical drawing containing one BOM and three rows. The fixture is not included because it contains proprietary drawing data.
- Integer fields that are not documented by the public Mechanical format are retained in `RawValues` and `RawAttributeValues` for forward analysis.
- The new `AcmBomTests` pass on both `net9.0` and `net48` (3/3 on each target).
- Local full-suite runs produced the same result on both targets: 2319 passed, 2 skipped, and 17 failures in existing DXF dictionary and MultiLeader round-trip cases outside the Mechanical BOM paths.