### PR TITLE
A region is written back, with the ACIS payload it was read with

### DIFF
--- a/src/ACadSharp.Tests/IO/RegionWriteTests.cs
+++ b/src/ACadSharp.Tests/IO/RegionWriteTests.cs
@@ -1,0 +1,204 @@
+using ACadSharp.Entities;
+using ACadSharp.IO;
+using ACadSharp.Tests.Common;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace ACadSharp.Tests.IO;
+
+/// <summary>
+/// A region is an ACIS entity: the reader keeps its payload, and until now no writer put it back.
+/// Measured on a production drawing with 32 of them, through AutoCAD 2027: AutoCAD's own export of
+/// the drawing has 32 REGION, its export of the file this library wrote had 0. Eight of seventeen
+/// production drawings carry regions, 846 in all, and 845 of those come with a full payload.
+/// </summary>
+public class RegionWriteTests
+{
+	private static string sampleR2018 => Path.Combine(TestVariables.SamplesFolder, "sample_AC1032_ascii.dxf");
+
+	private static string sampleR2000 => Path.Combine(TestVariables.SamplesFolder, "sample_AC1015_ascii.dxf");
+
+	//The oldest sample whose region carries the binary payload; R2000 files carry SAT text instead.
+	private static string sampleR2004 => Path.Combine(TestVariables.SamplesFolder, "sample_AC1018.dwg");
+
+	[Fact]
+	public void RegionSurvivesADxfRoundTrip()
+	{
+		CadDocument doc = DxfReader.Read(sampleR2018);
+		Region[] before = this.regions(doc);
+		Assert.NotEmpty(before);
+
+		CadDocument back = this.roundTrip(doc);
+
+		Region[] after = this.regions(back);
+		Assert.Equal(before.Length, after.Length);
+		for (int i = 0; i < before.Length; i++)
+		{
+			Assert.Equal(before[i].AcisData, after[i].AcisData);
+		}
+	}
+
+	[Fact]
+	public void ThePayloadIsWrittenToTheAcdsSectionInR2013Plus()
+	{
+		//R2013+ keeps the geometry out of the entity: the entity says it has a payload, the ACDSDATA
+		//section carries it, keyed by the entity's handle.
+		CadDocument doc = DxfReader.Read(sampleR2018);
+		Region region = this.regions(doc).First();
+
+		string text = this.write(doc);
+
+		Assert.Contains("ACDSDATA", text);
+		Assert.Contains("ASM_Data", text);
+		Assert.Contains(region.Handle.ToString("X"), text);
+	}
+
+	[Fact]
+	public void ABinaryPayloadIsLeftOutOfAPreR2013FileAndSaidSo()
+	{
+		//Before R2013 the payload has to be character-swapped SAT text inside the entity, and a
+		//binary SAB payload cannot be turned into one. Writing the region empty would leave a handle
+		//with no shape, so it is left out - and the reason is reported rather than left to be found.
+		CadDocument doc = DxfReader.Read(sampleR2018);
+		Region region = this.regions(doc).First();
+		if (!region.IsBinaryAcisData)
+		{
+			//The upstream sample carries SAT text; make the case the production drawings show.
+			region.AcisData = System.Text.Encoding.ASCII.GetBytes("ACIS BinaryFile-not-really-text");
+		}
+
+		doc.Header.Version = ACadVersion.AC1015;
+		string reported = null;
+		using MemoryStream stream = new();
+		using (DxfWriter writer = new(stream, doc, false))
+		{
+			writer.OnNotification += (s, e) => { if (e.Message.Contains("binary ACIS payload")) reported = e.Message; };
+			writer.Write();
+		}
+
+		Assert.NotNull(reported);
+		string text = System.Text.Encoding.UTF8.GetString(stream.ToArray());
+		Assert.DoesNotContain("\nREGION\n", text.Replace("\r", string.Empty));
+	}
+
+	[Fact]
+	public void ASatPayloadIsWrittenInsideThePreR2013Entity()
+	{
+		CadDocument doc = DxfReader.Read(sampleR2000);
+		Region[] before = this.regions(doc);
+		Assert.NotEmpty(before);
+		Assert.False(before[0].IsBinaryAcisData);
+
+		doc.Header.Version = ACadVersion.AC1015;
+		CadDocument back = this.roundTrip(doc);
+
+		Region[] after = this.regions(back);
+		Assert.Equal(before.Length, after.Length);
+		Assert.Equal(before[0].AcisData, after[0].AcisData);
+	}
+
+	[Theory]
+	[InlineData(ACadVersion.AC1018)]
+	[InlineData(ACadVersion.AC1024)]
+	public void ABinaryPayloadSurvivesADwgRoundTrip(ACadVersion version)
+	{
+		//R2004 and R2010 keep the payload inside the entity. Measured in AutoCAD 2027 on a
+		//production drawing with 32 regions: written at either version the drawing opens, audits to
+		//the same 5 errors it audited to before the change, and AutoCAD's own export of it has all
+		//32 regions back.
+		CadDocument doc = DwgReader.Read(sampleR2004);
+		Region[] before = this.regions(doc);
+		Assert.NotEmpty(before);
+		Assert.True(before[0].IsBinaryAcisData);
+
+		doc.Header.Version = version;
+		using MemoryStream stream = new();
+		using (DwgWriter writer = new(stream, doc))
+		{
+			writer.Write();
+		}
+
+		Region[] after = this.regions(DwgReader.Read(new MemoryStream(stream.ToArray())));
+		Assert.Equal(before.Length, after.Length);
+		Assert.Equal(before[0].AcisData, after[0].AcisData);
+	}
+
+	[Theory]
+	[InlineData(ACadVersion.AC1015)]
+	[InlineData(ACadVersion.AC1032)]
+	public void TheVersionsThatCannotCarryThePayloadLeaveTheRegionOutAndSaySo(ACadVersion version)
+	{
+		//R2000 wants SAT text in the entity and refuses every file this writer produced that way;
+		//R2013+ wants the payload in the AcDs data section, which this writer does not produce. A
+		//region without its geometry is a handle with no shape, so it is left out - said, not hidden.
+		CadDocument doc = DwgReader.Read(sampleR2004);
+		Assert.NotEmpty(this.regions(doc));
+
+		doc.Header.Version = version;
+		string reported = null;
+		using MemoryStream stream = new();
+		using (DwgWriter writer = new(stream, doc))
+		{
+			writer.OnNotification += (s, e) => { if (e.Message.Contains("is not written to a")) reported = e.Message; };
+			writer.Write();
+		}
+
+		Assert.NotNull(reported);
+		Assert.Empty(this.regions(DwgReader.Read(new MemoryStream(stream.ToArray()))));
+	}
+
+	[Theory]
+	[InlineData(ACadVersion.AC1018)]
+	[InlineData(ACadVersion.AC1024)]
+	[InlineData(ACadVersion.AC1032)]
+	public void ARegionWithNoGeometryIsNotWrittenToADwg(ACadVersion version)
+	{
+		//A region read from an R2013+ DWG has no payload: the geometry is in the AcDs data section,
+		//which the reader does not read. Written as an empty region it is a handle with no shape,
+		//and AutoCAD refuses the whole drawing - `sample_AC1032` round-tripped to R2018 would not
+		//open at all until this case was caught.
+		CadDocument doc = DwgReader.Read(sampleR2004);
+		Region region = this.regions(doc).First();
+		region.AcisData = null;
+
+		doc.Header.Version = version;
+		using MemoryStream stream = new();
+		using (DwgWriter writer = new(stream, doc))
+		{
+			writer.Write();
+		}
+
+		Assert.Empty(this.regions(DwgReader.Read(new MemoryStream(stream.ToArray()))));
+	}
+
+	private Region[] regions(CadDocument doc)
+	{
+		return doc.BlockRecords
+			.SelectMany(b => b.Entities.OfType<Region>())
+			.OrderBy(r => r.Handle)
+			.ToArray();
+	}
+
+	private string write(CadDocument doc)
+	{
+		using MemoryStream stream = new();
+		using (DxfWriter writer = new(stream, doc, false))
+		{
+			writer.Write();
+		}
+
+		return System.Text.Encoding.UTF8.GetString(stream.ToArray());
+	}
+
+	private CadDocument roundTrip(CadDocument doc)
+	{
+		using MemoryStream stream = new();
+		using (DxfWriter writer = new(stream, doc, false))
+		{
+			writer.Write();
+		}
+
+		return DxfReader.Read(new MemoryStream(stream.ToArray()));
+	}
+}

