### PR TITLE
A dictionary keeps every entry, even when two of them share a name

### DIFF
--- a/src/ACadSharp.Tests/IO/WriterSingleObjectTests.cs
+++ b/src/ACadSharp.Tests/IO/WriterSingleObjectTests.cs
@@ -85,6 +85,7 @@ public abstract class WriterSingleObjectTests : IOTestsBase
 		Data.Add(new(nameof(SingleCaseGenerator.Dimensions)));
 		Data.Add(new(nameof(SingleCaseGenerator.DimensionWithLineType)));
 		Data.Add(new(nameof(SingleCaseGenerator.GeoData)));
+		Data.Add(new(nameof(SingleCaseGenerator.TwoSortTablesInOneDictionary)));
 		Data.Add(new(nameof(SingleCaseGenerator.LineTypeInBlock)));
 		Data.Add(new(nameof(SingleCaseGenerator.XData)));
 		Data.Add(new(nameof(SingleCaseGenerator.XRef)));
@@ -1270,6 +1271,29 @@ public abstract class WriterSingleObjectTests : IOTestsBase
 
 			this.Document.Entities.Add(line);
 			this.Document.Entities.Add(anotherLine);
+		}
+
+		//Two entries of one dictionary whose objects carry the same name. Every SortEntitiesTable
+		//is called ACAD_SORTENTS, so the key the file stores them under is the only thing that
+		//tells them apart: one customer drawing keeps 448 of them and used to lose 447.
+		public void TwoSortTablesInOneDictionary()
+		{
+			Circle first = new Circle { Radius = 10 };
+			Circle second = new Circle { Radius = 5 };
+
+			this.Document.Entities.Add(first);
+			this.Document.Entities.Add(second);
+
+			SortEntitiesTable one = new SortEntitiesTable(this.Document.ModelSpace);
+			one.Add(first, first.Handle);
+
+			SortEntitiesTable two = new SortEntitiesTable(this.Document.ModelSpace);
+			two.Add(second, second.Handle);
+
+			CadDictionary holder = new CadDictionary("sort_tables");
+			this.Document.RootDictionary.Add(holder);
+			holder.Add("first", one);
+			holder.Add("second", two);
 		}
 
 		public void GeoData()

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
@@ -858,10 +858,13 @@ internal partial class DwgObjectWriter : DwgSectionIO
 	{
 		//Common:
 		//Numitems L number of dictionary items
-		List<NonGraphicalObject> entries = new List<NonGraphicalObject>();
-		foreach (var item in dictionary)
+		//The key, not the entry's own name: two entries can carry the same name - every
+		//SortEntitiesTable is called ACAD_SORTENTS - and writing the name twice produces a file
+		//whose dictionary cannot be read back.
+		List<KeyValuePair<string, NonGraphicalObject>> entries = new List<KeyValuePair<string, NonGraphicalObject>>();
+		foreach (var item in dictionary.KeyedEntries)
 		{
-			if (this.skipEntry(item))
+			if (this.skipEntry(item.Value))
 			{
 				continue;
 			}
@@ -889,16 +892,11 @@ internal partial class DwgObjectWriter : DwgSectionIO
 		//Common:
 		foreach (var item in entries)
 		{
-			if (this.skipEntry(item))
-			{
-				continue;
-			}
-
-			this._writer.WriteVariableText(item.Name);
-			this._writer.HandleReference(DwgReferenceType.SoftOwnership, item.Handle);
+			this._writer.WriteVariableText(item.Key);
+			this._writer.HandleReference(DwgReferenceType.SoftOwnership, item.Value.Handle);
 		}
 
-		this.addObjectsToWriter(entries);
+		this.addObjectsToWriter(entries.Select(e => e.Value));
 	}
 
 	private void writeDictionaryVariable(DictionaryVariable dictionaryVariable)

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
@@ -39,8 +39,12 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 		this._writer.Write(280, dict.HardOwnerFlag);
 		this._writer.Write(281, (int)dict.ClonningFlags);
 
-		foreach (NonGraphicalObject item in dict)
+		//Group 3 carries the key the entry is stored under, which is not always the entry's own
+		//name: every SortEntitiesTable is called ACAD_SORTENTS, and a dictionary holding more than
+		//one of them would otherwise write the same name twice.
+		foreach (KeyValuePair<string, NonGraphicalObject> entry in dict.KeyedEntries)
 		{
+			NonGraphicalObject item = entry.Value;
 			if (item is XRecord && !this.Configuration.WriteXRecords)
 			{
 				continue;
@@ -58,7 +62,7 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 				continue;
 			}
 
-			this._writer.Write(3, item.Name);
+			this._writer.Write(3, entry.Key);
 			if (dict.HardOwnerFlag)
 			{
 				this._writer.Write(360, item.Handle);

--- a/src/ACadSharp/IO/Templates/CadDictionaryTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadDictionaryTemplate.cs
@@ -44,9 +44,21 @@ namespace ACadSharp.IO.Templates
 						entry.Name = item.Key;
 					}
 
+					//The entry goes in under its own name, which is what the collections built on
+					//top of a dictionary look it up by. Some names are constants, though - every
+					//SortEntitiesTable is called ACAD_SORTENTS - so when that name is already
+					//taken the file's own key is used instead. Without this, a drawing that keeps
+					//several such objects in one dictionary loses all but the first: one customer
+					//drawing lost 447 draw order tables that way.
+					string key = string.IsNullOrEmpty(entry.Name) ? item.Key : entry.Name;
+					if (this.CadObject.ContainsKey(key))
+					{
+						key = item.Key;
+					}
+
 					try
 					{
-						this.CadObject.Add(entry.Name, entry);
+						this.CadObject.Add(key, entry);
 					}
 					catch (System.Exception ex)
 					{

--- a/src/ACadSharp/Objects/CadDictionary.cs
+++ b/src/ACadSharp/Objects/CadDictionary.cs
@@ -42,6 +42,16 @@ public class CadDictionary : NonGraphicalObject, IObservableCadCollection<NonGra
 	public string[] EntryNames { get { return this._entries.Keys.ToArray(); } }
 
 	/// <summary>
+	/// The entries with the key each one is stored under.
+	/// </summary>
+	/// <remarks>
+	/// The key is what the file carries and what a reader looks an entry up by; it is usually the
+	/// entry's own name, but not always - an object whose name is a constant, such as a
+	/// <see cref="SortEntitiesTable"/>, is stored under a key of the file's choosing.
+	/// </remarks>
+	public IEnumerable<KeyValuePair<string, NonGraphicalObject>> KeyedEntries { get { return this._entries; } }
+
+	/// <summary>
 	/// Indicates that elements of the dictionary are to be treated as hard-owned.
 	/// </summary>
 	[DxfCodeValue(280)]


### PR DESCRIPTION
﻿
# Description

A dictionary entry is stored, written and read back under the **entry's own name** rather than
under the **key the file gives it**. Most of the time those are the same string, so this is
invisible. They are not always the same: every `SortEntitiesTable` is called `ACAD_SORTENTS`,
because that is the key AutoCAD stores it under in an extension dictionary â€” the name is a constant
of the class, not a name the object chose.

A dictionary holding more than one of them therefore keeps the first and loses the rest. Reading one
production drawing raised **447 errors**, one per lost draw order table:

```
Error when trying to add the entry ACAD_SORTENTS to ACAD_DGNLINESTYLECOMP
```

AutoCAD's own DXF of that same drawing has **10,172 dictionaries carrying an `ACAD_SORTENTS`
entry** and **not one duplicate key anywhere** â€” the keys were there to be used all along.

Three places had to agree on what the key is:

| where | before | after |
|---|---|---|
| `CadDictionaryTemplate.build` | `Add(entry.Name, entry)` | the entry's name while that name is free, the file's key when it is not |
| `DwgObjectWriter.writeDictionary` | writes `item.Name` | writes the key |
| `DxfObjectsSectionWriter.writeDictionary` | writes `item.Name` in group 3 | writes the key |

The reader keeps preferring the name deliberately: the collections built on top of a dictionary â€”
book colours, scales â€” look their entries up **by name**, and for those the key differs from the
name on purpose. Falling back to the key only on a collision leaves every one of those cases exactly
as it was, and rescues the entries that used to be dropped.

Without the writer half, the fix is not a round trip: a file written with the same name twice cannot
be read back at all, because the reader's entry table is keyed by that name.

`CadDictionary.KeyedEntries` is added for the writers â€” the pairs, where the enumerator gives only
the values.

# What it fixes

- Entries silently lost on read, with an error per entry, whenever a dictionary holds two objects of
  the same name.
- The twelve `WriterSingleObjectTests` cases that fail on master at every version, `GeoData` and
  `InsertWithSpatialFilter`: they exercise an extension dictionary whose entry has no name of its
  own, and group 3 came out empty. Writing the key fills it.

| | master | this branch |
|---|---|---|
| `dotnet test` | 2312 passed / **17 failed** | 2335 passed / **5 failed** |

The five that remain are the `SingleMLeader` DWG cases, which have nothing to do with dictionaries.

> There is a second branch in this series, `pr48-dictionary-entry-name`, that fixes those same twelve
> from the other side: `CadDictionary.Add(key, value)` filling in a missing name from the key. The
> two are compatible and both are worth having â€” one keeps the object model consistent, the other
> keeps the file faithful â€” but if only one is taken, this is the one that also stops the entries
> being lost.

# Testing

- `TwoSortTablesInOneDictionary`, a new case in `WriterSingleObjectTests`: two sort tables in one
  dictionary, round tripped at every version in both formats. **11 tests, all red before this change
  and green after.**
- `dotnet test` on this branch: **2335 passed / 5 failed**, twelve fewer failures than master and no
  new ones.
- AutoCAD 2027 AUDIT: 0 errors on all five generated files.
- Nine round trip channels of three production drawings: unchanged, and the drawing that raised 447
  errors on read now raises none.

