### PR TITLE
Leader.HasHookline recognises a hook that runs against the horizontal direction

### DIFF
--- a/src/ACadSharp.Tests/Entities/LeaderHookLineTests.cs
+++ b/src/ACadSharp.Tests/Entities/LeaderHookLineTests.cs
@@ -1,0 +1,61 @@
+using ACadSharp.Entities;
+using ACadSharp.IO;
+using CSMath;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace ACadSharp.Tests.Entities;
+
+public class LeaderHookLineTests
+{
+	[Fact]
+	public void AHookAgainstTheHorizontalDirectionIsAHook()
+	{
+		//A leader whose text sits to its right ends with a hook that runs from the last vertex
+		//back toward the leader, against +X. That is HookLineDirection.Opposite, and it is a hook.
+		Leader leader = new Leader();
+		leader.Vertices.Add(new XYZ(0, 0, 0));
+		leader.Vertices.Add(new XYZ(10, 5, 0));
+		leader.Vertices.Add(new XYZ(12.5, 5, 0));
+
+		Assert.True(leader.HasHookline);
+	}
+
+	[Fact]
+	public void AHookAlongTheHorizontalDirectionIsAHook()
+	{
+		Leader leader = new Leader();
+		leader.Vertices.Add(new XYZ(20, 0, 0));
+		leader.Vertices.Add(new XYZ(10, 5, 0));
+		leader.Vertices.Add(new XYZ(7.5, 5, 0));
+
+		Assert.True(leader.HasHookline);
+	}
+
+	[Fact]
+	public void ASlopedLastSegmentIsNotAHook()
+	{
+		Leader leader = new Leader();
+		leader.Vertices.Add(new XYZ(0, 0, 0));
+		leader.Vertices.Add(new XYZ(10, 5, 0));
+		leader.Vertices.Add(new XYZ(12, 7, 0));
+
+		Assert.False(leader.HasHookline);
+	}
+
+	[Fact]
+	public void TheLeaderAutoCadWroteWithAHookIsReadWithOne()
+	{
+		//samples/sample_AC1032_ascii.dxf carries one LEADER, handle 512, that AutoCAD saved with
+		//75 = 1 and a last segment of 2.5 units running -X toward its MTEXT. It used to be read as
+		//having no hook line.
+		string path = Path.Combine(TestVariables.SamplesFolder, "sample_AC1032_ascii.dxf");
+		CadDocument doc = DxfReader.Read(path);
+
+		Leader leader = Assert.Single(doc.Entities.OfType<Leader>());
+		Assert.Equal(0x512UL, leader.Handle);
+		Assert.True(leader.HasHookline);
+		Assert.Equal(HookLineDirection.Opposite, leader.HookLineDirection);
+	}
+}

--- a/src/ACadSharp/Entities/Leader.cs
+++ b/src/ACadSharp/Entities/Leader.cs
@@ -62,14 +62,24 @@ public class Leader : Entity, IOrientable
 	{
 		get
 		{
-			bool result = false;
 			if (this.Vertices.Count <= 1)
 			{
-				return result;
+				return false;
 			}
 
-			double angle = (this.Vertices[this.Vertices.Count - 2] - this.Vertices[this.Vertices.Count - 1]).AngleBetweenVectors(this.HorizontalDirection);
-			return MathHelper.IsZero(angle);
+			//A hook line is the last segment lying along the horizontal direction, either way. The
+			//test used to accept only the segment pointing the same way as that direction, so a hook
+			//that runs against it - which is exactly what HookLineDirection.Opposite describes, and
+			//what AutoCAD writes for a leader whose text sits to the right of it - was read as no
+			//hook at all: leader 512 of samples/sample_AC1032.dxf says 75 = 1 and came back false.
+			XYZ last = this.Vertices[this.Vertices.Count - 2] - this.Vertices[this.Vertices.Count - 1];
+			if (last.IsZero() || this.HorizontalDirection.IsZero())
+			{
+				return false;
+			}
+
+			double angle = last.AngleBetweenVectors(this.HorizontalDirection);
+			return MathHelper.IsZero(angle) || MathHelper.IsZero(angle - System.Math.PI);
 		}
 	}
 


### PR DESCRIPTION
﻿
# Description

`HasHookline` compares the angle between the last segment and `HorizontalDirection` with zero, so
only a hook that points the same way as that direction (+X for the default) counts. A hook that runs
the other way - the shape AutoCAD writes when the text sits to the right of the leader, and the case
`HookLineDirection.Opposite` exists to describe - is read as no hook at all.

Leader `512` in `samples/sample_AC1032_ascii.dxf` is AutoCAD's own: `75 = 1`, last segment 2.5
units toward -X. It came back `HasHookline = false`, so a round trip wrote `75 = 0`.

The angle is now accepted at 0 or Ï€; a zero-length last segment or a zero horizontal direction is
not a hook.

# Tasks done in this PR

* [x] `Leader.HasHookline` accepts both directions along the horizontal.
* [x] `LeaderHookLineTests`: hook along +X, hook along -X, sloped last segment (no hook), and the
      sample leader read back with a hook in the `Opposite` direction. Two of the four fail without
      the fix.

# Related Issues / Pull Requests

- None.

# Notes for reviewer

**Testing**

`dotnet test` on this branch: **2316 passed / 17 failed**, the same 17 failures as master
(2312 + 4 new).

AutoCAD 2027: the DXF of a 17.6 MB production drawing with 522 leaders, written before and after
this change, differs only in `75 = 0 â†’ 1` on the leaders whose hook runs toward -X (and the file
timestamp) - the value AutoCAD's own DXF of the drawing has for them. Both audit with 0 errors after
the hatch fix in this stack; the DWG round trips audit 0 either way.