--- a/src/ACadSharp.Tests/IO/RegionWriteTests.cs
+++ b/src/ACadSharp.Tests/IO/RegionWriteTests.cs
@@ -172,6 +172,16 @@ public class RegionWriteTests
 		Assert.Empty(this.regions(DwgReader.Read(new MemoryStream(stream.ToArray()))));
 	}
 
+	[Fact]
+	public void ARegionWithNoGeometryIsNotWrittenToADxfEither()
+	{
+		CadDocument doc = DxfReader.Read(sampleR2018);
+		Region region = this.regions(doc).First();
+		region.AcisData = null;
+
+		Assert.Empty(this.regions(this.roundTrip(doc)));
+	}
+
 	private Region[] regions(CadDocument doc)
 	{
 		return doc.BlockRecords

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Entities.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Entities.cs
@@ -615,6 +615,9 @@ internal partial class DwgObjectWriter : DwgSectionIO
 			case Solid solid:
 				this.writeSolid(solid);
 				break;
+			case Region region:
+				this.writeModelerGeometry(region);
+				break;
 			case Solid3D solid3d:
 				this.writeSolid3D(solid3d);
 				break;
@@ -2200,6 +2203,48 @@ internal partial class DwgObjectWriter : DwgSectionIO
 
 		//Extrusion BE 210
 		this._writer.WriteBitExtrusion(solid.Normal);
+	}
+
+	private void writeModelerGeometry(ModelerGeometry geometry)
+	{
+		//Before R2013 the ACIS payload sits in the entity itself. The bit says whether it is
+		//*absent*: 0 means the data follows right here and the entity ends with it, which is the
+		//shape the reader expects and the shortest one that carries the geometry. Wireframe and
+		//silhouette data - isolines AutoCAD regenerates on open - are not written.
+		bool hasPayload = geometry.AcisData != null && geometry.AcisData.Length > 0;
+		if (!this.R2013Plus)
+		{
+			this._writer.WriteBit(!hasPayload);
+			if (hasPayload)
+			{
+				this.writeModelerGeometryData(geometry);
+			}
+		}
+
+		//Wireframe data present. This follows the payload rather than ending the entity: the reader
+		//here stops at the end-of-ACIS marker and does not care what comes after, but AutoCAD reads
+		//on, and a file that stopped short of this bit was refused before it finished loading.
+		this._writer.WriteBit(false);
+
+		if (this.R2007Plus)
+		{
+			//Unknown BL
+			this._writer.WriteBitLong(0);
+		}
+	}
+
+	private void writeModelerGeometryData(ModelerGeometry geometry)
+	{
+		//Unknown bit
+		this._writer.WriteBit(false);
+
+		//Version 2: the payload follows raw, and the reader finds its end by the end-of-ACIS marker
+		//inside it. Version 1 - the character-swapped SAT text in length-prefixed blocks, which is
+		//what R2000 files carry - is not written: written that way, in one block or one block per
+		//line, AutoCAD refuses to open the drawing at all, and a region no one can open is worse
+		//than a region that says it was left out. isEntitySupported keeps those entities out.
+		this._writer.WriteBitShort(2);
+		this._writer.WriteBytes(geometry.AcisData);
 	}
 
 	private void writeSolid3D(Solid3D solid)

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.cs
@@ -153,12 +153,50 @@ internal partial class DwgObjectWriter : DwgSectionIO
 			case ProxyEntity:
 			case Solid3D:
 			case CadBody:
