### PR TITLE
A block action keeps every object it refers to, not only the entities

### DIFF
--- a/src/ACadSharp.Tests/IO/BlockActionReferencesTests.cs
+++ b/src/ACadSharp.Tests/IO/BlockActionReferencesTests.cs
@@ -1,0 +1,81 @@
+﻿using ACadSharp.Entities;
+using ACadSharp.IO;
+using ACadSharp.Objects.Evaluations;
+using ACadSharp.Tables;
+using ACadSharp.Tests.Common;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace ACadSharp.Tests.IO;
+
+/// <summary>
+/// An action in a dynamic block refers to the parameters and grips it is wired to, not only to
+/// entities. The model held only entities, so on a production drawing 385 of 2,803 references in 118
+/// actions were dropped on write - none of them an entity, all of them objects AutoCAD keeps.
+/// </summary>
+public class BlockActionReferencesTests
+{
+	private static string sample => Path.Combine(TestVariables.SamplesFolder, "dynamic-blocks", "BLOCKFLIPPARAMETER.dwg");
+
+	//There is no DWG theory here yet: the DWG writer does not round trip the evaluation graph of
+	//this sample at all (EvaluationGraph comes back null, measured on the commit before this
+	//change too), so a DWG assertion would be testing that defect rather than this one. The DWG
+	//writer change is covered by the production-drawing measurement in the commit message until
+	//the graph round trip is fixed.
+
+	[Fact]
+	public void AnActionKeepsAReferenceToAParameterThroughDxf()
+	{
+		CadDocument doc = DwgReader.Read(sample);
+		(BlockFlipAction action, BlockFlipParameter parameter) = this.wire(doc);
+
+		MemoryStream ms = new MemoryStream();
+		using (DxfWriter writer = new DxfWriter(ms, doc, false))
+		{
+			writer.Write();
+		}
+
+		this.assertWired(DxfReader.Read(new MemoryStream(ms.ToArray())), action.Elements.Count);
+	}
+
+	[Fact]
+	public void EntitiesAddedOnlyToTheTypedListAreStillWritten()
+	{
+		//A caller that never heard of Elements and adds to Entities, as before, loses nothing.
+		CadDocument doc = DwgReader.Read(sample);
+		(BlockFlipAction action, _) = this.find(doc);
+		int before = action.GetReferencedObjects().Count();
+
+		var extra = new Circle { Radius = 1 };
+		doc.Entities.Add(extra);
+		action.Entities.Add(extra);
+
+		Assert.Equal(before + 1, action.GetReferencedObjects().Count());
+		Assert.Contains(extra, action.GetReferencedObjects());
+	}
+
+	private (BlockFlipAction, BlockFlipParameter) find(CadDocument doc)
+	{
+		EvaluationGraph graph = doc.BlockRecords["BLOCK_FLIP_PARAMETER"].EvaluationGraph;
+		var expressions = graph.Nodes.Select(n => n.Expression).ToList();
+		return (expressions.OfType<BlockFlipAction>().Single(), expressions.OfType<BlockFlipParameter>().Single());
+	}
+
+	private (BlockFlipAction, BlockFlipParameter) wire(CadDocument doc)
+	{
+		(BlockFlipAction action, BlockFlipParameter parameter) = this.find(doc);
+		//The sample's action refers to entities only. Wire it to its parameter, which is what a
+		//drawing authored in AutoCAD holds and what used to be dropped.
+		action.Elements.Add(parameter);
+		return (action, parameter);
+	}
+
+	private void assertWired(CadDocument doc, int expectedCount)
+	{
+		(BlockFlipAction action, BlockFlipParameter parameter) = this.find(doc);
+		Assert.Contains(parameter, action.Elements);
+		Assert.Equal(expectedCount, action.Elements.Count);
+		Assert.DoesNotContain(action.Entities, e => ReferenceEquals(e, parameter));
+	}
+}

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
@@ -119,10 +119,13 @@ internal partial class DwgObjectWriter : DwgSectionIO
 
 		this._writer.Write3BitDouble(action.LabelPosition);
 
-		this._writer.WriteBitLong(action.Entities.Count);
-		foreach (Entities.Entity entity in action.Entities)
+		//Elements, not Entities: an action refers to parameters and grips as well as entities, and
+		//writing only the entities dropped 385 references in one drawing's 118 actions.
+		List<CadObject> referenced = action.GetReferencedObjects().ToList();
+		this._writer.WriteBitLong(referenced.Count);
+		foreach (CadObject obj in referenced)
 		{
-			this._writer.HandleReference(DwgReferenceType.SoftPointer, entity);
+			this._writer.HandleReference(DwgReferenceType.SoftPointer, obj);
 		}
 
 		this._writer.WriteBitLong(action.ParametersIds.Count);

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
@@ -797,10 +797,12 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 			this._writer.Write(91, parameterId);
 		}
 
-		this._writer.Write(71, (short)action.Entities.Count);
-		foreach (Entity e in action.Entities)
+		//Elements, not Entities: see the DWG writer and BlockAction.Elements.
+		List<CadObject> referenced = action.GetReferencedObjects().ToList();
+		this._writer.Write(71, (short)referenced.Count);
+		foreach (CadObject obj in referenced)
 		{
-			this._writer.WriteHandle(330, e);
+			this._writer.WriteHandle(330, obj);
 		}
 
 		this._writer.Write(1010, action.LabelPosition, map);

