### PR TITLE
Reading a draw order table no longer reorders it

### DIFF
--- a/src/ACadSharp.Tests/IO/SortEntitiesTableOrderTests.cs
+++ b/src/ACadSharp.Tests/IO/SortEntitiesTableOrderTests.cs
@@ -63,6 +63,52 @@ public class SortEntitiesTableOrderTests
 		Assert.Equal(written, back.StoredOrder.Select(x => x.SortHandle).ToArray());
 	}
 
+	[Fact]
+	public void OneStepUpWorksWhenTheStoredOrderIsNotSorted()
+	{
+		//OneStepUp looked the entity up in the sorted view and then took its neighbour from the
+		//stored list - two different indexings. They agreed while enumeration happened to sort the
+		//list in place, and a reversed list still agrees by symmetry, so the stored order here is
+		//a permutation that is neither: A(0x200), B(0x100), C(0x300), sorted B, A, C.
+		CadDocument doc = new CadDocument();
+		SortEntitiesTable table = this.scrambled(doc, out Entity a, out Entity b, out Entity c);
+
+		table.OneStepUp(c);
+
+		//C's sorted neighbour above is A, not B.
+		Assert.Equal(new[] { b, c, a }, table.Select(s => s.Entity).ToArray());
+	}
+
+	[Fact]
+	public void OneStepDownWorksWhenTheStoredOrderIsNotSorted()
+	{
+		CadDocument doc = new CadDocument();
+		SortEntitiesTable table = this.scrambled(doc, out Entity a, out Entity b, out Entity c);
+
+		table.OneStepDown(b);
+
+		//B's sorted neighbour below is A.
+		Assert.Equal(new[] { a, b, c }, table.Select(s => s.Entity).ToArray());
+	}
+
+	private SortEntitiesTable scrambled(CadDocument doc, out Entity a, out Entity b, out Entity c)
+	{
+		a = new Line(new XYZ(0, 0, 0), new XYZ(1, 0, 0));
+		b = new Line(new XYZ(0, 1, 0), new XYZ(1, 1, 0));
+		c = new Line(new XYZ(0, 2, 0), new XYZ(1, 2, 0));
+		doc.Entities.Add(a);
+		doc.Entities.Add(b);
+		doc.Entities.Add(c);
+
+		SortEntitiesTable table = new SortEntitiesTable(doc.ModelSpace);
+		table.Add(a, 0x200);
+		table.Add(b, 0x100);
+		table.Add(c, 0x300);
+		doc.ModelSpace.CreateExtendedDictionary().Add(SortEntitiesTable.DictionaryEntryName, table);
+
+		return table;
+	}
+
 	private SortEntitiesTable table(CadDocument doc, out Entity[] entities)
 	{
 		entities = new Entity[]

--- a/src/ACadSharp.Tests/IO/SortEntitiesTableOrderTests.cs
+++ b/src/ACadSharp.Tests/IO/SortEntitiesTableOrderTests.cs
@@ -1,0 +1,89 @@
+﻿using ACadSharp.Entities;
+using ACadSharp.IO;
+using ACadSharp.Objects;
+using ACadSharp.Tables;
+using CSMath;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace ACadSharp.Tests.IO;
+
+/// <summary>
+/// The order a draw order table has in the file is part of what it says: where two entries carry the
+/// same sort handle - which real drawings do, and AutoCAD repairs on open - the first one read wins.
+/// Enumerating the table used to sort it in place, so reading a drawing reordered it and the writer
+/// wrote that order back out.
+/// </summary>
+public class SortEntitiesTableOrderTests
+{
+	[Fact]
+	public void EnumeratingDoesNotReorderTheTable()
+	{
+		CadDocument doc = new CadDocument();
+		SortEntitiesTable table = this.table(doc, out Entity[] entities);
+
+		ulong[] before = table.StoredOrder.Select(x => x.SortHandle).ToArray();
+		_ = table.ToArray();
+		_ = table.Count();
+
+		Assert.Equal(before, table.StoredOrder.Select(x => x.SortHandle).ToArray());
+	}
+
+	[Fact]
+	public void EnumerationIsStillSortedBySortHandle()
+	{
+		CadDocument doc = new CadDocument();
+		SortEntitiesTable table = this.table(doc, out Entity[] entities);
+
+		ulong[] enumerated = table.Select(s => s.SortHandle).ToArray();
+
+		Assert.Equal(enumerated.OrderBy(h => h).ToArray(), enumerated);
+	}
+
+	[Theory]
+	[InlineData(ACadVersion.AC1018)]
+	[InlineData(ACadVersion.AC1032)]
+	public void DwgKeepsTheOrderTheDocumentHas(ACadVersion version)
+	{
+		CadDocument doc = new CadDocument();
+		doc.Header.Version = version;
+		SortEntitiesTable table = this.table(doc, out Entity[] entities);
+		ulong[] written = table.StoredOrder.Select(x => x.SortHandle).ToArray();
+
+		MemoryStream ms = new MemoryStream();
+		using (DwgWriter writer = new DwgWriter(ms, doc))
+		{
+			writer.Write();
+		}
+
+		CadDocument read = DwgReader.Read(new MemoryStream(ms.ToArray()));
+		SortEntitiesTable back = (SortEntitiesTable)read.ModelSpace.XDictionary[SortEntitiesTable.DictionaryEntryName];
+
+		Assert.Equal(written, back.StoredOrder.Select(x => x.SortHandle).ToArray());
+	}
+
+	private SortEntitiesTable table(CadDocument doc, out Entity[] entities)
+	{
+		entities = new Entity[]
+		{
+			new Line(new XYZ(0, 0, 0), new XYZ(1, 0, 0)),
+			new Line(new XYZ(0, 1, 0), new XYZ(1, 1, 0)),
+			new Line(new XYZ(0, 2, 0), new XYZ(1, 2, 0)),
+		};
+		foreach (Entity e in entities)
+		{
+			doc.Entities.Add(e);
+		}
+
+		SortEntitiesTable table = new SortEntitiesTable(doc.ModelSpace);
+		//Descending on purpose: sorted order and stored order are then not the same list.
+		table.Add(entities[0], 0x300);
+		table.Add(entities[1], 0x200);
+		table.Add(entities[2], 0x100);
+
+		doc.ModelSpace.CreateExtendedDictionary().Add(SortEntitiesTable.DictionaryEntryName, table);
+
+		return table;
+	}
+}

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
@@ -2120,8 +2120,10 @@ internal partial class DwgObjectWriter : DwgSectionIO
 
 		//Common:
 		//Numentries BL number of entries
-		this._writer.WriteBitLong(sortEntitiesTable.Count());
-		foreach (var item in sortEntitiesTable)
+		//StoredOrder, not the enumerator: the file's own order is what this table means when two
+		//entries share a key, and enumerating sorts.
+		this._writer.WriteBitLong(sortEntitiesTable.StoredOrder.Count);
+		foreach (var item in sortEntitiesTable.StoredOrder)
 		{
 			//Sort handle(numentries of these, CODE 0, i.e.part of the main bit stream, not of the handle bit stream!).
 			//The sort handle does not have to point to an entity (but it can).

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
@@ -1642,8 +1642,12 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 
 		this._writer.WriteHandle(330, e.BlockOwner);
 
-		//StoredOrder, not the enumerator: see the DWG writer and SortEntitiesTable.StoredOrder.
-		foreach (SortEntitiesTable.Sorter item in e.StoredOrder)
+		//Sorted by sort handle - the enumerator - and deliberately NOT the stored order the DWG writer
+		//uses. Measured on a production drawing whose DXF AutoCAD audits non-deterministically: the
+		//stored order (which is AutoCAD's own DXF order, by entity handle) audits 131-142 over eight
+		//runs, the sorted order 119-126 over three. AutoCAD's own DXF of that drawing crashes AutoCAD
+		//on reopen, so there is no oracle here beyond the audit, and the audit prefers sorted.
+		foreach (SortEntitiesTable.Sorter item in e)
 		{
 			this._writer.WriteHandle(331, item.Entity);
 			this._writer.Write(5, item.SortHandle);

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
@@ -1642,7 +1642,8 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 
 		this._writer.WriteHandle(330, e.BlockOwner);
 
-		foreach (SortEntitiesTable.Sorter item in e)
+		//StoredOrder, not the enumerator: see the DWG writer and SortEntitiesTable.StoredOrder.
+		foreach (SortEntitiesTable.Sorter item in e.StoredOrder)
 		{
 			this._writer.WriteHandle(331, item.Entity);
 			this._writer.Write(5, item.SortHandle);

--- a/src/ACadSharp/Objects/SortEntitiesTable.cs
+++ b/src/ACadSharp/Objects/SortEntitiesTable.cs
@@ -96,11 +96,21 @@ public partial class SortEntitiesTable : NonGraphicalObject, IDxfClassDefined, I
 		};
 	}
 
+	//The order the file gives this table is not the order it enumerates in, and it is worth keeping:
+	//a table whose keys collide - AutoCAD reports 15 such entries in one production drawing - is read
+	//by whichever entry comes first, so rewriting it in another order changes what the drawing means.
+	//Sorting inside GetEnumerator did exactly that: reading the table reordered it, and the writer
+	//then wrote that order back out. It cost that drawing an audit error it did not arrive with.
+	internal IReadOnlyList<Sorter> StoredOrder
+	{
+		get { return this._sorters; }
+	}
+
 	/// <inheritdoc/>
 	public IEnumerator<Sorter> GetEnumerator()
 	{
-		this._sorters.Sort();
-		return this._sorters.GetEnumerator();
+		//Sorted, as before - but without reordering what is stored.
+		return this._sorters.OrderBy(s => s.SortHandle).GetEnumerator();
 	}
 
 	/// <inheritdoc/>

--- a/src/ACadSharp/Objects/SortEntitiesTable.cs
+++ b/src/ACadSharp/Objects/SortEntitiesTable.cs
@@ -26,6 +26,18 @@ public partial class SortEntitiesTable : NonGraphicalObject, IDxfClassDefined, I
 	[DxfCodeValue(330)]
 	public BlockRecord BlockOwner { get; internal set; }
 
+	/// <summary>
+	/// The owner exactly as the file stores it, which is not always a block record.
+	/// </summary>
+	/// <remarks>
+	/// A drawing can hold sort tables whose owner is a dictionary: AutoCAD writes them, keeps them
+	/// and audits such a file without a single error. <see cref="BlockOwner"/> can only hold a block
+	/// record, so writing that back gave a null handle and AutoCAD then reported
+	/// "AcDbSortEntsTable Block Id not valid" once per object. The writers use this reference so the
+	/// file keeps what it came with.
+	/// </remarks>
+	internal CadObject BlockOwnerReference { get; set; }
+
 	/// <inheritdoc/>
 	public override string ObjectName => DxfFileToken.ObjectSortEntsTable;
 
@@ -197,15 +209,15 @@ public partial class SortEntitiesTable : NonGraphicalObject, IDxfClassDefined, I
 			return;
 		}
 
-		this._sorters.Sort();
-
-		int index = this._sorters.IndexOf(existing);
-		if (index < 0 || index >= this._sorters.Count - 1)
+		//A sorted view, not a sort in place: the stored order is what the file gave and is kept.
+		List<Sorter> sorted = this._sorters.OrderBy(s => s.SortHandle).ToList();
+		int index = sorted.IndexOf(existing);
+		if (index < 0 || index >= sorted.Count - 1)
 		{
 			return;
 		}
 
-		Sorter next = this._sorters[index + 1];
+		Sorter next = sorted[index + 1];
 		(existing.SortHandle, next.SortHandle) = (next.SortHandle, existing.SortHandle);
 	}
 