-			case Region:
 				this.notify($"Entity type not implemented {entity.GetType().FullName}", NotificationType.NotImplemented);
+				return false;
+			//A region is only worth writing with its geometry, and there is exactly one way to carry
+			//that geometry in a DWG this writer can produce: the binary payload inside the entity, at
+			//R2004 to R2010. Every other case was measured against AutoCAD 2027 and refused:
+			//  R2013+ : the payload belongs in the AcDs data section, which this writer does not
+			//           produce. A region written there without one - which is what a region read
+			//           from an R2013+ file has, since its payload never reached the reader - makes
+			//           AutoCAD refuse the whole drawing.
+			//  R2000  : wants SAT text in the entity, in length-prefixed blocks; written that way, in
+			//           one block or one block per line, AutoCAD refuses the drawing as well.
+			//  SAT    : same, at any version - the corpus has none, every region in it is binary.
+			case Region regionEntity when !this.canWriteRegion(regionEntity):
+				this.notify(
+					$"Region {regionEntity.Handle} is not written to a {this._version} file: {this.whyNotWritten(regionEntity)}. {ACadVersion.AC1018} to {ACadVersion.AC1024} keep it.",
+					NotificationType.NotImplemented);
 				return false;
 			default:
 				return true;
 		}
+	}
+
+	private bool canWriteRegion(Region region)
+	{
+		return region.AcisData != null
+			&& region.AcisData.Length > 0
+			&& region.IsBinaryAcisData
+			&& this._version >= ACadVersion.AC1018
+			&& !this.R2013Plus;
+	}
+
+	private string whyNotWritten(Region region)
+	{
+		if (region.AcisData == null || region.AcisData.Length == 0)
+		{
+			return "it has no geometry to write, and an empty one is a handle with no shape";
+		}
+
+		if (!region.IsBinaryAcisData)
+		{
+			return "its geometry is SAT text, which this writer does not put back into a DWG";
+		}
+
+		return "that version does not carry the geometry inside the entity";
 	}
 
 	private void registerObject(CadObject cadObject)

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfAcdsDataSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfAcdsDataSectionWriter.cs
@@ -1,0 +1,170 @@
+using ACadSharp.Entities;
+using ACadSharp.IO.DXF.DxfStreamWriter;
+using ACadSharp.Tables;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ACadSharp.IO.DXF;
+
+/// <summary>
+/// Writes the ACDSDATA section of an R2013+ DXF: the ACIS payload of every modeler geometry entity
+/// in the document, keyed by the entity's handle.
+/// </summary>
+/// <remarks>
+/// From R2013 on AutoCAD moved the geometry out of the entity, which is why a region written
+/// without this section is a handle with no shape. The schema block below is fixed boilerplate,
+/// copied group for group from AutoCAD's own export of a production drawing; only the records that
+/// follow it carry anything of this document.
+/// </remarks>
+internal class DxfAcdsDataSectionWriter : DxfSectionWriterBase
+{
+	public override string SectionName { get { return DxfFileToken.AcdsDataSection; } }
+
+	private readonly IList<ModelerGeometry> _entities;
+
+	public DxfAcdsDataSectionWriter(
+		IDxfStreamWriter writer,
+		CadDocument document,
+		CadObjectHolder holder,
+		DxfWriterConfiguration configuration,
+		IList<ModelerGeometry> entities)
+		: base(writer, document, holder, configuration)
+	{
+		this._entities = entities;
+	}
+
+	/// <summary>
+	/// The modeler geometry entities of a document that have a payload to write, in handle order.
+	/// </summary>
+	/// <remarks>
+	/// Regions only: a record here names the entity that owns it, and the other modeler geometry
+	/// types are not written to the entities section at all - a record for one of those would point
+	/// at a handle the file does not contain.
+	/// </remarks>
+	public static IList<ModelerGeometry> CollectEntities(CadDocument document)
+	{
+		var found = new List<ModelerGeometry>();
+		foreach (BlockRecord record in document.BlockRecords)
+		{
+			foreach (Region region in record.Entities.OfType<Region>())
+			{
+				if (region.AcisData != null
+					&& region.AcisData.Length > 0
+					&& region.IsValid(CadFileFormat.DXF, document.Header.Version))
+				{
+					found.Add(region);
+				}
+			}
+		}
+
+		return found.OrderBy(e => e.Handle).ToList();
+	}
+
+	protected override void writeSection()
+	{
+		this._writer.Write(70, 2);
+		this._writer.Write(71, 8);
+
+		this.writeSchemas();
+
+		foreach (ModelerGeometry geometry in this._entities)
+		{
+			this._writer.Write(0, DxfFileToken.AcdsRecord);
+			this._writer.Write(90, 1);
+			this._writer.Write(2, "AcDbDs::ID");
+			this._writer.Write(280, 10);
+			this._writer.Write(320, geometry.Handle);
+			this._writer.Write(2, "ASM_Data");
+			this._writer.Write(280, 15);
+			this._writer.Write(94, geometry.AcisData.Length);
+
+			//127 bytes to a line, which is the 254 hex characters AutoCAD writes.
+			for (int i = 0; i < geometry.AcisData.Length; i += 127)
+			{
+				byte[] chunk = new byte[Math.Min(127, geometry.AcisData.Length - i)];
+				Array.Copy(geometry.AcisData, i, chunk, 0, chunk.Length);
+				this._writer.Write(310, chunk);
+			}
+		}
+	}
+
+	private void writeSchemas()
+	{
+		//Schema 0 - the thumbnail. No thumbnail record is written; the schema is kept because
+		//AutoCAD numbers the ASM schema 1 and a file with only schema 1 is not what it writes.
+		this._writer.Write(0, DxfFileToken.AcdsSchema);
+		this._writer.Write(90, 0);
+		this._writer.Write(1, "AcDb_Thumbnail_Schema");
+		this._writer.Write(2, "AcDbDs::ID");
+		this._writer.Write(280, 10);
+		this._writer.Write(91, 8);
+		this._writer.Write(2, "Thumbnail_Data");
+		this._writer.Write(280, 15);
+		this._writer.Write(91, 0);
+		this.writeSchemaProperties();
+
+		//Schema 1 - the one the records above refer to.
+		this._writer.Write(0, DxfFileToken.AcdsSchema);
+		this._writer.Write(90, 1);
+		this._writer.Write(1, "AcDb3DSolid_ASM_Data");
+		this._writer.Write(2, "AcDbDs::ID");
+		this._writer.Write(280, 10);
+		this._writer.Write(91, 8);
+		this._writer.Write(2, "ASM_Data");
+		this._writer.Write(280, 15);
+		this._writer.Write(91, 0);
+		this.writeSchemaProperties();
+
+		this.writeAttributeSchema(2, "AcDbDs::TreatedAsObjectDataSchema", "AcDbDs::TreatedAsObjectData", 1, 0);
+		this.writeAttributeSchema(3, "AcDbDs::LegacySchema", "AcDbDs::Legacy", 1, 0);
+		this.writeAttributeSchema(4, "AcDbDs::IndexedPropertySchema", "AcDs:Indexable", 1, 0);
+		this.writeAttributeSchema(5, "AcDbDs::HandleAttributeSchema", "AcDbDs::HandleAttribute", 7, 1);
+	}
+
+	private void writeAttributeSchema(int id, string schemaName, string propertyName, int type, int extra)
+	{
+		this._writer.Write(0, DxfFileToken.AcdsSchema);
+		this._writer.Write(90, id);
+		this._writer.Write(1, schemaName);
+		this._writer.Write(2, propertyName);
+		this._writer.Write(280, type);
+		this._writer.Write(91, extra);
+		if (extra == 1)
+		{
+			this._writer.Write(284, 1);
+		}
+	}
+
+	private void writeSchemaProperties()
+	{
+		//The four properties every schema of AutoCAD's carries, in its order.
+		this._writer.Write(101, DxfFileToken.AcdsRecord);
+		this._writer.Write(95, 0);
+		this._writer.Write(90, 2);
+		this._writer.Write(2, "AcDbDs::TreatedAsObjectData");
+		this._writer.Write(280, 1);
+		this._writer.Write(291, 1);
+
+		this._writer.Write(101, DxfFileToken.AcdsRecord);
+		this._writer.Write(95, 0);
+		this._writer.Write(90, 3);
+		this._writer.Write(2, "AcDbDs::Legacy");
+		this._writer.Write(280, 1);
+		this._writer.Write(291, 1);
+
+		this._writer.Write(101, DxfFileToken.AcdsRecord);
+		this._writer.Write(1, "AcDbDs::ID");
+		this._writer.Write(90, 4);
+		this._writer.Write(2, "AcDs:Indexable");
+		this._writer.Write(280, 1);
+		this._writer.Write(291, 1);
+
+		this._writer.Write(101, DxfFileToken.AcdsRecord);
+		this._writer.Write(1, "AcDbDs::ID");
+		this._writer.Write(90, 5);
+		this._writer.Write(2, "AcDbDs::HandleAttribute");
+		this._writer.Write(280, 7);
+		this._writer.Write(282, 1);
+	}
+}

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
@@ -102,6 +102,9 @@ internal abstract partial class DxfSectionWriterBase
 			case Ray ray:
 				this.writeRay(ray);
 				break;
