### PR TITLE
A value a damaged drawing carries costs the value, not the entity

### DIFF
--- a/src/ACadSharp.Tests/IO/DamagedValueTests.cs
+++ b/src/ACadSharp.Tests/IO/DamagedValueTests.cs
@@ -1,0 +1,100 @@
+﻿using ACadSharp.Entities;
+using ACadSharp.IO;
+using ACadSharp.Tables;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace ACadSharp.Tests.IO;
+
+/// <summary>
+/// A drawing that AutoCAD opens - repairing it as it goes - must not cost entities here. The
+/// values used are the ones real drawings carry: a scale of 0 on a block reference, which AutoCAD
+/// repairs and keeps.
+/// </summary>
+public class DamagedValueTests
+{
+	public static TheoryData<ACadVersion> Versions => new TheoryData<ACadVersion>
+	{
+		ACadVersion.AC1015,
+		ACadVersion.AC1018,
+		ACadVersion.AC1024,
+		ACadVersion.AC1032,
+	};
+
+	[Theory]
+	[MemberData(nameof(Versions))]
+	public void DwgKeepsAnInsertWithAZeroScale(ACadVersion version)
+	{
+		CadDocument doc = this.documentWithZeroScale(version, "_zscale");
+
+		MemoryStream ms = new MemoryStream();
+		using (DwgWriter writer = new DwgWriter(ms, doc))
+		{
+			writer.Write();
+		}
+
+		CadDocument read = DwgReader.Read(new MemoryStream(ms.ToArray()));
+		Insert insert = read.Entities.OfType<Insert>().Single();
+		Assert.Equal("my_block", insert.Block.Name);
+		Assert.Equal(1, insert.ZScale);
+	}
+
+	[Theory]
+	[MemberData(nameof(Versions))]
+	public void DwgKeepsAnInsertWithAZeroXScale(ACadVersion version)
+	{
+		CadDocument doc = this.documentWithZeroScale(version, "_xscale");
+
+		MemoryStream ms = new MemoryStream();
+		using (DwgWriter writer = new DwgWriter(ms, doc))
+		{
+			writer.Write();
+		}
+
+		CadDocument read = DwgReader.Read(new MemoryStream(ms.ToArray()));
+		Insert insert = read.Entities.OfType<Insert>().Single();
+		Assert.Equal(1, insert.XScale);
+	}
+
+	[Theory]
+	[MemberData(nameof(Versions))]
+	public void DxfKeepsAnInsertWithAZeroScale(ACadVersion version)
+	{
+		CadDocument doc = this.documentWithZeroScale(version, "_zscale");
+
+		MemoryStream ms = new MemoryStream();
+		using (DxfWriter writer = new DxfWriter(ms, doc, false))
+		{
+			writer.Write();
+		}
+
+		CadDocument read = DxfReader.Read(new MemoryStream(ms.ToArray()));
+		Insert insert = read.Entities.OfType<Insert>().Single();
+		Assert.Equal("my_block", insert.Block.Name);
+		Assert.Equal(1, insert.ZScale);
+	}
+
+	private CadDocument documentWithZeroScale(ACadVersion version, string field)
+	{
+		CadDocument doc = new CadDocument();
+		doc.Header.Version = version;
+
+		BlockRecord block = new BlockRecord("my_block");
+		block.Entities.Add(new Line(new CSMath.XYZ(0, 0, 0), new CSMath.XYZ(10, 10, 0)));
+		doc.BlockRecords.Add(block);
+
+		Insert insert = new Insert(block);
+		doc.Entities.Add(insert);
+
+		//The property refuses a scale of 0 on purpose - a drawing carrying one is damaged. The
+		//point of the test is what happens when a file holds it anyway, so the field is set
+		//directly, which is the only way to build that file from this side.
+		typeof(Insert)
+			.GetField(field, BindingFlags.Instance | BindingFlags.NonPublic)
+			.SetValue(insert, 0.0);
+
+		return doc;
+	}
+}

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -3746,7 +3746,24 @@ namespace ACadSharp.IO.DWG
 					//Background color CMC 63
 					mtext.BackgroundColor = this._mergedReaders.ReadCmColor();
 					//Background transparency BL 441
-					mtext.BackgroundTransparency = new Transparency((short)this._objectReader.ReadBitLong());
+					//The field is a raw 32 bit value, not the 0-90 percentage the model holds:
+					//AutoCAD writes 843012 for one MTEXT of a real drawing, which cast to a short
+					//is -8956 and cost the whole entity. What cannot be represented is dropped -
+					//the text is worth more than a background transparency AutoCAD does not
+					//implement anyway. The DXF reader already keeps such an MTEXT.
+					int backgroundTransparency = this._objectReader.ReadBitLong();
+					if (backgroundTransparency == -1
+						|| backgroundTransparency == 100
+						|| (backgroundTransparency >= 0 && backgroundTransparency <= 90))
+					{
+						mtext.BackgroundTransparency = new Transparency((short)backgroundTransparency);
+					}
+					else
+					{
+						this._builder.Notify(
+							$"MText with handle {mtext.Handle} carries a background transparency of {backgroundTransparency}, which the model cannot represent; the value is dropped and the entity kept",
+							NotificationType.Warning);
+					}
 				}
 			}
 
