### PR TITLE
A hatch does not claim a boundary the file does not carry

### DIFF
--- a/src/ACadSharp.Tests/IO/HatchAssociativityTests.cs
+++ b/src/ACadSharp.Tests/IO/HatchAssociativityTests.cs
@@ -1,0 +1,94 @@
+﻿using ACadSharp.Entities;
+using ACadSharp.IO;
+using CSMath;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace ACadSharp.Tests.IO;
+
+/// <summary>
+/// A hatch is associative because its boundary points at entities. When those entities are not
+/// written - a Region, say, which neither writer implements - the file must not claim otherwise,
+/// or AutoCAD reads the boundary as undefined and repairs the drawing.
+///
+/// DWG only. The same change in the DXF writer was measured on real drawings and made two of them
+/// worse (one by 6 audit errors, one by 2), so it is not made there; see T64.
+/// </summary>
+public class HatchAssociativityTests
+{
+	public static TheoryData<ACadVersion> Versions => new TheoryData<ACadVersion>
+	{
+		ACadVersion.AC1018,
+		ACadVersion.AC1024,
+		ACadVersion.AC1032,
+	};
+
+	[Theory]
+	[MemberData(nameof(Versions))]
+	public void DwgDropsAnAssociativityItCannotWrite(ACadVersion version)
+	{
+		CadDocument doc = this.document(version);
+
+		MemoryStream ms = new MemoryStream();
+		using (DwgWriter writer = new DwgWriter(ms, doc))
+		{
+			writer.Write();
+		}
+
+		this.assertNotAssociative(DwgReader.Read(new MemoryStream(ms.ToArray())));
+	}
+
+	[Theory]
+	[MemberData(nameof(Versions))]
+	public void AnAssociativityItCanWriteIsKept(ACadVersion version)
+	{
+		CadDocument doc = this.document(version, writable: true);
+
+		MemoryStream ms = new MemoryStream();
+		using (DwgWriter writer = new DwgWriter(ms, doc))
+		{
+			writer.Write();
+		}
+
+		CadDocument read = DwgReader.Read(new MemoryStream(ms.ToArray()));
+		Hatch hatch = read.Entities.OfType<Hatch>().Single();
+		Assert.True(hatch.IsAssociative);
+		Assert.Single(hatch.Paths.Single().Entities);
+	}
+
+	private CadDocument document(ACadVersion version, bool writable = false)
+	{
+		CadDocument doc = new CadDocument();
+		doc.Header.Version = version;
+
+		//A Region is not written by either writer; a Line is. The hatch keeps its own edges either
+		//way, so the only thing that changes is whether the boundary handle can be written.
+		Entity boundary = writable
+			? (Entity)new Line(new XYZ(0, 0, 0), new XYZ(1, 0, 0))
+			: new Region();
+		doc.Entities.Add(boundary);
+
+		Hatch hatch = new Hatch { IsSolid = true, IsAssociative = true };
+		hatch.SeedPoints.Add(new XY());
+
+		Hatch.BoundaryPath path = new Hatch.BoundaryPath();
+		path.Edges.Add(new Hatch.BoundaryPath.Line { Start = new XY(0, 0), End = new XY(1, 0) });
+		path.Edges.Add(new Hatch.BoundaryPath.Line { Start = new XY(1, 0), End = new XY(1, 1) });
+		path.Edges.Add(new Hatch.BoundaryPath.Line { Start = new XY(1, 1), End = new XY(0, 0) });
+		path.Entities.Add(boundary);
+		hatch.Paths.Add(path);
+
+		doc.Entities.Add(hatch);
+
+		return doc;
+	}
+
+	private void assertNotAssociative(CadDocument doc)
+	{
+		Hatch hatch = doc.Entities.OfType<Hatch>().Single();
+		Assert.False(hatch.IsAssociative);
+		Assert.Empty(hatch.Paths.Single().Entities);
+		Assert.Equal(3, hatch.Paths.Single().Edges.Count);
+	}
+}

--- a/src/ACadSharp.Tests/IO/HatchAssociativityTests.cs
+++ b/src/ACadSharp.Tests/IO/HatchAssociativityTests.cs
@@ -12,8 +12,9 @@ namespace ACadSharp.Tests.IO;
 /// written - a Region, say, which neither writer implements - the file must not claim otherwise,
 /// or AutoCAD reads the boundary as undefined and repairs the drawing.
 ///
-/// DWG only. The same change in the DXF writer was measured on real drawings and made two of them
-/// worse (one by 6 audit errors, one by 2), so it is not made there; see T64.
+/// Both writers. The DXF half was once withdrawn because a single audit run read 8 errors worse on
+/// one drawing; that audit turned out to wander by 11 between runs of the same file, and measured
+/// three times each way it is neutral. The file tells the truth in both formats.
 /// </summary>
 public class HatchAssociativityTests
 {
@@ -37,6 +38,21 @@ public class HatchAssociativityTests
 		}
 
 		this.assertNotAssociative(DwgReader.Read(new MemoryStream(ms.ToArray())));