+			case Region region:
+				this.writeModelerGeometry(region);
+				break;
 			case Shape shape:
 				this.writeShape(shape);
 				break;
@@ -157,12 +160,43 @@ internal abstract partial class DxfSectionWriterBase
 			case TableEntity:
 			case Solid3D:
 			case CadBody:
-			case Region:
 				this.notify($"Entity type not implemented {entity.GetType().FullName}", NotificationType.NotImplemented);
+				return false;
+			//A region is only worth writing with its geometry. Where that geometry goes depends on the
+			//version: an R2013+ file keeps it in the ACDSDATA section, an older one inside the entity
+			//as character-swapped SAT text. A binary payload - which is what every region read from
+			//an R2007 or later file carries - has no place inside a pre-R2013 entity, and this writer
+			//cannot turn it into SAT text. Say what is missing rather than write a handle with no
+			//shape.
+			case Region regionEntity when !this.canWriteRegion(regionEntity):
+				this.notify(
+					$"Region {regionEntity.Handle} is not written to a {this.Version} file: {this.whyNotWritten(regionEntity)}.",
+					NotificationType.NotImplemented);
 				return false;
 			default:
 				return true;
 		}
+	}
+
+	private bool canWriteRegion(Region region)
+	{
+		if (region.AcisData == null || region.AcisData.Length == 0)
+		{
+			return false;
+		}
+
+		//R2013+ carries any payload in the ACDSDATA section; older versions only text.
+		return this.Version >= ACadVersion.AC1027 || !region.IsBinaryAcisData;
+	}
+
+	private string whyNotWritten(Region region)
+	{
+		if (region.AcisData == null || region.AcisData.Length == 0)
+		{
+			return "it has no geometry to write, and an empty one is a handle with no shape";
+		}
+
+		return $"its geometry is a binary ACIS payload, which that version has no place for - {ACadVersion.AC1027} is the oldest version that keeps it";
 	}
 
 	private void writeArc(Arc arc)