--- a/src/ACadSharp/IO/Templates/CadBlockActionTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadBlockActionTemplate.cs
@@ -19,16 +19,39 @@ internal class CadBlockActionTemplate : CadBlockElementTemplate
 	{
 		base.build(builder);
 
+		//The file does not restrict these to entities. Checked against AutoCAD's own DXF of a
+		//production drawing: all 184 handles this used to report as "entity not found" were
+		//objects - stretch actions, linear parameters, flip grips - and the writers then wrote 385
+		//fewer references than the file held. Keep every object, in file order, and the entities
+		//among them in the typed list as well.
+		int stale = 0;
+		ulong firstStale = 0;
 		foreach (var handle in this.EntityHandles)
 		{
-			if (builder.TryGetCadObject(handle, out Entity entity))
+			if (builder.TryGetCadObject(handle, out CadObject obj))
 			{
-				this.BlockAction.Entities.Add(entity);
+				this.BlockAction.Elements.Add(obj);
+				if (obj is Entity entity)
+				{
+					this.BlockAction.Entities.Add(entity);
+				}
 			}
 			else
 			{
-				builder.Notify($"[{this.BlockAction.ToString()}] entity with handle {handle} not found.");
+				if (stale == 0)
+				{
+					firstStale = handle;
+				}
+
+				stale++;
 			}
+		}
+
+		if (stale > 0)
+		{
+			builder.Notify(
+				$"{this.BlockAction}: {stale} of {this.EntityHandles.Count} references point at objects that are not in the drawing (first: {firstStale}); dropped",
+				NotificationType.Warning);
 		}
 	}
 }

--- a/src/ACadSharp/Objects/Evaluations/BlockAction.cs
+++ b/src/ACadSharp/Objects/Evaluations/BlockAction.cs
@@ -16,6 +16,36 @@ public abstract class BlockAction : BlockElement
 	public List<Entity> Entities { get; } = new List<Entity>();
 
 	/// <summary>
+	/// Every object the action refers to, in the order the file gives them. The file does not
+	/// restrict this list to entities: an action refers to the parameters, grips and other actions
+	/// it is wired to, and a production drawing had 385 such references in 118 actions - all of
+	/// them dropped on write while only <see cref="Entities"/> was written. Objects that are
+	/// entities appear in both lists; the writers write this list plus any entity added only to
+	/// <see cref="Entities"/>.
+	/// </summary>
+	public List<CadObject> Elements { get; } = new List<CadObject>();
+
+	/// <summary>
+	/// The references the writers put in the file: <see cref="Elements"/> in file order, followed
+	/// by any <see cref="Entities"/> member that is not already among them.
+	/// </summary>
+	public IEnumerable<CadObject> GetReferencedObjects()
+	{
+		foreach (CadObject element in this.Elements)
+		{
+			yield return element;
+		}
+
+		foreach (Entity entity in this.Entities)
+		{
+			if (!this.Elements.Contains(entity))
+			{
+				yield return entity;
+			}
+		}
+	}
+
+	/// <summary>
 	/// Gets or sets the position of the action label.
 	/// </summary>
 	[DxfCodeValue(1010, 1020, 1030)]


### PR DESCRIPTION
﻿
# Description

`BlockAction.Entities` is a `List<Entity>`, and `CadBlockActionTemplate` asked the builder for an
`Entity` when resolving each handle. The file does not restrict that list to entities: an action in
a dynamic block refers to the **parameters, grips and other actions** it is wired to.

Measured on a production drawing with 118 actions, against AutoCAD's own DXF export of it:

| | references inside the 118 actions |
|---|---|
| AutoCAD's file | **2,803** |
| this library, before | 2,418 |
| this library, after | **2,803** |

All 184 distinct handles the reader used to report as `entity with handle â€¦ not found` are present in
AutoCAD's file â€” as `BLOCKSTRETCHACTION`, `BLOCKLINEARPARAMETER`, `BLOCKFLIPGRIP`, and so on â€” and
the 385 references to them were then absent from what both writers produced. Those references are
what tells a stretch action which linear parameter drives it. `AUDIT` does not notice their absence;
the block's dynamic behaviour would.

| where | after |
|---|---|
| `BlockAction` | gains `Elements`, an ordered `List<CadObject>` of everything referred to, in file order; `Entities` is unchanged and still holds the entities among them, so a caller that only knows `Entities` loses nothing |
| `BlockAction.GetReferencedObjects()` | what the writers write: `Elements`, then any entity added only to `Entities` |
| `CadBlockActionTemplate.build` | resolves any `CadObject`; entities go into both lists; unresolved handles are reported once per action |
| `DwgObjectWriter.writeBlockAction`, `DxfObjectsSectionWriter` | write `GetReferencedObjects()` |

**A separate defect surfaced while writing the test and is not addressed here**: the DWG writer does
not round trip the evaluation graph of `samples/dynamic-blocks/BLOCKFLIPPARAMETER.dwg` at all â€”
`BlockRecord.EvaluationGraph` reads back `null`, on master too. The DXF writer does. The DWG writer
change in this PR is therefore covered by the production-drawing measurement above rather than by a
sample round trip.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`BlockActionReferencesTests`: the sample's flip action wired to its flip parameter keeps that
reference through DXF; an entity added only to `Entities` is still written. Whole suite on this
branch: see the table in the checklist. `AUDIT` 0 errors on all five generated files; the production
drawing above reads with 162 notifications where it read with 547.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