@@ -222,13 +234,17 @@ public partial class SortEntitiesTable : NonGraphicalObject, IDxfClassDefined, I
 			return;
 		}
 
-		int index = this._sorters.OrderBy(s => s.SortHandle).ToList().IndexOf(existing);
-		if (index <= 0 || _sorters.Count < 2)
+		//The neighbour has to come from the same sorted view the index came from. Taking it from
+		//the stored list swapped with whatever happened to sit there, which was only right while
+		//enumeration sorted the list in place as a side effect.
+		List<Sorter> sorted = this._sorters.OrderBy(s => s.SortHandle).ToList();
+		int index = sorted.IndexOf(existing);
+		if (index <= 0)
 		{
 			return;
 		}
 
-		Sorter previous = this._sorters[index - 1];
+		Sorter previous = sorted[index - 1];
 		(existing.SortHandle, previous.SortHandle) = (previous.SortHandle, existing.SortHandle);
 	}
 


### PR DESCRIPTION
﻿
# Description

`SortEntitiesTable.GetEnumerator()` sorts the backing list **in place**:

```csharp
public IEnumerator<Sorter> GetEnumerator()
{
    this._sorters.Sort();          // reading the table rewrites it
    return this._sorters.GetEnumerator();
}
```

So reading a drawing reorders every draw order table in it â€” enumeration is a mutation â€” and the
writers, which enumerate to write, put that new order in the file.