@@ -1185,6 +1219,45 @@ internal abstract partial class DxfSectionWriterBase
 		this._writer.Write(10, ray.StartPoint, map);
 
 		this._writer.Write(11, ray.Direction, map);
+	}
+
+	private void writeModelerGeometry(ModelerGeometry geometry)
+	{
+		this._writer.Write(DxfCode.Subclass, DxfSubclassMarker.ModelerGeometry);
+
+		if (this.Version >= ACadVersion.AC1027)
+		{
+			//R2013+: the payload lives in the ACDSDATA section, keyed by this entity's handle, and
+			//the entity itself only says that it has one. AutoCAD also writes a group 2 GUID here;
+			//it is not needed - stripped from AutoCAD's own file, all 32 regions of a production
+			//drawing still open, audit 0 and come back with a GUID AutoCAD made up on the way in -
+			//and a drawing read from a DWG has none to write.
+			this._writer.Write(290, 1);
+			return;
+		}
+
+		//Before R2013 the SAT text sits in the entity, character-swapped, 255 characters to a line.
+		this._writer.Write(70, geometry.ModelerFormatVersion == 0 ? (short)1 : geometry.ModelerFormatVersion);
+
+		string text = geometry.GetAcisText();
+		if (string.IsNullOrEmpty(text))
+		{
+			return;
+		}
+
+		foreach (string line in text.Split('\n'))
+		{
+			string encoded = AcisTextCodec.Decode(line.TrimEnd('\r'));
+			for (int i = 0; i < encoded.Length; i += 255)
+			{
+				this._writer.Write(i == 0 ? 1 : 3, encoded.Substring(i, Math.Min(255, encoded.Length - i)));
+			}
+
+			if (encoded.Length == 0)
+			{
+				this._writer.Write(1, string.Empty);
+			}
+		}
 	}
 
 	private void writeSeqend(Seqend seqend)

