### PR TITLE
A table is written to DXF as its block reference instead of being dropped

### DIFF
--- a/src/ACadSharp.Tests/IO/DXF/DxfTableEntityTests.cs
+++ b/src/ACadSharp.Tests/IO/DXF/DxfTableEntityTests.cs
@@ -1,0 +1,80 @@
+using ACadSharp.Entities;
+using ACadSharp.IO;
+using ACadSharp.Tables;
+using CSMath;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace ACadSharp.Tests.IO.DXF
+{
+	/// <summary>
+	/// A table is a block reference of the anonymous *T block that holds its drawn geometry, with
+	/// the cell data on top. The writer used to skip the whole entity, so every table disappeared
+	/// from a DXF: the block stayed in the file with nothing referencing it, and the drawn table
+	/// was gone. It goes out as its block reference instead.
+	/// </summary>
+	public class DxfTableEntityTests
+	{
+		[Fact]
+		public void TableIsWrittenAsTheBlockReferenceOfItsTableBlock()
+		{
+			CadDocument doc = new CadDocument();
+			BlockRecord block = new BlockRecord("*T1");
+			block.Entities.Add(new Line(new XYZ(0, 0, 0), new XYZ(10, 0, 0)));
+			doc.BlockRecords.Add(block);
+			TableEntity table = new TableEntity(block)
+			{
+				InsertPoint = new XYZ(5, 7, 0),
+			};
+			doc.ModelSpace.Entities.Add(table);
+
+			CadDocument result = writeAndRead(doc, out bool notified);
+
+			Insert insert = Assert.Single(result.ModelSpace.Entities.OfType<Insert>());
+			Assert.Equal("*T1", insert.Block.Name);
+			Assert.Equal(5, insert.InsertPoint.X);
+			Assert.Equal(7, insert.InsertPoint.Y);
+			Assert.Empty(result.ModelSpace.Entities.OfType<TableEntity>());
+			Assert.True(notified, "the loss of the cell data is notified");
+		}
+
+		[Fact]
+		public void TableBlockContentSurvivesTheRoundTrip()
+		{
+			CadDocument doc = new CadDocument();
+			BlockRecord block = new BlockRecord("*T2");
+			block.Entities.Add(new Line(new XYZ(0, 0, 0), new XYZ(10, 0, 0)));
+			block.Entities.Add(new Line(new XYZ(0, 0, 0), new XYZ(0, 4, 0)));
+			doc.BlockRecords.Add(block);
+			doc.ModelSpace.Entities.Add(new TableEntity(block));
+
+			CadDocument result = writeAndRead(doc, out _);
+
+			BlockRecord written = result.BlockRecords["*T2"];
+			Assert.Equal(2, written.Entities.OfType<Line>().Count());
+		}
+
+		private static CadDocument writeAndRead(CadDocument doc, out bool notified)
+		{
+			bool raised = false;
+			byte[] bytes;
+			using (MemoryStream stream = new MemoryStream())
+			using (DxfWriter writer = new DxfWriter(stream, doc, false))
+			{
+				writer.OnNotification += (s, e) =>
+				{
+					if (e.Message.Contains("cell values", System.StringComparison.OrdinalIgnoreCase))
+					{
+						raised = true;
+					}
+				};
+				writer.Write();
+				bytes = stream.ToArray();
+			}
+
+			notified = raised;
+			return DxfReader.Read(new MemoryStream(bytes));
+		}
+	}
+}

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
@@ -18,6 +18,24 @@ internal abstract partial class DxfSectionWriterBase
 			return;
 		}
 