@@ -6116,6 +6133,24 @@ namespace ACadSharp.IO.DWG
 			return template;
 		}
 
+		//A scale of 0 is not something the model accepts, and a drawing that carries one loses the
+		//whole block reference on the way in - 110 of them in one drawing AutoCAD opens. AutoCAD
+		//repairs the scale and keeps the reference (its own DXF of that drawing has no 43 = 0
+		//anywhere), so the reader does the same and says so.
+		private double insertScaleOrOne(double value, string axis, Insert insert)
+		{
+			if (!value.Equals(0))
+			{
+				return value;
+			}
+
+			this._builder.Notify(
+				$"Insert with handle {insert.Handle} carries a {axis} of 0 and is read with 1; the block reference would be lost otherwise",
+				NotificationType.Warning);
+
+			return 1;
+		}
+
 		private void readInsertCommonData(CadInsertTemplate template)
 		{
 			Insert insert = template.CadObject as Insert;
@@ -6130,11 +6165,11 @@ namespace ACadSharp.IO.DWG
 			{
 				XYZ scale = this._objectReader.Read3BitDouble();
 				//X Scale BD 41
-				insert.XScale = scale.X;
+				insert.XScale = this.insertScaleOrOne(scale.X, "X scale", insert);
 				//Y Scale BD 42
-				insert.YScale = scale.Y;
+				insert.YScale = this.insertScaleOrOne(scale.Y, "Y scale", insert);
 				//Z Scale BD 43
-				insert.ZScale = scale.Z;
+				insert.ZScale = this.insertScaleOrOne(scale.Z, "Z scale", insert);
 			}
 
 			//R2000 + Only:
@@ -6146,18 +6181,18 @@ namespace ACadSharp.IO.DWG
 				{
 					//00 – 41 value stored as a RD, followed by a 42 value stored as DD (use 41 for default value), and a 43 value stored as a DD(use 41 value for default value).
 					case 0:
-						insert.XScale = this._objectReader.ReadDouble();
-						insert.YScale = this._objectReader.ReadBitDoubleWithDefault(insert.XScale);
-						insert.ZScale = this._objectReader.ReadBitDoubleWithDefault(insert.XScale);
+						insert.XScale = this.insertScaleOrOne(this._objectReader.ReadDouble(), "X scale", insert);
+						insert.YScale = this.insertScaleOrOne(this._objectReader.ReadBitDoubleWithDefault(insert.XScale), "Y scale", insert);
+						insert.ZScale = this.insertScaleOrOne(this._objectReader.ReadBitDoubleWithDefault(insert.XScale), "Z scale", insert);
 						break;
 					//01 – 41 value is 1.0, 2 DD’s are present, each using 1.0 as the default value, representing the 42 and 43 values.
 					case 1:
-						insert.YScale = this._objectReader.ReadBitDoubleWithDefault(insert.XScale);
-						insert.ZScale = this._objectReader.ReadBitDoubleWithDefault(insert.XScale);
+						insert.YScale = this.insertScaleOrOne(this._objectReader.ReadBitDoubleWithDefault(insert.XScale), "Y scale", insert);
+						insert.ZScale = this.insertScaleOrOne(this._objectReader.ReadBitDoubleWithDefault(insert.XScale), "Z scale", insert);
 						break;
 					//10 – 41 value stored as a RD, and 42 & 43 values are not stored, assumed equal to 41 value.
 					case 2:
-						double xyz = this._objectReader.ReadDouble();
+						double xyz = this.insertScaleOrOne(this._objectReader.ReadDouble(), "scale", insert);
 						insert.XScale = xyz;
 						insert.YScale = xyz;
 						insert.ZScale = xyz;

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -6181,9 +6181,17 @@ namespace ACadSharp.IO.DWG
 				{
 					//00 – 41 value stored as a RD, followed by a 42 value stored as DD (use 41 for default value), and a 43 value stored as a DD(use 41 value for default value).
 					case 0:
-						insert.XScale = this.insertScaleOrOne(this._objectReader.ReadDouble(), "X scale", insert);
-						insert.YScale = this.insertScaleOrOne(this._objectReader.ReadBitDoubleWithDefault(insert.XScale), "Y scale", insert);
-						insert.ZScale = this.insertScaleOrOne(this._objectReader.ReadBitDoubleWithDefault(insert.XScale), "Z scale", insert);
+						{
+							//The 42 and 43 values are DD-encoded against the raw 41 value: codes 01 and
+							//10 patch bytes INTO the default, so the default has to be the file's X,
+							//not the repaired one. Read all three raw, repair after.
+							double rawX = this._objectReader.ReadDouble();
+							double rawY = this._objectReader.ReadBitDoubleWithDefault(rawX);
+							double rawZ = this._objectReader.ReadBitDoubleWithDefault(rawX);
+							insert.XScale = this.insertScaleOrOne(rawX, "X scale", insert);
+							insert.YScale = this.insertScaleOrOne(rawY, "Y scale", insert);
+							insert.ZScale = this.insertScaleOrOne(rawZ, "Z scale", insert);
+						}
 						break;
 					//01 – 41 value is 1.0, 2 DD’s are present, each using 1.0 as the default value, representing the 42 and 43 values.
 					case 1:

--- a/src/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
@@ -997,6 +997,34 @@ internal abstract class DxfSectionReaderBase
 				return true;
 			case 66:
 				return true;
+			case 41:
+			case 42:
+			case 43:
+				//A scale of 0 is refused by the model, and refusing it here costs the whole block
+				//reference. AutoCAD repairs the scale and keeps the reference, so this does too.
+				double scale = this._reader.ValueAsDouble;
+				Insert insert = (Insert)template.CadObject;
+				if (scale.Equals(0))
+				{
+					this._builder.Notify(
+						$"Insert with handle {insert.Handle} carries a scale of 0 in group {this._reader.Code} and is read with 1; the block reference would be lost otherwise",
+						NotificationType.Warning);
+					scale = 1;
+				}
+
+				switch (this._reader.Code)
+				{
+					case 41:
+						insert.XScale = scale;
+						break;
+					case 42:
+						insert.YScale = scale;
+						break;
+					default:
+						insert.ZScale = scale;
+						break;
+				}
+				return true;
 			default:
 				return this.tryAssignCurrentValue(template.CadObject, map.SubClasses[DxfSubclassMarker.Insert]);
 		}


### PR DESCRIPTION
﻿
# Description

Fourteen production drawings were read for the first time. They raised **243 errors**, and every
one of them was an entity thrown away:

```
110 + 80 + 52   Could not read INSERT   ZScale value must be none zero
          1     Could not read MTEXT    Transparency must be in range from 0 to 90
```

The drawings *are* damaged â€” AutoCAD's `AUDIT` reports 214 errors repaired on one of them. But
AutoCAD repairs the scale and **keeps the block reference**:

| in one 3 MB drawing | |
|---|---|
| `INSERT` entities in AutoCAD's own DXF of it | **5,070** |
| `INSERT` entities this library read | **4,960** |
| difference | **110** â€” exactly the 110 errors |
| group 43 entries equal to 0 in AutoCAD's DXF | **none**: it repaired every one |

A block reference is drawn geometry. Losing 110 of them loses part of the drawing, quietly, and the
file still opens cleanly afterwards â€” nothing downstream can tell.

So the readers now do what AutoCAD does: **a scale of 0 is read as 1, and said out loud**.

| where | before | after |
|---|---|---|
| `DwgObjectReader.readInsertCommonData` | assigns the file's value into a property that refuses 0, losing the whole entity | reads 0 as 1 with a warning naming the handle and the axis |
| `DxfSectionReaderBase.readInsert` | the failure is caught per property: the entity survives, the scale is lost under a message that names neither | the same reading as the DWG path, and the same warning |

The transparency is the same mistake in a different shape. The DWG field behind group 441 is a raw
32 bit value, not the 0â€“90 percentage the model holds: AutoCAD writes **843012** for that MTEXT,
which cast to a `short` is **-8956**. What cannot be represented is now dropped; the text stays.
(The DXF reader already keeps such an MTEXT â€” reading AutoCAD's own DXF of that drawing raises no
error at all.)

**Worth knowing for both**: with `Failsafe` off, the first of those inserts ended the read of the
whole drawing with an exception. Nothing in the file was unreadable â€” the model was refusing what
the file said.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`DamagedValueTests`: an insert whose scale is 0 *in the file* â€” the property refuses 0 on purpose,
so the test sets the field directly, which is the only way to build such a file from this side â€”
round tripped through DWG at AC1015, AC1018, AC1024 and AC1032, and through DXF. **12 tests, 8 red
before this change and all 12 green after.** The four DXF cases were green before, because that path
lost the value rather than the entity; they now also assert the value.

Whole suite: 2,548 passed / 0 failed, with AutoCAD `AUDIT` reporting 0 errors on all five generated
files. Across a 17 drawing corpus, reading now raises **0 errors** where four drawings raised 243.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