--- a/src/ACadSharp/IO/DxfWriter.cs
+++ b/src/ACadSharp/IO/DxfWriter.cs
@@ -137,6 +137,23 @@ public class DxfWriter : CadWriterBase<DxfWriterConfiguration>
 
 	private void writeACDSData()
 	{
+		//R2013+ only: this is where the ACIS payload of a region or a solid lives from that version
+		//on. Older files carry it inside the entity, so there is no section to write.
+		if (this._document.Header.Version < ACadVersion.AC1027)
+		{
+			return;
+		}
+
+		var entities = DxfAcdsDataSectionWriter.CollectEntities(this._document);
+		if (entities.Count == 0)
+		{
+			return;
+		}
+
+		var writer = new DxfAcdsDataSectionWriter(this._writer, this._document, this._objectHolder, this.Configuration, entities);
+		writer.OnNotification += this.triggerNotification;
+
+		writer.Write();
 	}
 
 	private void writeBlocks()


### PR DESCRIPTION
﻿
# Description

`Region` is on the not-implemented list of both writers, so every region in a drawing is dropped on
write. The reader has kept the payload all along - `ModelerGeometry.AcisData` - and nothing put it
back.

Measured through the product path, with AutoCAD 2027: a production drawing with 32 regions, saved by
AutoCAD to DXF, has 32 `REGION`. The same drawing read by this library and written to DXF, then saved
by AutoCAD, had **0**. Eight of seventeen production drawings carry regions, **846** in all, and 845
of those come with a full payload (5.7 MB of ACIS data read and thrown away).

