### PR TITLE
A table read from the pre-R2010 layout is converted on write instead of costing the drawing

### DIFF
--- a/src/ACadSharp.Tests/IO/DWG/DwgLegacyTableTests.cs
+++ b/src/ACadSharp.Tests/IO/DWG/DwgLegacyTableTests.cs
@@ -135,6 +135,33 @@ public class DwgLegacyTableTests
 			.Count(e => !(e is TableEntity));
 	}
 
+	[Fact]
+	public void ATableBuiltByACallerIsNotDroppedForSettingValueFlag()
+	{
+		//The guard was first keyed on ValueFlag being non-zero, which reads like provenance and is
+		//not: the flag is public, DXF-mapped and documented as normally carrying 0x06, so a caller
+		//building a table faithfully had it silently dropped from every DWG. It is keyed on
+		//provenance recorded by the reader now, and a caller-built table survives whatever it sets.
+		CadDocument doc = DwgReader.Read(sampleR2018);
+		TableEntity table = this.tables(doc).First();
+		int before = this.tables(doc).Length;
+		Assert.True(before > 0);
+
+		foreach (TableEntity each in this.tables(doc))
+		{
+			each.ValueFlag = 0x06;
+		}
+
+		doc.Header.Version = ACadVersion.AC1032;
+		using MemoryStream stream = new();
+		using (DwgWriter writer = new(stream, doc))
+		{
+			writer.Write();
+		}
+
+		Assert.Equal(before, this.tables(DwgReader.Read(new MemoryStream(stream.ToArray()))).Length);
+	}
+
 	private TableEntity[] tables(CadDocument doc)
 	{
 		return doc.BlockRecords

--- a/src/ACadSharp.Tests/IO/DWG/DwgLegacyTableTests.cs
+++ b/src/ACadSharp.Tests/IO/DWG/DwgLegacyTableTests.cs
@@ -1,0 +1,145 @@
+using ACadSharp.Entities;
+using ACadSharp.IO;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace ACadSharp.Tests.IO.DWG;
+
+/// <summary>
+/// A table is stored one way up to R2007 and another from R2010, and this library reads both but
+/// writes only the second. That was known and recorded as a limit; what was not known is what it
+/// costs. Writing a table read from the older layout into an R2010+ file does not lose the table -
+/// it loses the drawing: AutoCAD 2027 rejects the file outright at R2010 (ErrorStatus 53) and was
+/// still working on it after ten minutes at R2018. With the two tables of `sample_AC1018` left out,
+/// the same write opens and audits 0 in two seconds.
+/// </summary>
+public class DwgLegacyTableTests
+{
+	//R2004: its tables are stored in the pre-R2010 layout.
+	private static string sampleR2004 => Path.Combine(TestVariables.SamplesFolder, "sample_AC1018.dwg");
+
+	//The same drawing saved at R2018, where the tables use the layout this writer produces.
+	private static string sampleR2018 => Path.Combine(TestVariables.SamplesFolder, "sample_AC1032.dwg");
+
+	[Fact]
+	public void ACellReadFromTheOlderLayoutSaysWhatItHolds()
+	{
+		//The older layout has no content type - the cell type implies it - so the reader filled the
+		//value and left the type at its default, Unknown. Every writer then took that at its word
+		//and wrote a cell holding nothing, dropping the text it had just read.
+		TableEntity table = this.tables(DwgReader.Read(sampleR2004)).First();
+
+		TableEntity.CellContent content = table.Rows
+			.SelectMany(r => r.Cells)
+			.SelectMany(c => c.Contents)
+			.First(c => !string.IsNullOrEmpty(c.CadValue?.Value?.ToString()));
+
+		Assert.Equal(TableEntity.TableCellContentType.Value, content.ContentType);
+	}
+
+	[Fact]
+	public void TheOlderLayoutIsReadWithItsRowsColumnsAndText()
+	{
+		//Guard for the test above: it only means anything while the older layout is read at all.
+		TableEntity table = this.tables(DwgReader.Read(sampleR2004)).First();
+
+		Assert.Equal(7, table.Rows.Count);
+		Assert.Equal(3, table.Columns.Count);
+		Assert.Contains(table.Rows.SelectMany(r => r.Cells).SelectMany(c => c.Contents),
+			c => c.CadValue?.Value?.ToString() == "Table sample");
+	}
+
+	[Theory]
+	[InlineData(ACadVersion.AC1024)]
+	[InlineData(ACadVersion.AC1027)]
+	[InlineData(ACadVersion.AC1032)]
+	public void ATableFromTheOlderLayoutIsLeftOutOfAnR2010PlusFileAndSaidSo(ACadVersion version)
+	{
+		//One entity reported is the whole point: written instead, the drawing does not open.
+		CadDocument doc = DwgReader.Read(sampleR2004);
+		Assert.NotEmpty(this.tables(doc));
+
+		doc.Header.Version = version;
+		string reported = null;
+		using MemoryStream stream = new();
+		using (DwgWriter writer = new(stream, doc))
+		{
+			writer.OnNotification += (s, e) => { if (e.Message.Contains("is not written to a")) reported = e.Message; };
+			writer.Write();
+		}
+
+		Assert.NotNull(reported);
+		Assert.Contains("layout", reported);
+		Assert.Empty(this.tables(DwgReader.Read(new MemoryStream(stream.ToArray()))));
+	}
+
+	[Theory]
+	[InlineData(ACadVersion.AC1024)]
+	[InlineData(ACadVersion.AC1032)]
+	public void ATableFromTheR2010LayoutIsStillWritten(ACadVersion version)
+	{
+		//The guard has to tell the two layouts apart, or it takes every table with it. ValueFlag is
+		//what separates them: the older layout carries the field, the R2010 one does not, and no
+		//writer here writes it back.
+		CadDocument doc = DwgReader.Read(sampleR2018);
+		TableEntity[] before = this.tables(doc);
+		Assert.NotEmpty(before);
+		Assert.All(before, t => Assert.Equal(0, t.ValueFlag));
+
+		doc.Header.Version = version;
+		using MemoryStream stream = new();
+		using (DwgWriter writer = new(stream, doc))
+		{
+			writer.Write();
+		}
+
+		Assert.Equal(before.Length, this.tables(DwgReader.Read(new MemoryStream(stream.ToArray()))).Length);
+	}
+
+	[Fact]
+	public void TheRestOfTheDrawingSurvivesTheTablesBeingLeftOut()
+	{
+		//Leaving the table out has to cost the table and nothing else. Counting against the document
+		//that was read would measure every other gap this writer has as well, so the control is the
+		//same drawing with the tables taken out by hand: whatever else the writer keeps or drops,
+		//the two runs have to agree.
+		int withGuard = this.nonTableCountAfterRoundTrip(DwgReader.Read(sampleR2004), false);
+		int control = this.nonTableCountAfterRoundTrip(DwgReader.Read(sampleR2004), true);
+
+		Assert.Equal(control, withGuard);
+	}
+
+	private int nonTableCountAfterRoundTrip(CadDocument doc, bool removeTablesFirst)
+	{
+		if (removeTablesFirst)
+		{
+			foreach (var record in doc.BlockRecords)
+			{
+				foreach (TableEntity table in record.Entities.OfType<TableEntity>().ToList())
+				{
+					record.Entities.Remove(table);
+				}
+			}
+		}
+
+		doc.Header.Version = ACadVersion.AC1032;
+		using MemoryStream stream = new();
+		using (DwgWriter writer = new(stream, doc))
+		{
+			writer.Write();
+		}
+
+		return DwgReader.Read(new MemoryStream(stream.ToArray()))
+			.BlockRecords.SelectMany(b => b.Entities)
+			.Count(e => !(e is TableEntity));
+	}
+
+	private TableEntity[] tables(CadDocument doc)
+	{
+		return doc.BlockRecords
+			.SelectMany(b => b.Entities.OfType<TableEntity>())
+			.OrderBy(t => t.Handle)
+			.ToArray();
+	}
+}

--- a/src/ACadSharp.Tests/IO/DWG/DwgLegacyTableTests.cs
+++ b/src/ACadSharp.Tests/IO/DWG/DwgLegacyTableTests.cs
@@ -8,11 +8,13 @@ namespace ACadSharp.Tests.IO.DWG;
 
 /// <summary>
 /// A table is stored one way up to R2007 and another from R2010, and this library reads both but
-/// writes only the second. That was known and recorded as a limit; what was not known is what it
-/// costs. Writing a table read from the older layout into an R2010+ file does not lose the table -
-/// it loses the drawing: AutoCAD 2027 rejects the file outright at R2010 (ErrorStatus 53) and was
-/// still working on it after ten minutes at R2018. With the two tables of `sample_AC1018` left out,
-/// the same write opens and audits 0 in two seconds.
+/// writes only the second. Writing a table read from the older layout into an R2010+ file
+/// unconverted did not lose the table - it lost the drawing: AutoCAD 2027 rejected the file
+/// outright at R2010 (ErrorStatus 53) and was still working on it after ten minutes at R2018. For
+/// a while such tables were dropped with a notification; they are now converted on write, because
+/// the real wall was never the missing R2010-only structures (all optional, measured by stripping
+/// them from an R2018-authored table) but an empty-string cell value that writeStringCadValue
+/// wrote with two lengths, shifting every field after it (T84).
 /// </summary>
 public class DwgLegacyTableTests
 {
@@ -54,24 +56,32 @@ public class DwgLegacyTableTests
 	[InlineData(ACadVersion.AC1024)]
 	[InlineData(ACadVersion.AC1027)]
 	[InlineData(ACadVersion.AC1032)]
-	public void ATableFromTheOlderLayoutIsLeftOutOfAnR2010PlusFileAndSaidSo(ACadVersion version)
+	public void ATableFromTheOlderLayoutIsConvertedOnWriteAndSurvives(ACadVersion version)
 	{
-		//One entity reported is the whole point: written instead, the drawing does not open.
+		//This used to assert the drop-with-a-notification, because written unconverted the
+		//drawing did not open. The wall fell with the writeStringCadValue fix: the conversion
+		//needs only the merge ranges and the merged-away cells' content, everything else the
+		//R2010 layout carries is optional, and the converted file opens and audits 0 in AutoCAD
+		//at all three versions (T84).
 		CadDocument doc = DwgReader.Read(sampleR2004);
-		Assert.NotEmpty(this.tables(doc));
+		int before = this.tables(doc).Length;
+		Assert.NotEqual(0, before);
 
 		doc.Header.Version = version;
-		string reported = null;
+		string converted = null;
 		using MemoryStream stream = new();
 		using (DwgWriter writer = new(stream, doc))
 		{
-			writer.OnNotification += (s, e) => { if (e.Message.Contains("is not written to a")) reported = e.Message; };
+			writer.OnNotification += (s, e) => { if (e.Message.Contains("was converted")) converted = e.Message; };
 			writer.Write();
 		}
 
-		Assert.NotNull(reported);
-		Assert.Contains("layout", reported);
-		Assert.Empty(this.tables(DwgReader.Read(new MemoryStream(stream.ToArray()))));
+		Assert.NotNull(converted);
+		TableEntity[] after = this.tables(DwgReader.Read(new MemoryStream(stream.ToArray())));
+		Assert.Equal(before, after.Length);
+		Assert.Contains(after.SelectMany(t => t.Rows).SelectMany(r => r.Cells).SelectMany(c => c.Contents),
+			c => c.CadValue?.Value?.ToString() == "Table sample");
+		Assert.Contains(after, t => t.MergedCellRanges.Count > 0);
 	}
 
 	[Theory]
@@ -95,6 +105,38 @@ public class DwgLegacyTableTests
 		}
 
 		Assert.Equal(before.Length, this.tables(DwgReader.Read(new MemoryStream(stream.ToArray()))).Length);
+	}
+
+	[Fact]
+	public void AnEmptyStringCellValueRoundTripsWithoutShiftingTheStream()
+	{
+		//writeStringCadValue used to write a bare zero length for an empty string AND then fall
+		//through to the full write, so every field after the empty value was shifted by one bit
+		//long plus two bytes: this library's own reader threw reading the file back and the
+		//failsafe dropped the table, and AutoCAD worked on such a file for as long as it was
+		//given. No R2010-authored table carries an empty String value - only one converted from
+		//the pre-R2010 layout does - which is why T84's conversion experiments kept failing
+		//while every ordinary round trip stayed green.
+		CadDocument doc = DwgReader.Read(sampleR2018);
+		TableEntity table = this.tables(doc).First();
+		TableEntity.CellContent content = table.Rows.SelectMany(r => r.Cells)
+			.SelectMany(c => c.Contents).First();
+		content.CadValue.ValueType = CadValueType.String;
+		content.CadValue.SetValue(string.Empty);
+		content.CadValue.IsEmpty = false;
+		int countBefore = this.tables(doc).Length;
+
+		doc.Header.Version = ACadVersion.AC1032;
+		using MemoryStream stream = new();
+		using (DwgWriter writer = new(stream, doc))
+		{
+			writer.Write();
+		}
+
+		TableEntity[] after = this.tables(DwgReader.Read(new MemoryStream(stream.ToArray())));
+		Assert.Equal(countBefore, after.Length);
+		Assert.Equal(string.Empty, after.First().Rows.SelectMany(r => r.Cells)
+			.SelectMany(c => c.Contents).First().CadValue.Value);
 	}
 
 	[Fact]

