### PR TITLE
A dimension association is written back, to both formats

### DIFF
--- a/src/ACadSharp.Tests/IO/DimensionAssociationWriteTests.cs
+++ b/src/ACadSharp.Tests/IO/DimensionAssociationWriteTests.cs
@@ -1,0 +1,207 @@
+using ACadSharp.Entities;
+using ACadSharp.IO;
+using ACadSharp.Objects;
+using CSMath;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace ACadSharp.Tests.IO;
+
+/// <summary>
+/// A dimension association records which piece of geometry a dimension is attached to. Upstream
+/// disabled the DXF writer for it - "ignore dimassoc due missing testing" - and the DWG writer wrote
+/// only the first three fields of each osnap point reference, because the DWG reader only ever read
+/// those three. A DWG object stream is length delimited, so the rest was skipped in silence and the
+/// model came back with the osnap point at the origin.
+///
+/// The layout of the rest was read off the bits against AutoCAD's own DXF export of a production
+/// drawing: two of its seven associations differ in 91 and 40, which is what pins down which field is
+/// which. Written back, that drawing keeps all seven associations through both writers, and AutoCAD
+/// audits the result to the same numbers it did before: 28 on both DWG channels, 26 on DXF.
+/// </summary>
+public class DimensionAssociationWriteTests
+{
+	//The values AutoCAD wrote for object 53DDAD7 of that drawing, which is the shape being pinned.
+	private const double MeasuredGeometryParameter = 1.0;
+
+	private const int MeasuredGsMarker = 1;
+
+	private const short MeasuredSubentType = 2;
+
+	//AutoCAD's own "not set" sentinel for a coordinate, not a position anything is at.
+	private static readonly XYZ MeasuredOsnapPoint = new XYZ(0.0, 0.0, 2.0e50);
+
+	[Theory]
+	[InlineData(ACadVersion.AC1018)]
+	[InlineData(ACadVersion.AC1024)]
+	[InlineData(ACadVersion.AC1032)]
+	public void EveryFieldSurvivesADwgRoundTrip(ACadVersion version)
+	{
+		CadDocument doc = this.document(out DimensionAssociation before);
+		doc.Header.Version = version;
+
+		using MemoryStream stream = new();
+		using (DwgWriter writer = new(stream, doc))
+		{
+			writer.Write();
+		}
+
+		DimensionAssociation after = this.association(DwgReader.Read(new MemoryStream(stream.ToArray())));
+		this.assertSame(before, after);
+	}
+
+	[Fact]
+	public void EveryFieldSurvivesADxfRoundTrip()
+	{
+		CadDocument doc = this.document(out DimensionAssociation before);
+
+		using MemoryStream stream = new();
+		using (DxfWriter writer = new(stream, doc, false))
+		{
+			writer.Write();
+		}
+
+		DimensionAssociation after = this.association(DxfReader.Read(new MemoryStream(stream.ToArray())));
+		this.assertSame(before, after);
+	}
+
+	[Fact]
+	public void TheDxfCarriesTheGroupCodesAutoCadWrites()
+	{
+		//The order and the codes are AutoCAD's own, taken from its export of the drawing above.
+		CadDocument doc = this.document(out DimensionAssociation _);
+
+		using MemoryStream stream = new();
+		using (DxfWriter writer = new(stream, doc, false))
+		{
+			writer.Write();
+		}
+
+		string text = System.Text.Encoding.UTF8.GetString(stream.ToArray()).Replace("\r", string.Empty);
+		Assert.Contains("AcDbDimAssoc", text);
+		Assert.Contains(DimensionAssociation.OsnapPointRefClassName, text);
+	}
+
+	[Fact]
+	public void AnOsnapPointIsNotSilentlyMovedToTheOrigin()
+	{
+		//The defect this covers: the DWG reader stopped after the geometry handle, so every osnap
+		//point read from a DWG came back as 0,0,0 with no geometry parameter. A round trip that
+		//loses those without a word is exactly what nothing caught before.
+		CadDocument doc = this.document(out DimensionAssociation _);
+		doc.Header.Version = ACadVersion.AC1032;
+
+		using MemoryStream stream = new();
+		using (DwgWriter writer = new(stream, doc))
+		{
+			writer.Write();
+		}
+
+		DimensionAssociation after = this.association(DwgReader.Read(new MemoryStream(stream.ToArray())));
+		Assert.NotEqual(XYZ.Zero, after.FirstPointRef.OsnapPoint);
+		Assert.Equal(MeasuredGeometryParameter, after.FirstPointRef.GeometryParameter);
+	}
+
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void AFlagWithNoReferenceBehindItIsNotWritten(bool dwg)
+	{
+		//The flags say how many references follow. A flag with nothing behind it would promise data
+		//the file never writes, and in a DWG that misaligns everything after the object.
+		CadDocument doc = this.document(out DimensionAssociation association);
+		association.AssociativityFlags = AssociativityFlags.FirstPointReference | AssociativityFlags.ThirdPointReference;
+
+		string reported = null;
+		using MemoryStream stream = new();
+		if (dwg)
+		{
+			using DwgWriter writer = new(stream, doc);
+			writer.OnNotification += (s, e) => { if (e.Message.Contains("carries no reference")) reported = e.Message; };
+			writer.Write();
+		}
+		else
+		{
+			using DxfWriter writer = new(stream, doc, false);
+			writer.OnNotification += (s, e) => { if (e.Message.Contains("carries no reference")) reported = e.Message; };
+			writer.Write();
+		}
+
+		Assert.NotNull(reported);
+
+		CadDocument back = dwg
+			? DwgReader.Read(new MemoryStream(stream.ToArray()))
+			: DxfReader.Read(new MemoryStream(stream.ToArray()));
+		DimensionAssociation after = this.association(back);
+
+		Assert.Equal(AssociativityFlags.FirstPointReference, after.AssociativityFlags);
+		Assert.Null(after.ThirdPointRef);
+		Assert.NotNull(after.FirstPointRef);
+		Assert.Equal(MeasuredGeometryParameter, after.FirstPointRef.GeometryParameter);
+	}
+
+	private DimensionAssociation association(CadDocument doc)
+	{
+		DimensionLinear dimension = doc.Entities.OfType<DimensionLinear>().Single();
+		return dimension.XDictionary.Cast<NonGraphicalObject>().OfType<DimensionAssociation>().Single();
+	}
+
+	private void assertSame(DimensionAssociation before, DimensionAssociation after)
+	{
+		Assert.Equal(before.AssociativityFlags, after.AssociativityFlags);
+		Assert.Equal(before.IsTransSpace, after.IsTransSpace);
+		Assert.Equal(before.RotatedDimensionType, after.RotatedDimensionType);
+		Assert.Equal(before.Dimension.Handle, after.Dimension.Handle);
+
+		DimensionAssociation.OsnapPointRef a = before.FirstPointRef;
+		DimensionAssociation.OsnapPointRef b = after.FirstPointRef;
+		Assert.NotNull(b);
+		Assert.Equal(a.ObjectOsnapType, b.ObjectOsnapType);
+		Assert.Equal(a.SubentType, b.SubentType);
+		Assert.Equal(a.GsMarker, b.GsMarker);
+		Assert.Equal(a.GeometryParameter, b.GeometryParameter);
+		Assert.Equal(a.OsnapPoint, b.OsnapPoint);
+		Assert.Equal(a.HasLastPointRef, b.HasLastPointRef);
+		Assert.Equal(a.Geometry.Handle, b.Geometry.Handle);
+	}
+
+	private CadDocument document(out DimensionAssociation association)
+	{
+		CadDocument doc = new();
+
+		Line line = new(XYZ.Zero, new XYZ(10, 0, 0));
+		doc.Entities.Add(line);
+
+		DimensionLinear dimension = new()
+		{
+			FirstPoint = XYZ.Zero,
+			SecondPoint = new XYZ(10, 0, 0),
+			DefinitionPoint = new XYZ(0, -5, 0),
+		};
+		doc.Entities.Add(dimension);
+
+		association = new DimensionAssociation
+		{
+			Name = "ACAD_DIMASSOC",
+			AssociativityFlags = AssociativityFlags.FirstPointReference,
+			Dimension = dimension,
+			IsTransSpace = false,
+			RotatedDimensionType = RotatedDimensionType.Unknown,
+			FirstPointRef = new DimensionAssociation.OsnapPointRef
+			{
+				ObjectOsnapType = ObjectOsnapType.Endpoint,
+				SubentType = (SubentType)MeasuredSubentType,
+				GsMarker = MeasuredGsMarker,
+				GeometryParameter = MeasuredGeometryParameter,
+				OsnapPoint = MeasuredOsnapPoint,
+				HasLastPointRef = false,
+				Geometry = line,
+			},
+		};
+
+		dimension.CreateExtendedDictionary();
+		dimension.XDictionary.Add(association);
+		return doc;
+	}
+}

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -7290,6 +7290,44 @@ namespace ACadSharp.IO.DWG
 			//331
 			template.ObjectHandle = this.handleReference();
 