Where the payload belongs depends on the version, and that is what the change is about:

| version | where the geometry goes | this PR |
|---|---|---|
| DXF R2013+ (`AC1027`+) | `ACDSDATA` section, one `ACDSRECORD` per entity keyed by its handle; the entity itself only carries the flag | **written** - a new `DxfAcdsDataSectionWriter`, and `DxfWriter.writeACDSData` (an empty method until now) fills it |
| DXF before R2013 | character-swapped SAT text in the entity, groups 1 and 3 | **written** when the payload is SAT; a binary SAB payload cannot be turned into SAT text, so the region is left out **and the reason is reported** |
| DWG R2004 to R2010 (`AC1018`-`AC1024`) | binary payload inside the entity | **written** |
| DWG R2000 (`AC1015`) | SAT text inside the entity, in length-prefixed blocks | **not written**: written that way - in one block, and one block per SAT line - AutoCAD refuses to open the drawing at all. `AC1018` is the oldest version this writer fills, and the entity is left out with that message |
| DWG R2013+ | AcDs data section | **not written**: this writer produces no AcDs section, and a region without its payload is a handle with no shape. Left out, with a notification naming `AC1024` as the newest version that keeps it |

**One bit of the entity layout was wrong and is fixed here too.** The reader stops at the
end-of-ACIS marker and returns, so nothing noticed that the wireframe section still follows the
payload. Written without it, AutoCAD refused the file while loading the modeler
(`ErrorStatus=53`); written with it, the same drawing opens and audits clean.

AutoCAD says the files are right. The 32-region drawing, written by this branch and then opened,
audited and re-exported by AutoCAD 2027:

| written as | AUDIT | `REGION` in AutoCAD's own export |
|---|---|---|
| DXF R2018 | 6 - unchanged from before the change | **32**, carrying all 107,598 payload bytes the reader had read |
| DWG R2004 | 5 - unchanged | **32** |
| DWG R2010 | 5 - unchanged | **32**, 111,066 payload bytes - the same number AutoCAD's own save of the source has |
| DWG R2000 | 5 - unchanged | 0, left out on purpose (above) |
| DWG R2018 | 5 - unchanged | 0, left out on purpose (above) |

`samples/sample_AC1015.dwg`, whose region carries SAT text, round-trips to a file AutoCAD audits with
**0 errors**.

Seventeen production drawings, 51 channels (DWG R2018, DWG R2000, DXF R2018): every channel opens,
**nothing worse than before**, and three DXF channels audit *better* (117 to 114, 798 to 796, 1037 to
1014).

**The group 2 GUID is not written.** AutoCAD writes one, and a drawing read from a DWG has none to
write. Removing the GUID from all 32 regions of AutoCAD's own file and reopening it: `AUDIT` 0 errors,
all 32 regions present, each with a GUID AutoCAD made up on the way in.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`RegionWriteTests`: a region survives a DXF round trip with its payload byte for byte; the payload
lands in the `ACDSDATA` section keyed by the entity handle for R2013+; a SAT payload is written
inside the entity for older DXF versions and read back; a binary payload in a pre-R2013 DXF is left
out and reported; a binary payload survives a DWG round trip at R2004 and at R2010; R2000 and R2018
leave the region out and say why. `HatchAssociativityTests` used a `Region` as "an entity no writer can write" and now
uses a `Solid3D`. Whole suite: see the checklist table. AutoCAD measurements above, plus the
17-drawing, 51-channel gate.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