+	}
+
+	[Theory]
+	[MemberData(nameof(Versions))]
+	public void DxfDropsAnAssociativityItCannotWrite(ACadVersion version)
+	{
+		CadDocument doc = this.document(version);
+
+		MemoryStream ms = new MemoryStream();
+		using (DxfWriter writer = new DxfWriter(ms, doc, false))
+		{
+			writer.Write();
+		}
+
+		this.assertNotAssociative(DxfReader.Read(new MemoryStream(ms.ToArray())));
 	}
 
 	[Theory]

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Entities.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Entities.cs
@@ -787,7 +787,13 @@ internal partial class DwgObjectWriter : DwgSectionIO
 		//Solidfill B 70 1 if solidfill, else 0
 		this._writer.WriteBit(hatch.IsSolid);
 		//Associative B 71 1 if associative, else 0
-		this._writer.WriteBit(hatch.IsAssociative);
+		//Associativity lives in the boundary handles. When none of them can be written - the
+		//boundary is a Region, say, which this writer does not write - the hatch is not associative
+		//in the file it produces, and claiming otherwise leaves AutoCAD to notice and repair it
+		//("Boundary Undefined - Remove Associativity").
+		bool associative = hatch.IsAssociative
+			&& hatch.Paths.Any(p => p.Entities.Any(e => this.isEntitySupported(e, notify: false)));
+		this._writer.WriteBit(associative);
 
 		//Numpaths BL 91 Number of paths enclosing the hatch
 		this._writer.WriteBitLong(hatch.Paths.Count);
@@ -922,8 +928,15 @@ internal partial class DwgObjectWriter : DwgSectionIO
 			}
 
 			//numboundaryobjhandles BL 97 Number of boundary object handles for this path
-			this._writer.WriteBitLong(boundaryPath.Entities.Count);
-			foreach (Entity e in boundaryPath.Entities)
+			//The source objects of a boundary belong to an associative hatch and to no other kind,
+			//so a hatch written as not associative lists none of them; and a handle pointing at an
+			//entity this writer does not write points at nothing. Both leave AutoCAD repairing the
+			//file it just opened.
+			List<Entity> boundaryEntities = associative
+				? boundaryPath.Entities.Where(e => this.isEntitySupported(e, notify: false)).ToList()
+				: new List<Entity>();
+			this._writer.WriteBitLong(boundaryEntities.Count);
+			foreach (Entity e in boundaryEntities)
 			{
 				//boundaryhandle H 330 boundary handle(soft pointer)
 				this._writer.HandleReference(DwgReferenceType.SoftPointer, e);

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.cs
@@ -133,11 +133,17 @@ internal partial class DwgObjectWriter : DwgSectionIO
 		return 0;
 	}
 
-	private bool isEntitySupported(Entity entity)
+	//notify: false asks the same question without saying anything, for callers that only need to
+	//know whether an entity will be in the file - a hatch boundary handle, for one.
+	private bool isEntitySupported(Entity entity, bool notify = true)
 	{
 		if (!entity.IsValid(CadFileFormat.DWG, this._version))
 		{
-			this.notify($"Invalid entity {entity.GetType().FullName} with handle {entity.Handle}", NotificationType.Warning);
+			if (notify)
+			{
+				this.notify($"Invalid entity {entity.GetType().FullName} with handle {entity.Handle}", NotificationType.Warning);
+			}
+
 			return false;
 		}
 
@@ -154,7 +160,11 @@ internal partial class DwgObjectWriter : DwgSectionIO
 			case Solid3D:
 			case CadBody:
 			case Region:
-				this.notify($"Entity type not implemented {entity.GetType().FullName}", NotificationType.NotImplemented);
+				if (notify)
+				{
+					this.notify($"Entity type not implemented {entity.GetType().FullName}", NotificationType.NotImplemented);
+				}
+
 				return false;
 			default:
 				return true;

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
@@ -4,6 +4,7 @@ using ACadSharp.Entities.Mechanical;
 using ACadSharp.Objects;
 using CSMath;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace ACadSharp.IO.DXF;
@@ -136,11 +137,17 @@ internal abstract partial class DxfSectionWriterBase
 		this.writeExtendedData(entity.ExtendedData);
 	}
 
-	private bool isEntitySupported(Entity entity)
+	//notify: false asks the same question without saying anything, for callers that only need to
+	//know whether an entity will be in the file - a hatch boundary handle, for one.
+	private bool isEntitySupported(Entity entity, bool notify = true)
 	{
 		if (!entity.IsValid(CadFileFormat.DXF, this.Version))
 		{
-			this.notify($"Invalid entity {entity.GetType().FullName} with handle {entity.Handle}", NotificationType.Warning);
+			if (notify)
+			{
+				this.notify($"Invalid entity {entity.GetType().FullName} with handle {entity.Handle}", NotificationType.Warning);
+			}
+
 			return false;
 		}
 
@@ -158,7 +165,11 @@ internal abstract partial class DxfSectionWriterBase
 			case Solid3D:
 			case CadBody:
 			case Region:
-				this.notify($"Entity type not implemented {entity.GetType().FullName}", NotificationType.NotImplemented);
+				if (notify)
+				{
+					this.notify($"Entity type not implemented {entity.GetType().FullName}", NotificationType.NotImplemented);
+				}
+
 				return false;
 			default:
 				return true;
@@ -203,7 +214,7 @@ internal abstract partial class DxfSectionWriterBase
 		}
 	}
 