+			//Everything below this point used to be left unread. A DWG object stream is length
+			//delimited, so the reader simply stopped and the rest was skipped without a word - which
+			//is why the model came back with the osnap point at the origin and no geometry parameter.
+			//The layout was read off the bits against AutoCAD's own DXF export of the same objects
+			//(oracle/corpus/D_acad.dxf, objects 53DDAD7 and 53DDCA5, which differ in 91 and 40 and so
+			//pin down which field is which).
+
+			//The main object arrives as a subentity path: a count of object ids, then the ids
+			//themselves, then the subentity that is being pointed at. Every reference in the corpus
+			//names exactly one object - the handle already read above. A count other than one would
+			//mean further handles follow and everything after this would be misread, so say so rather
+			//than carry on quietly.
+			int mainPathIdCount = this._mergedReaders.ReadBitLong();
+			if (mainPathIdCount != 1)
+			{
+				this.notify($"Osnap point reference with {mainPathIdCount} object ids in its subentity path; only a single id is understood, the reference is read as far as it can be", NotificationType.Warning);
+			}
+
+			//73
+			osnap.SubentType = (SubentType)this._mergedReaders.ReadBitShort();
+			//91
+			osnap.GsMarker = this._mergedReaders.ReadBitLong();
+
+			//The intersection object arrives the same way, and in every sample the count is zero: no
+			//intersection object, so no handle and no 74/92/332/302 to go with it.
+			int intersectPathIdCount = this._mergedReaders.ReadBitLong();
+			if (intersectPathIdCount != 0)
+			{
+				this.notify($"Osnap point reference names {intersectPathIdCount} intersection object ids; no drawing measured so far has any, so the intersection fields are not read", NotificationType.Warning);
+			}
+
+			//40
+			osnap.GeometryParameter = this._mergedReaders.ReadBitDouble();
+			//10, 20, 30
+			osnap.OsnapPoint = this._mergedReaders.Read3BitDouble();
+			//75
+			osnap.HasLastPointRef = this._mergedReaders.ReadBit();
+
 			return template;
 		}
 

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
@@ -49,7 +49,6 @@ internal partial class DwgObjectWriter : DwgSectionIO
 			case AecWallStyle:
 			case AecCleanupGroup:
 			case AecBinRecord:
-			case DimensionAssociation:
 			case UnknownNonGraphicalObject:
 			case VisualStyle:
 			case ProxyObject:
@@ -914,32 +913,63 @@ internal partial class DwgObjectWriter : DwgSectionIO
 	{
 		this._writer.HandleReference(DwgReferenceType.SoftPointer, association.Dimension);
 
+		//The flags say which references follow, so a flag set with no reference behind it would
+		//promise data that is not there and leave everything after this object misaligned. Write the
+		//flags the references actually support.
+		AssociativityFlags flags = this.presentPointReferences(association);
+
 		//90
-		this._writer.WriteBitLong((int)association.AssociativityFlags);
+		this._writer.WriteBitLong((int)flags);
 		//70
 		this._writer.WriteBit(association.IsTransSpace);
 		//71
 		this._writer.WriteByte((byte)association.RotatedDimensionType);
 
-		if (association.AssociativityFlags.HasFlag(AssociativityFlags.FirstPointReference))
+		if (flags.HasFlag(AssociativityFlags.FirstPointReference))
 		{
 			this.writeOsnapPointRef(association.FirstPointRef);
 		}
 
-		if (association.AssociativityFlags.HasFlag(AssociativityFlags.SecondPointReference))
+		if (flags.HasFlag(AssociativityFlags.SecondPointReference))
 		{
 			this.writeOsnapPointRef(association.SecondPointRef);
 		}
 
-		if (association.AssociativityFlags.HasFlag(AssociativityFlags.ThirdPointReference))
+		if (flags.HasFlag(AssociativityFlags.ThirdPointReference))
 		{
 			this.writeOsnapPointRef(association.ThirdPointRef);
 		}
 
-		if (association.AssociativityFlags.HasFlag(AssociativityFlags.FourthPointReference))
+		if (flags.HasFlag(AssociativityFlags.FourthPointReference))
 		{
 			this.writeOsnapPointRef(association.FourthPointRef);
 		}
+	}
+
+	/// <summary>
+	/// The associativity flags of <paramref name="association"/> narrowed to the point references it
+	/// actually carries, so a file never claims a reference it does not go on to write.
+	/// </summary>
+	private AssociativityFlags presentPointReferences(DimensionAssociation association)
+	{
+		AssociativityFlags flags = association.AssociativityFlags;
+
+		void drop(AssociativityFlags flag, DimensionAssociation.OsnapPointRef pointRef)
+		{
+			if (!flags.HasFlag(flag) || pointRef != null)
+			{
+				return;
+			}
+
+			flags &= ~flag;
+			this.notify($"Dimension association {association.Handle} is flagged {flag} but carries no reference for it; the flag is left out so the file stays readable", NotificationType.Warning);
+		}
+
+		drop(AssociativityFlags.FirstPointReference, association.FirstPointRef);
+		drop(AssociativityFlags.SecondPointReference, association.SecondPointRef);
+		drop(AssociativityFlags.ThirdPointReference, association.ThirdPointRef);
+		drop(AssociativityFlags.FourthPointReference, association.FourthPointRef);
+		return flags;
 	}
 
 	private void writeDynamicBlockPurgePreventer(DynamicBlockPurgePreventer purge)