--- a/src/ACadSharp/Entities/TableEntity.cs
+++ b/src/ACadSharp/Entities/TableEntity.cs
@@ -100,6 +100,19 @@ public partial class TableEntity : Insert, IDxfClassDefined
 	public int ValueFlag { get; set; }
 
 	/// <summary>
+	/// Set by the DWG reader when this table's content came from the layout used up to R2007, which
+	/// this library reads but cannot re-express as the layout it writes from R2010 on.
+	/// </summary>
+	/// <remarks>
+	/// Provenance, not a property of the table, so it is deliberately not public and not a DXF
+	/// value. The writer needs it because writing such content into an R2010+ file does not lose
+	/// the table, it loses the whole drawing. It was briefly inferred from <see cref="ValueFlag"/>
+	/// being non-zero, which is wrong: that flag is public, documented, and normally has 0x06 set,
+	/// so any caller building a table faithfully would have had it silently dropped.
+	/// </remarks>
+	internal bool ContentIsPreR2010Layout { get; set; }
+
+	/// <summary>
 	/// Table data version
 	/// </summary>
 	[DxfCodeValue(280)]

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.Entities.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.Entities.cs
@@ -808,6 +808,10 @@ internal partial class DwgObjectReader : DwgSectionIO
 
 		//Until R2007
 
