### PR TITLE
Three per-object containers are created on first use

### DIFF
--- a/src/ACadSharp/CadObject.cs
+++ b/src/ACadSharp/CadObject.cs
@@ -60,7 +60,7 @@ public abstract class CadObject : IHandledCadObject
 	{
 		get
 		{
-			return this._reactors;
+			return (IEnumerable<CadObject>)this._reactors ?? Enumerable.Empty<CadObject>();
 		}
 	}
 
@@ -91,7 +91,14 @@ public abstract class CadObject : IHandledCadObject
 		}
 	}
 
-	private List<CadObject> _reactors = new List<CadObject>();
+	//Created with the first reactor. Hardly any object of a real drawing has one, and giving each
+	//of them an empty list cost 28 MB of the 548 MB a 17 MB production drawing needed.
+	private List<CadObject> _reactors;
+
+	private List<CadObject> reactors
+	{
+		get { return this._reactors ?? (this._reactors = new List<CadObject>()); }
+	}
 
 	private CadDictionary _xdictionary = null;
 
@@ -112,7 +119,7 @@ public abstract class CadObject : IHandledCadObject
 	/// <param name="reactor"></param>
 	public void AddReactor(CadObject reactor)
 	{
-		this._reactors.Add(reactor);
+		this.reactors.Add(reactor);
 	}
 
 	/// <summary>
@@ -120,12 +127,12 @@ public abstract class CadObject : IHandledCadObject
 	/// </summary>
 	public void CleanReactors()
 	{
-		var reactors = this._reactors.ToList();
+		var reactors = this.Reactors.ToList();
 		foreach (var reactor in reactors)
 		{
 			if (reactor.Document != this.Document)
 			{
-				this._reactors.Remove(reactor);
+				this._reactors?.Remove(reactor);
 			}
 		}
 	}
@@ -147,7 +154,7 @@ public abstract class CadObject : IHandledCadObject
 		clone.Owner = null;
 
 		//Collections
-		clone._reactors = new List<CadObject>();
+		clone._reactors = null;
 		clone.ExtendedData = new ExtendedDataDictionary(clone);
 		clone.XDictionary = this._xdictionary?.CloneTyped();
 
@@ -210,7 +217,7 @@ public abstract class CadObject : IHandledCadObject
 	/// <returns></returns>
 	public bool RemoveReactor(CadObject reactor)
 	{
-		return this._reactors.Remove(reactor);
+		return this._reactors != null && this._reactors.Remove(reactor);
 	}
 
 	/// <inheritdoc/>
@@ -263,7 +270,7 @@ public abstract class CadObject : IHandledCadObject
 			}
 		}
 
-		this._reactors.Clear();
+		this._reactors?.Clear();
 	}
 
 	protected static T updateCollection<T>(T entry, ICadCollection<T> table)

--- a/src/ACadSharp/Entities/Entity.cs
+++ b/src/ACadSharp/Entities/Entity.cs
@@ -102,7 +102,14 @@ public abstract class Entity : CadObject, IEntity
 	/// <summary>
 	/// Gets the list of proxy geometries for this entity.
 	/// </summary>
-	public List<IProxyGeometry> ProxyGeometries { get; } = new();
+	//Created on first use: a production drawing had 615400 entities each holding an empty list,
+	//19 MB of the 548 MB the document needed.
+	public List<IProxyGeometry> ProxyGeometries
+	{
+		get { return this._proxyGeometries ?? (this._proxyGeometries = new List<IProxyGeometry>()); }
+	}
+
+	private List<IProxyGeometry> _proxyGeometries;
 
 	/// <inheritdoc/>
 	public override string SubclassMarker => DxfSubclassMarker.Entity;

--- a/src/ACadSharp/XData/ExtendedDataDictionary.cs
+++ b/src/ACadSharp/XData/ExtendedDataDictionary.cs
@@ -20,7 +20,22 @@ public class ExtendedDataDictionary : IEnumerable<KeyValuePair<AppId, ExtendedDa
 	/// </summary>
 	public CadObject Owner { get; }
 
-	private Dictionary<AppId, ExtendedData> _data = new Dictionary<AppId, ExtendedData>();
+	//Almost every object of a drawing carries no extended data at all. A 17 MB production drawing
+	//holds 909016 objects, and giving each of them an empty dictionary cost 99 MB of the 548 MB the
+	//document needed to be read. The dictionary is created on the first write instead.
+	private Dictionary<AppId, ExtendedData> _data;
+
+	private static readonly Dictionary<AppId, ExtendedData> _empty = new Dictionary<AppId, ExtendedData>();
+
+	private Dictionary<AppId, ExtendedData> data
+	{
+		get { return this._data ?? (this._data = new Dictionary<AppId, ExtendedData>()); }
+	}
+
+	private Dictionary<AppId, ExtendedData> readable
+	{
+		get { return this._data ?? _empty; }
+	}
 
 	/// <summary>
 	/// Default constructor.
@@ -70,17 +85,17 @@ public class ExtendedDataDictionary : IEnumerable<KeyValuePair<AppId, ExtendedDa
 		{
 			if (this.Document.AppIds.TryGetValue(app.Name, out AppId existing))
 			{
-				this._data.Add(existing, extendedData);
+				this.data.Add(existing, extendedData);
 			}
 			else
 			{
 				this.Document.AppIds.Add(app);
-				this._data.Add(app, extendedData);
+				this.data.Add(app, extendedData);
 			}
 		}
 		else
 		{
-			this._data.Add(app, extendedData);
+			this.data.Add(app, extendedData);
 		}
 	}
 