@@ -1937,6 +1967,28 @@ internal partial class DwgObjectWriter : DwgSectionIO
 		this._writer.WriteByte((byte)osnap.ObjectOsnapType);
 		//331
 		this._writer.HandleReference(DwgReferenceType.Undefined, osnap.Geometry);
+
+		//The rest of the reference, in the order the reader now reads it back - see
+		//DwgObjectReader.readOsnapPointRef, where the layout and how it was measured are written down.
+
+		//The main object is named by a subentity path: how many object ids, then the subentity. The
+		//single id is the geometry handle written just above.
+		this._writer.WriteBitLong(1);
+
+		//73
+		this._writer.WriteBitShort((short)osnap.SubentType);
+		//91
+		this._writer.WriteBitLong(osnap.GsMarker);
+
+		//No intersection object: zero ids in that path, so no handle and no 74/92/332/302 follow.
+		this._writer.WriteBitLong(0);
+
+		//40
+		this._writer.WriteBitDouble(osnap.GeometryParameter);
+		//10, 20, 30
+		this._writer.Write3BitDouble(osnap.OsnapPoint);
+		//75
+		this._writer.WriteBit(osnap.HasLastPointRef);
 	}
 
 	private void writeParameterValueSet(ParameterValueSet valueSet)

--- a/src/ACadSharp/IO/DXF/DxfStreamReader/DxfObjectsSectionReader.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamReader/DxfObjectsSectionReader.cs
@@ -1205,7 +1205,9 @@ internal class DxfObjectsSectionReader : DxfSectionReaderBase
 					&& dimassoc.FirstPointRef == null)
 				{
 					dimassoc.FirstPointRef = new DimensionAssociation.OsnapPointRef();
-					this.readOsnapPointRef(dimassoc.FirstPointRef);
+					//The template carries the 331 handle; dropping it left every geometry reference
+					//read from a DXF unresolved, which nothing noticed while the writer was disabled.
+					tmp.FirstPointRef = this.readOsnapPointRef(dimassoc.FirstPointRef);
 					this.lockPointer = true;
 					return true;
 				}