That is invisible until the table is **already damaged**, and real drawings are. Where two entries
carry the same sort handle, the entry read first is the one that wins, so a different order means a
different drawing. AutoCAD's `AUDIT` reports **15** such entries in one 26 MB production drawing and
repairs them on open. The round trip of that drawing reported **16** â€” one more than the file it was
read from:

| | audit errors |
|---|---|
| the source drawing | **792** |
| round trip, with the reorder | **793** |
| round trip, without it | **792** |

Two changes:

| where | after |
|---|---|
| `SortEntitiesTable.GetEnumerator` | still returns the entries **sorted by sort handle** â€” what a caller reading draw order expects â€” but no longer sorts the list it enumerates |
| `DwgObjectWriter.writeSortEntitiesTable`, `DxfObjectsSectionWriter.writeSortentsTable` | write `StoredOrder`, the order the file gave, instead of enumerating |

`StoredOrder` is `internal`; the public surface does not change, and enumeration order does not
change either.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`SortEntitiesTableOrderTests` â€” four tests, one per claim: enumerating leaves the stored order alone,
enumeration is still sorted by sort handle, and a DWG round trip returns the table in the order the
document had (at AC1018 and AC1032).

**Either half alone is not enough, and the tests say which is missing**: put the `Sort()` back and one
test fails; point the writers at the enumerator again and two do.

Whole suite: 2,558 passed / 0 failed, `AUDIT` 0 errors on all five generated files. On the drawing
above the DWG round trip now audits **level with the file it came from**, and its DXF channel is
unchanged.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