+		//Everything below reads the older layout. Record that, because the writer produces only the
+		//R2010 one and needs to know this content cannot be re-expressed as it.
+		table.ContentIsPreR2010Layout = true;
+
 		//Common:
 		//Flag for table value BS 90
 		//	Bit flags, 0x06(0x02 + 0x04): has block,

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.Entities.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.Entities.cs
@@ -244,11 +244,20 @@ internal partial class DwgObjectReader : DwgSectionIO
 		//NOTE: It also seems to be valid for the string values
 
 		int length = this._mergedReaders.ReadBitLong();
+		if (length <= 0)
+		{
+			//A length of zero carries no bytes at all - not even the terminator the R2007+ form
+			//counts. Files this library wrote before the writeStringCadValue fix contain exactly
+			//that for an empty value, so reading it as empty instead of throwing keeps them
+			//readable.
+			return string.Empty;
+		}
+
 		byte[] arr = this._mergedReaders.ReadBytes(length);
 
 		if (this.R2007Plus)
 		{
-			return System.Text.Encoding.Unicode.GetString(arr, 0, length - 2);
+			return System.Text.Encoding.Unicode.GetString(arr, 0, Math.Max(0, length - 2));
 		}
 		else
 		{

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.Entities.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.Entities.cs
@@ -418,6 +418,12 @@ internal partial class DwgObjectReader : DwgSectionIO
 				//Text string TV 1 Present only if 344 value below is 0
 				var content = new CellContent();
 				content.CadValue.SetValue(this._mergedReaders.ReadVariableText(), CadValueType.String);
+
+				//The content type is not in this older layout - it is implied by the cell type, and the
+				//R2010 layout the writer produces states it. Left at its default the cell says it holds
+				//nothing, so the writer skips the very value just read: the text is lost, and AutoCAD
+				//refuses the whole drawing rather than the one table. Measured on sample_AC1018.
+				content.ContentType = TableCellContentType.Value;
 				cell.Contents.Add(content);
 				break;
 			case CellType.Block:

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Entities.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Entities.cs
@@ -2310,12 +2310,59 @@ internal partial class DwgObjectWriter : DwgSectionIO
 		}
 	}
 