+		if (entity is TableEntity table)
+		{
+			//A table is a block reference of the anonymous *T block that holds its drawn geometry,
+			//with the cell data on top of it. The cell data is not written here, and an ACAD_TABLE
+			//record without its AcDbTable subclass is one AutoCAD refuses, so the table goes out as
+			//the INSERT it derives from: the drawn table survives - the *T block is already written
+			//- instead of the whole entity disappearing from the file.
+			this.notify(
+				$"Table {table.Handle} is written as the block reference of {table.Block?.Name}; cell values, styles and merges are not written to DXF.",
+				NotificationType.NotImplemented);
+
+			this._writer.Write(DxfCode.Start, DxfFileToken.EntityInsert);
+			this.writeCommonObjectData(table);
+			this.writeCommonEntityData(table);
+			this.writeInsert(table, DxfSubclassMarker.Insert);
+			return;
+		}
+
 		this._writer.Write(DxfCode.Start, entity.ObjectName);
 
 		this.writeCommonObjectData(entity);
@@ -154,7 +172,6 @@ internal abstract partial class DxfSectionWriterBase
 			case Shape:
 				return this.Configuration.WriteShapes;
 			case ProxyEntity:
-			case TableEntity:
 			case Solid3D:
 			case CadBody:
 			case Region:
@@ -625,11 +642,13 @@ internal abstract partial class DxfSectionWriterBase
 		}
 	}
 
-	private void writeInsert(Insert insert)
+	private void writeInsert(Insert insert, string subclassMarker = null)
 	{
 		DxfClassMap map = DxfClassMap.Create<Insert>();
 
-		this._writer.Write(DxfCode.Subclass, insert.SubclassMarker);
+		//A table writes the block-reference body under the block-reference marker; its own marker
+		//names AcDbTable, which is not what these groups are.
+		this._writer.Write(DxfCode.Subclass, subclassMarker ?? insert.SubclassMarker);
 
 		this._writer.WriteName(2, insert.Block, map);
 


### PR DESCRIPTION
﻿
# Description

`TableEntity` is on the "not implemented" list of the DXF writer, so a drawing that contains a
table loses it completely. The anonymous `*T` block that holds the drawn table is still written -
the geometry is all there - but nothing references it any more, so the table is invisible.

Reading `samples/sample_AC1015_ascii.dxf` and writing it back loses:

- 2 `ACAD_TABLE` entities,
- 2 `TABLECONTENT` objects,
- 1 `CELLSTYLEMAP` object.

Plotted through AutoCAD, the table area of the round trip is empty: 165,565 of the 165,566 ink
pixels AutoCAD draws for the original are gone.

A table *is* a block reference with cell data on top - `TableEntity` derives from `Insert` and the
`*T` block is its content, which is exactly how AutoCAD writes it (`100 AcDbBlockReference`,
`2 *T9`, then `100 AcDbTable`). The block reference half can be written even though the cell data
cannot, so the entity now goes out as an `INSERT` record. The drawn table comes back; the cell
values, styles and merges are still not written, and that loss is notified.

Writing it as an `ACAD_TABLE` record without the `AcDbTable` subclass is not an option: AutoCAD
rejects the whole file with *"Class separator for class AcDbBlockReference expected"* (measured).

# Tasks done in this PR

* [x] `writeEntity` writes a `TableEntity` as the `INSERT` of its table block, under the
      `AcDbBlockReference` subclass marker, with a `NotImplemented` notification naming what is
      not written.
* [x] `DxfTableEntityTests`: the table is written as the block reference of its table block and the
      loss is notified; the table block's content survives the round trip.

# Related Issues / Pull Requests

- None.

# Notes for reviewer

**Testing**

`dotnet test` on this branch: **2314 passed / 17 failed**, the same 17 failures as master
(2312 + 2 new tests).

AutoCAD 2027, `samples/sample_AC1032.dwg` read and written back to DXF, table area plotted against
AutoCAD's own render of the source drawing:

| | ink pixels missing | AUDIT |
|---|---|---|
| before | 165,565 of 165,566 | 0 errors |
| after | **0** | 0 errors |

The reader is untouched. Both readers already build the same table model - the DXF and the DWG of
the same drawing give 7x3 and 4x5 cells with the same text - so this is only about the writer.