@@ -1214,7 +1216,9 @@ internal class DxfObjectsSectionReader : DxfSectionReaderBase
 					&& dimassoc.SecondPointRef == null)
 				{
 					dimassoc.SecondPointRef = new DimensionAssociation.OsnapPointRef();
-					this.readOsnapPointRef(dimassoc.SecondPointRef);
+					//The template carries the 331 handle; dropping it left every geometry reference
+					//read from a DXF unresolved, which nothing noticed while the writer was disabled.
+					tmp.SecondPointRef = this.readOsnapPointRef(dimassoc.SecondPointRef);
 					this.lockPointer = true;
 					return true;
 				}
@@ -1223,7 +1227,9 @@ internal class DxfObjectsSectionReader : DxfSectionReaderBase
 					&& dimassoc.ThirdPointRef == null)
 				{
 					dimassoc.ThirdPointRef = new DimensionAssociation.OsnapPointRef();
-					this.readOsnapPointRef(dimassoc.ThirdPointRef);
+					//The template carries the 331 handle; dropping it left every geometry reference
+					//read from a DXF unresolved, which nothing noticed while the writer was disabled.
+					tmp.ThirdPointRef = this.readOsnapPointRef(dimassoc.ThirdPointRef);
 					this.lockPointer = true;
 					return true;
 				}
@@ -1232,7 +1238,9 @@ internal class DxfObjectsSectionReader : DxfSectionReaderBase
 					&& dimassoc.FourthPointRef == null)
 				{
 					dimassoc.FourthPointRef = new DimensionAssociation.OsnapPointRef();
-					this.readOsnapPointRef(dimassoc.FourthPointRef);
+					//The template carries the 331 handle; dropping it left every geometry reference
+					//read from a DXF unresolved, which nothing noticed while the writer was disabled.
+					tmp.FourthPointRef = this.readOsnapPointRef(dimassoc.FourthPointRef);
 					this.lockPointer = true;
 					return true;
 				}

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
@@ -722,7 +722,6 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 			case AecWallStyle:
 			case AecCleanupGroup:
 			case AecBinRecord:
-			case DimensionAssociation:
 			case Material:
 			case MultiLeaderObjectContextData:
 			case VisualStyle:
@@ -1400,30 +1399,60 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 
 		this._writer.Write(100, DxfSubclassMarker.DimensionAssociation);
 
+		//A flag set with no reference behind it would promise a reference the file never writes, so
+		//the flags written are the ones the references actually support.
+		AssociativityFlags flags = this.presentPointReferences(dimAssociation);
+
 		this._writer.WriteHandle(330, dimAssociation.Dimension, map);
-		this._writer.Write(90, (int)dimAssociation.AssociativityFlags, map);
+		this._writer.Write(90, (int)flags, map);
 		this._writer.Write(70, dimAssociation.IsTransSpace, map);
 		this._writer.Write(71, (short)dimAssociation.RotatedDimensionType, map);
 
-		if (dimAssociation.AssociativityFlags.HasFlag(AssociativityFlags.FirstPointReference))
+		if (flags.HasFlag(AssociativityFlags.FirstPointReference))
 		{
 			this.writeOsnapPointRef(dimAssociation.FirstPointRef);
 		}
 
-		if (dimAssociation.AssociativityFlags.HasFlag(AssociativityFlags.SecondPointReference))
+		if (flags.HasFlag(AssociativityFlags.SecondPointReference))
 		{
 			this.writeOsnapPointRef(dimAssociation.SecondPointRef);
 		}
 
-		if (dimAssociation.AssociativityFlags.HasFlag(AssociativityFlags.ThirdPointReference))
+		if (flags.HasFlag(AssociativityFlags.ThirdPointReference))
 		{
 			this.writeOsnapPointRef(dimAssociation.ThirdPointRef);
 		}
 
-		if (dimAssociation.AssociativityFlags.HasFlag(AssociativityFlags.FourthPointReference))
+		if (flags.HasFlag(AssociativityFlags.FourthPointReference))
 		{
 			this.writeOsnapPointRef(dimAssociation.FourthPointRef);
 		}
