### PR TITLE
A repositioned reader decides again whether the object has a string stream

### DIFF
--- a/src/ACadSharp.Tests/IO/DWG/DwgStreamReaderStateTests.cs
+++ b/src/ACadSharp.Tests/IO/DWG/DwgStreamReaderStateTests.cs
@@ -1,0 +1,57 @@
+using ACadSharp.IO.DWG;
+using System.IO;
+using Xunit;
+
+namespace ACadSharp.Tests.IO.DWG;
+
+public class DwgStreamReaderStateTests
+{
+	/// <summary>
+	/// Moving a reader to another object has to decide again whether that object has a string
+	/// stream. The flag used to be latched on, so a reader that had seen one object without a
+	/// string stream reported every later object as empty too, and the values read after that were
+	/// wrong without anything being thrown.
+	/// </summary>
+	[Fact]
+	public void MovingToAnObjectWithAStringStreamClearsTheEmptyFlag()
+	{
+		//A zeroed buffer with a single bit set: at bit 100 the string stream flag is 1, and the
+		//size field it then reads, at bit 84, is zero, which is a string stream of length zero.
+		byte[] buffer = new byte[32];
+		buffer[12] = 0x08;
+
+		IDwgStreamReader reader = DwgStreamReaderBase.GetStreamHandler(
+			ACadVersion.AC1032,
+			new MemoryStream(buffer));
+
+		//Bit 200 is zero: no string stream.
+		reader.SetPositionByFlag(200);
+		Assert.True(reader.IsEmpty, "an object without a string stream should report empty");
+
+		//The same reader, moved to the object whose flag is set.
+		reader.SetPositionByFlag(100);
+		Assert.False(reader.IsEmpty, "a reader moved to an object with a string stream is not empty");
+	}
+
+	[Fact]
+	public void AFreshReaderAndAMovedOneAgreeOnTheSameObject()
+	{
+		byte[] buffer = new byte[32];
+		buffer[12] = 0x08;
+
+		IDwgStreamReader fresh = DwgStreamReaderBase.GetStreamHandler(
+			ACadVersion.AC1032,
+			new MemoryStream(buffer));
+		long freshPosition = fresh.SetPositionByFlag(100);
+
+		IDwgStreamReader moved = DwgStreamReaderBase.GetStreamHandler(
+			ACadVersion.AC1032,
+			new MemoryStream(buffer));
+		moved.SetPositionByFlag(200);
+		long movedPosition = moved.SetPositionByFlag(100);
+
+		Assert.Equal(fresh.IsEmpty, moved.IsEmpty);
+		Assert.Equal(freshPosition, movedPosition);
+		Assert.Equal(fresh.PositionInBits(), moved.PositionInBits());
+	}
+}

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgStreamReaderBase.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgStreamReaderBase.cs
@@ -373,6 +373,13 @@ namespace ACadSharp.IO.DWG
 
 		public long SetPositionByFlag(long position)
 		{
+			//Whether a string stream is present is a property of the object this reader is being
+			//placed on, so it is decided again here. It used to be latched: once an object without
+			//one had set it, every later object read by the same reader was taken for empty as
+			//well. A reader built per object never noticed; a reader moved from one object to the
+			//next silently read the wrong values.
+			this.IsEmpty = false;
+
 			this.SetPositionInBits(position);
 
 			//String stream present bit (last bit in pre-handles section).


### PR DESCRIPTION
﻿
# Description

`DwgStreamReaderBase.SetPositionByFlag` places a reader on an object and works out whether that
object carries a string stream. When there is none it sets `IsEmpty`, and nothing ever sets it
back:

```csharp
public long SetPositionByFlag(long position)
{
    this.SetPositionInBits(position);
    bool flag = this.ReadBit();
    if (flag) { /* ...position on the string stream... */ }
    else
    {
        this.IsEmpty = true;      //never cleared again
        this.Position = this.Stream.Length;
    }
}
```

So the flag is a one-way latch on the **reader** rather than a fact about the object it currently
points at.

Every reader is built per object today, so nothing reaches the latch in practice. It is still
wrong, and wrong in the dangerous direction: a reader moved from an object without a string stream
to one that has it reports the second as empty too, and the values read after that are wrong with
nothing thrown.

The rest of the reader's state already survives repositioning correctly - `SetPositionInBits` sets
the byte position and the bit shift and refreshes the cached byte when the shift is not zero, and
`ReadBit` refreshes it when it is - so `IsEmpty` was the only field left behind.

# Tasks done in this PR

* [x] Clear `IsEmpty` at the top of `SetPositionByFlag`, so the method's own outcome decides it.
* [x] `DwgStreamReaderStateTests`: a reader moved from an object without a string stream to one
      with it agrees with a fresh reader, on the flag and on the resulting position.

# Related Issues / Pull Requests

- None; this one stands on its own and is cut straight from `master`.

# Notes for reviewer

**Testing**

`dotnet test` on this branch: **2314 passed / 17 failed** - master's 2312/17 plus the two new
tests. Both fail without the one-line change.

The test builds its own buffer rather than needing a drawing: 32 zero bytes with a single bit set,
so that one bit position has a string stream present and another does not.

This was found while trying to reuse readers instead of allocating three per object. That
optimisation is the next pull request; this fix is worth having on its own, because the latch is a
trap for anyone who reuses a reader and it fails silently.

---

_On a 17.6 MB drawing read with reused readers, the latch made two MATERIAL round-trip tests read
wrong values; with this change they pass._