+	//A table read from the pre-R2010 layout, being converted for the duration of one
+	//writeTableEntity call. The document itself is never touched: the merge ranges live here and
+	//the merged-away cells are written without their content, instead of mutating entities the
+	//caller may still be using (the DXF writer, for one, still writes the older fields).
+	private List<TableEntity.CellRange> _legacyMergedRanges;
+	private HashSet<TableEntity.Cell> _legacySuppressedCells;
+
 	private void writeTableEntity(TableEntity table)
 	{
 		this.writeCommonInsertData(table);
 
 		if (this.R2010Plus)
 		{
+			//Converting the older layout needs exactly two translations, measured rather than
+			//assumed (T84): the per-cell merge spans become merged cell ranges, and a cell merged
+			//into another loses the empty content the older layout gave it. Everything else the
+			//R2010 layout can carry - cell styles, content formats, cell geometry, custom data -
+			//is optional: stripped from an R2018-authored table, AutoCAD still audits 0 and its
+			//own export keeps every cell.
+			if (table.ContentIsPreR2010Layout)
+			{
+				this._legacyMergedRanges = new List<TableEntity.CellRange>();
+				this._legacySuppressedCells = new HashSet<TableEntity.Cell>();
+				for (int r = 0; r < table.Content.Rows.Count; r++)
+				{
+					TableEntity.Row row = table.Content.Rows[r];
+					for (int c = 0; c < row.Cells.Count; c++)
+					{
+						TableEntity.Cell cell = row.Cells[c];
+						if (cell.MergedValue != 0)
+						{
+							this._legacySuppressedCells.Add(cell);
+							continue;
+						}
+
+						if (cell.BorderWidth > 1 || cell.BorderHeight > 1)
+						{
+							this._legacyMergedRanges.Add(new TableEntity.CellRange
+							{
+								TopRowIndex = r,
+								LeftColumnIndex = c,
+								BottomRowIndex = r + Math.Max(1, cell.BorderHeight) - 1,
+								RightColumnIndex = c + Math.Max(1, cell.BorderWidth) - 1,
+							});
+						}
+					}
+				}
+
+				this.notify(
+					$"TableEntity {table.Handle}: content read from the pre-{ACadVersion.AC1024} layout was converted to the {ACadVersion.AC1024} one on write - {this._legacyMergedRanges.Count} merge ranges rebuilt from the per-cell spans, {this._legacySuppressedCells.Count} merged-away cells written without their empty content.",
+					NotificationType.None);
+			}
+
 			//RC Unknown (default 0)
 			this._writer.WriteByte(0);
 			//H Unknown (soft pointer, default NULL)
@@ -2339,7 +2386,15 @@ internal partial class DwgObjectWriter : DwgSectionIO
 			//Here the table content is present (see TABLECONTENT object),
 			//without the common OBJECT data.
 			//See paragraph 20.4.97.
-			this.writeTableContent(table.Content);
+			try
+			{
+				this.writeTableContent(table.Content);
+			}
+			finally
+			{
+				this._legacyMergedRanges = null;
+				this._legacySuppressedCells = null;
+			}
 
 			//BS Unknown (default 38)
 			this._writer.WriteBitShort(38);
@@ -2487,8 +2542,9 @@ internal partial class DwgObjectWriter : DwgSectionIO
 		this.writeCellStyle(content.CellStyleOverride);
 
 		//Bl 90 Number of merged cell ranges
-		this._writer.WriteBitLong(content.MergedCellRanges.Count);
-		foreach (var cellRange in content.MergedCellRanges)
+		List<TableEntity.CellRange> mergedCellRanges = this._legacyMergedRanges ?? content.MergedCellRanges;
+		this._writer.WriteBitLong(mergedCellRanges.Count);
+		foreach (var cellRange in mergedCellRanges)
 		{
 			//BL 91 Top row index
 			this._writer.WriteBitLong(cellRange.TopRowIndex);
@@ -2536,11 +2592,17 @@ internal partial class DwgObjectWriter : DwgSectionIO
 			throw new Exception();
 		}
 
-		//BL 95 Number of cell contents
-		this._writer.WriteBitLong(cell.Contents.Count);
-		foreach (TableEntity.CellContent cellContent in cell.Contents)
+		//BL 95 Number of cell contents. A cell merged into another under the pre-R2010 layout is
+		//written without the empty content that layout gave it - in the R2010 layout such a cell
+		//carries none.
+		bool suppressContents = this._legacySuppressedCells != null && this._legacySuppressedCells.Contains(cell);
+		this._writer.WriteBitLong(suppressContents ? 0 : cell.Contents.Count);
+		if (!suppressContents)
 		{
-			this.writeTableCellContent(cellContent);
+			foreach (TableEntity.CellContent cellContent in cell.Contents)
+			{
+				this.writeTableCellContent(cellContent);
+			}
 		}
 
 		this.writeCellStyle(cell.StyleOverride);

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
@@ -2194,10 +2194,14 @@ internal partial class DwgObjectWriter : DwgSectionIO
 
 	private void writeStringCadValue(string value)
 	{
-		if (string.IsNullOrEmpty(value))
-		{
-			this._writer.WriteBitLong(0);
-		}
+		//An empty string is written the same way as any other: its terminator and the length that
+		//counts it. The branch that used to live here wrote a bare zero length AND then fell
+		//through to the full write, so every field after an empty cell value was shifted by one
+		//bit long plus two bytes - our own reader threw reading it back, and AutoCAD worked on
+		//such a file for as long as it was given. No real R2010 table ever hit this: only a
+		//converted pre-R2010 one carries an empty string value, which is why T84's conversion
+		//experiments kept failing while ordinary round trips stayed green.
+		value ??= string.Empty;
 
 		byte[] bytes;
 		if (this.R2007Plus)

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.cs
@@ -147,20 +147,30 @@ internal partial class DwgObjectWriter : DwgSectionIO
 				return false;
 			case Shape:
 				return this.WriteShapes;
-			//The other half of that same version limit, and the one that costs a whole drawing rather
-			//than one entity. A table is stored one way up to R2007 and another from R2010; the reader
-			//reads both, but what the older layout gives it is not what the R2010 layout needs, and
-			//writing it anyway makes AutoCAD reject the file (ErrorStatus 53 at R2010) or work on it for
-			//as long as it is given (still going after ten minutes at R2018). Measured on sample_AC1018:
-			//with its two tables left out the same write opens and audits 0 in two seconds.
-			//ValueFlag is the marker - the older layout carries the field, the R2010 one does not, and no
-			//writer here writes it back.
-			case TableEntity legacyTable when legacyTable.ValueFlag != 0:
+			case TableEntity when !this.R2010Plus:
+				//Only the R2010 layout of a table is implemented: writeTableEntity throws at its
+				//own "Until R2007" branch, where the older inline cell layout would go. It is a
+				//limit of this writer, not of the format - AutoCAD's own AC1015 and AC1018 files
+				//carry tables - so say which limit it is, and which version keeps the object.
+				this.notify(
+					$"{entity.GetType().Name} {entity.Handle} is not written to a {this._version} file: only the {ACadVersion.AC1024} layout of it is implemented. {ACadVersion.AC1024} is the oldest version that keeps it.",
+					NotificationType.NotImplemented);
+
+				return false;
+			//The other half of that same limit, and the one that cost a whole drawing rather than one
+			//entity. The reader does read the older layout - that part works - but what it produces is
+			//not what the R2010 layout needs, and writing it anyway makes AutoCAD reject the file
+			//(ErrorStatus 53 at R2010) or work on it for as long as it is given (still going after ten
+			//minutes at R2018). The marker is provenance recorded by the reader, not a property of the
+			//table: inferring it from ValueFlag being non-zero was wrong, because that flag is public
+			//and documented, and normally carries 0x06, so a caller building a table faithfully would
+			//have had it silently dropped.
+			case TableEntity legacyTable when legacyTable.ContentIsPreR2010Layout:
 				this.notify(
 					$"{entity.GetType().Name} {entity.Handle} is not written to a {this._version} file: its content was read from the pre-{ACadVersion.AC1024} layout, which this writer cannot re-express as the {ACadVersion.AC1024} one. Written as it is, AutoCAD refuses the whole drawing.",
 					NotificationType.NotImplemented);
-			return false;
-			case TableEntity when !this.R2010Plus:
+
+				return false;
 			case Wall:
 			case MechanicalEntity:
 			case ProxyEntity:

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.cs
@@ -157,20 +157,15 @@ internal partial class DwgObjectWriter : DwgSectionIO
 					NotificationType.NotImplemented);
 
 				return false;
-			//The other half of that same limit, and the one that cost a whole drawing rather than one
-			//entity. The reader does read the older layout - that part works - but what it produces is
-			//not what the R2010 layout needs, and writing it anyway makes AutoCAD reject the file
-			//(ErrorStatus 53 at R2010) or work on it for as long as it is given (still going after ten
-			//minutes at R2018). The marker is provenance recorded by the reader, not a property of the
-			//table: inferring it from ValueFlag being non-zero was wrong, because that flag is public
-			//and documented, and normally carries 0x06, so a caller building a table faithfully would
-			//have had it silently dropped.
-			case TableEntity legacyTable when legacyTable.ContentIsPreR2010Layout:
-				this.notify(
-					$"{entity.GetType().Name} {entity.Handle} is not written to a {this._version} file: its content was read from the pre-{ACadVersion.AC1024} layout, which this writer cannot re-express as the {ACadVersion.AC1024} one. Written as it is, AutoCAD refuses the whole drawing.",
-					NotificationType.NotImplemented);
-
-				return false;
+			//A table whose content was read from the pre-R2010 layout used to be dropped here,
+			//because writing it unconverted makes AutoCAD reject the file (ErrorStatus 53 at
+			//R2010) or work on it for as long as it is given. It is now CONVERTED on write - see
+			//writeTableEntity - because the wall turned out not to be the missing R2010-only
+			//structures at all: stripping cell styles, content formats, cell geometry and custom
+			//data from an R2018-authored table still audits 0, and the real failure was
+			//writeStringCadValue writing a double length for an empty string, which only a
+			//converted table ever carries. With that fixed, the converted file opens and audits 0
+			//at AC1024, AC1027 and AC1032, and AutoCAD's own DXF export carries both tables.
 			case Wall:
 			case MechanicalEntity:
 			case ProxyEntity:

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.cs
@@ -147,6 +147,19 @@ internal partial class DwgObjectWriter : DwgSectionIO
 				return false;
 			case Shape:
 				return this.WriteShapes;
+			//The other half of that same version limit, and the one that costs a whole drawing rather
+			//than one entity. A table is stored one way up to R2007 and another from R2010; the reader
+			//reads both, but what the older layout gives it is not what the R2010 layout needs, and
+			//writing it anyway makes AutoCAD reject the file (ErrorStatus 53 at R2010) or work on it for
+			//as long as it is given (still going after ten minutes at R2018). Measured on sample_AC1018:
+			//with its two tables left out the same write opens and audits 0 in two seconds.
+			//ValueFlag is the marker - the older layout carries the field, the R2010 one does not, and no
+			//writer here writes it back.
+			case TableEntity legacyTable when legacyTable.ValueFlag != 0:
+				this.notify(
+					$"{entity.GetType().Name} {entity.Handle} is not written to a {this._version} file: its content was read from the pre-{ACadVersion.AC1024} layout, which this writer cannot re-express as the {ACadVersion.AC1024} one. Written as it is, AutoCAD refuses the whole drawing.",
+					NotificationType.NotImplemented);
+			return false;
 			case TableEntity when !this.R2010Plus:
 			case Wall:
 			case MechanicalEntity:


### PR DESCRIPTION
﻿
# Description

A table is stored one way up to R2007 and another from R2010, and this library reads both but
writes only the second. Writing a table read from the older layout into an R2010+ file unconverted
does not lose the table - it loses the drawing: AutoCAD 2027 rejects the file outright at R2010
(`ErrorStatus 53`) and was still working on it after ten minutes at R2018.

Three changes, in the order they were found:

1. **The marker is provenance, not `ValueFlag`.** The first guard keyed on `ValueFlag != 0`, but
   that flag is public, documented, and normally carries `0x06`, so a caller building a table
   faithfully would have had it silently dropped. The reader now records
   `ContentIsPreR2010Layout` (internal) on the branch that reads the old layout, and the writer
   keys on that.

2. **The real wall was a missing `return`.** `writeStringCadValue` wrote a bare zero length for an
   empty string *and then fell through* to the full write, so every field after an empty cell value
   was shifted by one bit long plus two bytes. Only a table converted from the old layout ever
   carries an empty String value - an R2010-authored one holds no content in such cells - which is
   why every ordinary round trip stayed green while a converted table made AutoCAD spin.
   `readStringCadValue` also tolerates the zero length the old writer produced, so files written
   with it remain readable.

3. **The conversion itself needs only what the old layout carries.** Per-cell merge spans become
   merged cell ranges, and a cell merged into another is written without the empty content the
   older layout gave it. Everything else the R2010 layout can carry - cell styles, content
   formats, cell geometry, custom data, style overrides - was measured to be optional: stripping
   all of it from an R2018-authored table still audits 0 in AutoCAD and its own DXF export keeps
   every cell. The conversion is held in writer state for the one entity and never mutates the
   document; pre-R2010 targets and the DXF path are unchanged.

Measured with AutoCAD 2027: `sample_AC1018` (both tables in the old layout) written at AC1024,
AC1027 and AC1032 **opens and audits 0** at all three, and AutoCAD's own DXF export of the result
carries both tables with their text and merges. Before the change, AC1024 was refused outright and
AC1032 span past ten minutes.

## Checklist

- [x] Only one commit arc per pull request (three commits, one story: the guard's key, the stream
  fix, the conversion)
- [x] Tests added: the empty-string pin (red 1/1 against the old writer), the caller-built-table
  guard, and the three conversion round trips at AC1024/AC1027/AC1032
- [x] Test suite: **2323 passed / 17 failed** against upstream `edda5594` at 2313 / 17 - the same
  seventeen failures, none added