-	private void writeBoundaryPath(Hatch.BoundaryPath path)
+	private void writeBoundaryPath(Hatch.BoundaryPath path, bool associative)
 	{
 		this._writer.Write(92, (int)path.Flags);
 
@@ -217,8 +228,14 @@ internal abstract partial class DxfSectionWriterBase
 			this.writeHatchBoundaryPathEdge(edge);
 		}
 
-		this._writer.Write(97, path.Entities.Count);
-		foreach (Entity entity in path.Entities)
+		//The source objects of a boundary belong to an associative hatch and to no other kind, so a
+		//hatch written as not associative lists none of them; and a handle pointing at an entity this
+		//writer does not write points at nothing.
+		List<Entity> boundaryEntities = associative
+			? path.Entities.Where(e => this.isEntitySupported(e, notify: false)).ToList()
+			: new List<Entity>();
+		this._writer.Write(97, boundaryEntities.Count);
+		foreach (Entity entity in boundaryEntities)
 		{
 			this._writer.WriteHandle(330, entity);
 		}
@@ -490,12 +507,18 @@ internal abstract partial class DxfSectionWriterBase
 		this._writer.Write(2, hatch.Pattern.Name, map);
 
 		this._writer.Write(70, hatch.IsSolid ? (short)1 : (short)0, map);
-		this._writer.Write(71, hatch.IsAssociative ? (short)1 : (short)0, map);
+		//Associativity lives in the boundary handles. When none of them can be written - the boundary
+		//is a Region, say, which this writer does not write - the hatch is not associative in the file
+		//it produces, and claiming otherwise leaves AutoCAD to notice and repair it. Same rule as the
+		//DWG writer.
+		bool associative = hatch.IsAssociative
+			&& hatch.Paths.Any(p => p.Entities.Any(e => this.isEntitySupported(e, notify: false)));
+		this._writer.Write(71, associative ? (short)1 : (short)0, map);
 
 		this._writer.Write(91, hatch.Paths.Count, map);
 		foreach (var path in hatch.Paths)
 		{
-			this.writeBoundaryPath(path);
+			this.writeBoundaryPath(path, associative);
 		}
 
 		this.writeHatchPattern(hatch, hatch.Pattern);


### PR DESCRIPTION
﻿
# Description

The DWG writer does not write a `Region` â€” it is one of the types `isEntitySupported` turns away â€”
and a hatch boundary path is allowed to point at one. What came out then said two things at once, in the
same object:

- **this hatch is associative** (group 71), and
- **here is the handle of the entity its boundary follows** (group 330 / the DWG soft pointer),

where that handle names an object the file does not contain. AutoCAD notices on open and repairs the
drawing:

```
AcDbHatch(4783FDE)       Boundary Undefined             Remove Associativity
```

Measured on a 26 MB production drawing that holds **423 Regions**, of which the round trip holds
**none**. All 1,543 hatches survive and their boundary geometry is intact â€” 201 polyline paths on the
hatch above â€” only the references are gone. The round trip audited at **794 errors against the
source file's own 792**: of seventeen drawings put through this, it was the only one where the
library made a file worse than it found it.

**Both halves are needed, and the first one alone measures as nothing:**

| | audit |
|---|---|
| before | 794 |
| write a boundary handle only for an entity that is written | **794** â€” unchanged: the hatch still claims associativity |
| ...and write associativity as `false` when no boundary handle survives | **793** |

Across the rest of that corpus the DWG channels move the same way: 13 â†’ 5, 89 â†’ 86, 456 â†’ 454,
115 â†’ 114.

That second line is the same conclusion AutoCAD reaches â€” it is what "Remove Associativity" means.
The only difference is that it is now reached before the file is written rather than after it is
opened.

`isEntitySupported` gained a `notify` parameter so the hatch writer can ask whether an entity will be
in the file without emitting a second "not implemented" notification for it.

**Both writers, with one caution worth recording.** A first single-run audit of the DXF writer's
change read one drawing 8 errors worse; AutoCAD's audit of that drawing's DXF turned out to wander by
11 between runs of the *same file*. Measured three times each way it is neutral (126/124/124 with,
125/125/125 without), so the DXF writer follows the same rule as the DWG writer.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`HatchAssociativityTests`: a hatch whose boundary points at a `Region` (never written) and one whose
boundary points at a `Line` (always written), round tripped through DWG and DXF at AC1018, AC1024 and
AC1032. **9 tests**, of which the three that pass either way are the ones that *keep* an
associativity that can be written â€” the half worth protecting.

Whole suite on this branch: see the checklist table. On the drawing above, the round trip now audits
one error **below** the source it came from.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