+	}
+
+	/// <summary>
+	/// The associativity flags of <paramref name="association"/> narrowed to the point references it
+	/// actually carries, so a file never claims a reference it does not go on to write.
+	/// </summary>
+	private AssociativityFlags presentPointReferences(DimensionAssociation association)
+	{
+		AssociativityFlags flags = association.AssociativityFlags;
+
+		void drop(AssociativityFlags flag, DimensionAssociation.OsnapPointRef pointRef)
+		{
+			if (!flags.HasFlag(flag) || pointRef != null)
+			{
+				return;
+			}
+
+			flags &= ~flag;
+			this.notify($"Dimension association {association.Handle} is flagged {flag} but carries no reference for it; the flag is left out so the file stays readable", NotificationType.Warning);
+		}
+
+		drop(AssociativityFlags.FirstPointReference, association.FirstPointRef);
+		drop(AssociativityFlags.SecondPointReference, association.SecondPointRef);
+		drop(AssociativityFlags.ThirdPointReference, association.ThirdPointRef);
+		drop(AssociativityFlags.FourthPointReference, association.FourthPointRef);
+		return flags;
 	}
 
 	private void writeDxfValuePair(DxfValuePair pair)


### PR DESCRIPTION
﻿
# Description

`DIMASSOC` is what ties a dimension to the geometry it measures. This library reads the type and
models it fully, but no file ever gets one back: `isObjectSupported` rejects it before dispatch can
reach the writer, with the comment *"ignore dimassoc due missing testing"*. The DXF writer behind
that gate has been complete since 7988a843.

Opening the gate on its own would have written something untrue, because two defects sat behind it.
Both are fixed here, and each is worth stating separately.

**The DWG reader stopped three fields into each osnap point reference.** A DWG object stream is
length delimited, so the four fields after the class name, the osnap type and the 331 handle were
skipped without a word - and every dimension association read from a DWG came back claiming its
osnap point was the origin, with no geometry parameter, subentity type or GS marker.

The layout was read off the bits against AutoCAD's own DXF export of a production drawing:

```
BL   object ids in the main subentity path (1 in every sample)
BS   73  subentity type
BL   91  GS marker
BL   object ids in the intersection path (0 in every sample)
BD   40  geometry parameter
3BD  10  osnap point
B    75  has last point reference
```

Two of that drawing's seven associations disagree with the other five - `91=0` and `40=0.0` where
the rest have `91=1` and `40=1.0` - and that disagreement is what identifies which field is which.
One sample would have fitted several readings equally well. The Z coordinate anchors the rest: its
64 bits decode to exactly the `2.0e+50` AutoCAD writes.

The two counts are inferred from one drawing, so a differing value is **reported rather than read
through**. No sample carries an intersection object, which is why 74, 92, 332 and 302 are still
unread.

**The DXF reader threw away the template that holds the 331 handle.** `readOsnapPointRef` builds a
template, records the geometry handle in it and returns it; all four callers dropped it on the floor,
so nothing ever resolved the handle and every geometry reference read from a DXF had a null
`Geometry`. It went unnoticed precisely because the writer was disabled - no round trip could see it.

**A third hole, in both writers.** The associativity flags say how many references follow, and both
wrote the model's flags before writing the references. A flag with no reference behind it promises
data the file never writes, which in a DWG misaligns everything after the object. Both now write the
flags the references actually support, and report each one they had to drop.

# Measurements

AutoCAD 2027, on the production drawing that carries them, against the recorded baseline for its
three channels: DWG R2018 **28 errors**, DWG R2000 **28**, DXF **26** - each exactly what it was
before. A type census of a round trip no longer reports the class as dropped, and reading our own
DWG back returns all seven associations with every field intact.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`DimensionAssociationWriteTests`, eight cases - the testing the gate was waiting for: a round trip
through DXF and through DWG keeps every field of every reference; a flag with no reference behind it
is dropped and reported rather than written; the osnap point, geometry parameter, subentity type and
GS marker come back as AutoCAD wrote them.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