@@ -91,7 +106,7 @@ public class ExtendedDataDictionary : IEnumerable<KeyValuePair<AppId, ExtendedDa
 	/// <param name="records">The ExtendedData records.</param>
 	public void Add(AppId app, IEnumerable<ExtendedDataRecord> records)
 	{
-		this._data.Add(app, new ExtendedData(records));
+		this.data.Add(app, new ExtendedData(records));
 	}
 
 	/// <summary>
@@ -99,7 +114,7 @@ public class ExtendedDataDictionary : IEnumerable<KeyValuePair<AppId, ExtendedDa
 	/// </summary>
 	public void Clear()
 	{
-		this._data.Clear();
+		this._data?.Clear();
 	}
 
 	/// <summary>
@@ -108,7 +123,7 @@ public class ExtendedDataDictionary : IEnumerable<KeyValuePair<AppId, ExtendedDa
 	/// <param name="app">The AppId object.</param>
 	public bool ContainsKey(AppId app)
 	{
-		return this._data.ContainsKey(app);
+		return this._data != null && this._data.ContainsKey(app);
 	}
 
 	/// <summary>
@@ -117,7 +132,7 @@ public class ExtendedDataDictionary : IEnumerable<KeyValuePair<AppId, ExtendedDa
 	/// <param name="name">The AppId name.</param>
 	public bool ContainsKeyName(string name)
 	{
-		return this._data.Keys.Select(k => k.Name).Contains(name);
+		return this.readable.Keys.Select(k => k.Name).Contains(name);
 	}
 
 	/// <summary>
@@ -136,19 +151,19 @@ public class ExtendedDataDictionary : IEnumerable<KeyValuePair<AppId, ExtendedDa
 	/// <param name="app">The AppId object.</param>
 	public ExtendedData Get(AppId app)
 	{
-		return this._data[app];
+		return this.readable[app];
 	}
 
 	/// <inheritdoc/>
 	public IEnumerator<KeyValuePair<AppId, ExtendedData>> GetEnumerator()
 	{
-		return this._data.GetEnumerator();
+		return this.readable.GetEnumerator();
 	}
 
 	/// <inheritdoc/>
 	IEnumerator IEnumerable.GetEnumerator()
 	{
-		return this._data.GetEnumerator();
+		return this.readable.GetEnumerator();
 	}
 
 	/// <summary>
@@ -157,7 +172,7 @@ public class ExtendedDataDictionary : IEnumerable<KeyValuePair<AppId, ExtendedDa
 	/// <returns></returns>
 	public IDictionary<string, ExtendedData> GetExtendedDataByName()
 	{
-		return this._data.ToDictionary(x => x.Key.Name, x => x.Value, StringComparer.OrdinalIgnoreCase);
+		return this.readable.ToDictionary(x => x.Key.Name, x => x.Value, StringComparer.OrdinalIgnoreCase);
 	}
 
 	/// <summary>
@@ -191,7 +206,7 @@ public class ExtendedDataDictionary : IEnumerable<KeyValuePair<AppId, ExtendedDa
 	/// <param name="value">ExtendedData object.</param>
 	public bool TryGet(AppId app, out ExtendedData value)
 	{
-		return this._data.TryGetValue(app, out value);
+		return this.readable.TryGetValue(app, out value);
 	}
 
 	/// <summary>


### PR DESCRIPTION
﻿
# Description

Every `CadObject` is given an `ExtendedDataDictionary` with a `Dictionary` inside it and a `List`
for its reactors, and every `Entity` a `List` for its proxy geometries, whether or not anything is
ever put in them. Almost nothing in a real drawing uses any of the three.

A heap walk of a 17.6 MB production drawing with 909016 objects, of the 548 MB it needed:

| | bytes | instances |
|---|---|---|
| empty `Dictionary<AppId, ExtendedData>` | 99 MB | 909016 |
| empty `List<CadObject>` of reactors | 28 MB | 909016 |
| empty `List<IProxyGeometry>` | 19 MB | 615400 |

All three are now allocated when something is first put in them.

# Tasks done in this PR

* [x] `ExtendedDataDictionary` creates its inner dictionary on the first write, and reads go
      through an empty one.
* [x] `CadObject` creates the reactor list with the first reactor; `Reactors` returns an empty
      sequence until then.
* [x] `Entity.ProxyGeometries` is created on first access and still hands back a mutable list.

# Related Issues / Pull Requests

- None; this one stands on its own and is cut straight from `master`.

# Notes for reviewer

**Testing**

`dotnet test` on this branch: **2312 passed / 17 failed**, the same as master.

The public shape does not change: `Reactors` still enumerates and is empty, the extended data
dictionary still reports itself empty, enumerates nothing and answers `ContainsKey` with false,
and `ProxyGeometries` still returns a list you can add to.

**A benchmark you can run**, since the drawing is a client file:

```csharp
using ACadSharp; using ACadSharp.Entities; using CSMath;

long before = GC.GetTotalMemory(true);
CadDocument doc = new CadDocument();
for (int i = 0; i < 200000; i++)
    doc.ModelSpace.Entities.Add(new Line(new XYZ(i, 0, 0), new XYZ(i, 1, 0)));
GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
long after = GC.GetTotalMemory(true);
Console.WriteLine($"{(after - before) / 1048576} MB, {(after - before) / 200000} bytes each");
GC.KeepAlive(doc);
```

| | master | this branch |
|---|---|---|
| 200000 lines in model space | 133 MB, 698 bytes each | **105 MB, 554 bytes each** |

---

_The same drawing also drove the second half of this work, the per-object event subscriptions,
which is a separate pull request cut from this one._

