### PR TITLE
An image with no clip boundary is written with the whole-image rectangle

### DIFF
--- a/src/ACadSharp.Tests/IO/ImageWithoutClipTests.cs
+++ b/src/ACadSharp.Tests/IO/ImageWithoutClipTests.cs
@@ -1,0 +1,90 @@
+using ACadSharp.Entities;
+using ACadSharp.IO;
+using ACadSharp.Objects;
+using CSMath;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace ACadSharp.Tests.IO;
+
+public class ImageWithoutClipTests
+{
+	public static TheoryData<ACadVersion> Versions => new TheoryData<ACadVersion>
+	{
+		ACadVersion.AC1015,
+		ACadVersion.AC1018,
+		ACadVersion.AC1024,
+		ACadVersion.AC1032,
+	};
+
+	private static CadDocument document(ACadVersion version)
+	{
+		CadDocument doc = new CadDocument();
+		doc.Header.Version = version;
+		ImageDefinition definition = new ImageDefinition
+		{
+			Name = "photo",
+			FileName = "photo.png",
+			Size = new XY(550, 550),
+			DefaultSize = new XY(1, 1),
+		};
+		RasterImage image = new RasterImage(definition)
+		{
+			InsertPoint = new XYZ(0, 0, 0),
+			UVector = new XYZ(2, 0, 0),
+			VVector = new XYZ(0, 2, 0),
+			Size = new XY(550, 550),
+			ClippingState = false,
+		};
+		//No clip boundary at all: the case AutoCAD refuses to read when it is written as such.
+		Assert.Empty(image.ClipBoundaryVertices);
+		doc.ModelSpace.Entities.Add(image);
+		return doc;
+	}
+
+	[Theory]
+	[MemberData(nameof(Versions))]
+	public void DxfWritesTheDefaultRectangleForAnImageWithoutAClip(ACadVersion version)
+	{
+		//AutoCAD writes an unclipped image with a rectangular boundary of two vertices, (-0.5,-0.5)
+		//and (Size - 0.5): checked on six such images of a production drawing it saved as DXF. An
+		//image written with no boundary at all makes it discard the whole file.
+		CadDocument doc = document(version);
+
+		MemoryStream ms = new MemoryStream();
+		using (DxfWriter writer = new DxfWriter(ms, doc, false))
+		{
+			writer.Write();
+		}
+
+		CadDocument rt = DxfReader.Read(new MemoryStream(ms.ToArray()));
+		RasterImage got = Assert.Single(rt.ModelSpace.Entities.OfType<RasterImage>());
+		Assert.Equal(ClipType.Rectangular, got.ClipType);
+		Assert.Equal(2, got.ClipBoundaryVertices.Count);
+		Assert.Equal(new XY(-0.5, -0.5), got.ClipBoundaryVertices[0]);
+		Assert.Equal(new XY(549.5, 549.5), got.ClipBoundaryVertices[1]);
+		Assert.False(got.ClippingState);
+	}
+
+	[Theory]
+	[MemberData(nameof(Versions))]
+	public void DwgWritesTheDefaultRectangleForAnImageWithoutAClip(ACadVersion version)
+	{
+		//The DWG writer used to index [0] and [1] on the empty list and throw.
+		CadDocument doc = document(version);
+
+		MemoryStream ms = new MemoryStream();
+		using (DwgWriter writer = new DwgWriter(ms, doc))
+		{
+			writer.Write();
+		}
+
+		CadDocument rt = DwgReader.Read(new MemoryStream(ms.ToArray()));
+		RasterImage got = Assert.Single(rt.ModelSpace.Entities.OfType<RasterImage>());
+		Assert.Equal(ClipType.Rectangular, got.ClipType);
+		Assert.Equal(2, got.ClipBoundaryVertices.Count);
+		Assert.Equal(new XY(-0.5, -0.5), got.ClipBoundaryVertices[0]);
+		Assert.Equal(new XY(549.5, 549.5), got.ClipBoundaryVertices[1]);
+	}
+}

--- a/src/ACadSharp/Entities/CadWipeoutBase.cs
+++ b/src/ACadSharp/Entities/CadWipeoutBase.cs
@@ -53,6 +53,33 @@ public abstract class CadWipeoutBase : Entity
 	public List<XY> ClipBoundaryVertices { get; set; } = new List<XY>();
 
 	/// <summary>
+	/// The clip boundary as a file has to carry it: the vertices given, or, when there are none,
+	/// the default rectangle that covers the whole image.
+	/// </summary>
+	/// <remarks>
+	/// AutoCAD writes an image that is not clipped with a rectangular boundary of two vertices,
+	/// (-0.5, -0.5) and (Size.X - 0.5, Size.Y - 0.5) in pixel space, and refuses a file whose
+	/// image carries no boundary at all: "in IMAGE ... Xdata wasn't read. Invalid or incomplete
+	/// DXF input -- drawing discarded." Checked on six unclipped images of a production drawing
+	/// AutoCAD 2027 saved as DXF, all six identical in that respect. Nothing in this library
+	/// stopped a caller writing an image with an empty list, and one application did, and worked
+	/// around the discard by adding those two points itself.
+	/// </remarks>
+	public IReadOnlyList<XY> GetEffectiveClipBoundary()
+	{
+		if (this.ClipBoundaryVertices.Count > 0)
+		{
+			return this.ClipBoundaryVertices;
+		}
+
+		return new[]
+		{
+			new XY(-0.5, -0.5),
+			new XY(this.Size.X - 0.5, this.Size.Y - 0.5),
+		};
+	}
+
+	/// <summary>
 	/// Clipping state.
 	/// </summary>
 	[DxfCodeValue(290)]
@@ -255,9 +282,12 @@ public abstract class CadWipeoutBase : Entity
 	{
 		var result = base.IsValid(format, version, out errors);
 
-		if (this.ClipBoundaryVertices.Count < 2)
+		//An empty list is not an error: it means the image is not clipped, and both writers put
+		//the whole-image rectangle of GetEffectiveClipBoundary in the file, which is what AutoCAD
+		//itself writes for an unclipped image. A single vertex is not a boundary either way.
+		if (this.ClipBoundaryVertices.Count == 1)
 		{
-			errors.Add($"Invalid {nameof(ClipBoundaryVertices)} count: {this.ClipBoundaryVertices.Count}, must be at least 2.");
+			errors.Add($"Invalid {nameof(ClipBoundaryVertices)} count: {this.ClipBoundaryVertices.Count}, must be 0 for an unclipped image or at least 2.");
 			result = false;
 		}
 

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Entities.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Entities.cs
@@ -57,19 +57,23 @@ internal partial class DwgObjectWriter : DwgSectionIO
 			this._writer.WriteBit(image.ClipMode == ClipMode.Inside);
 		}
 
-		this._writer.WriteBitShort((short)image.ClipType);
+		//See CadWipeoutBase.GetEffectiveClipBoundary: no vertices means the default rectangle. This
+		//writer used to index [0] and [1] on the empty list and throw.
+		IReadOnlyList<XY> boundary = image.GetEffectiveClipBoundary();
+		ClipType clipType = image.ClipBoundaryVertices.Count == 0 ? ClipType.Rectangular : image.ClipType;
+		this._writer.WriteBitShort((short)clipType);
 
-		switch (image.ClipType)
+		switch (clipType)
 		{
 			case ClipType.Rectangular:
-				this._writer.Write2RawDouble(image.ClipBoundaryVertices[0]);
-				this._writer.Write2RawDouble(image.ClipBoundaryVertices[1]);
+				this._writer.Write2RawDouble(boundary[0]);
+				this._writer.Write2RawDouble(boundary[1]);
 				break;
 			case ClipType.Polygonal:
-				this._writer.WriteBitLong(image.ClipBoundaryVertices.Count);
-				for (int i = 0; i < image.ClipBoundaryVertices.Count; i++)
+				this._writer.WriteBitLong(boundary.Count);
+				for (int i = 0; i < boundary.Count; i++)
 				{
-					this._writer.Write2RawDouble(image.ClipBoundaryVertices[i]);
+					this._writer.Write2RawDouble(boundary[i]);
 				}
 				break;
 		}

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
@@ -4,6 +4,7 @@ using ACadSharp.Entities.Mechanical;
 using ACadSharp.Objects;
 using CSMath;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace ACadSharp.IO.DXF;
@@ -253,22 +254,27 @@ internal abstract partial class DxfSectionWriterBase
 			this.Holder.Objects.Enqueue(image.DefinitionReactor);
 		}
 
-		this._writer.Write(71, (short)image.ClipType, map);
+		//An image with no boundary vertices is written with the default rectangle that covers it,
+		//and as rectangular whatever the type says: a polygon of nothing is not a boundary, and a
+		//record with no boundary at all is one AutoCAD refuses to read.
+		IReadOnlyList<XY> boundary = image.GetEffectiveClipBoundary();
+		ClipType clipType = image.ClipBoundaryVertices.Count == 0 ? ClipType.Rectangular : image.ClipType;
+		this._writer.Write(71, (short)clipType, map);
 
-		if (image.ClipType == ClipType.Polygonal)
+		if (clipType == ClipType.Polygonal)
 		{
-			this._writer.Write(91, image.ClipBoundaryVertices.Count + 1, map);
-			foreach (XY bv in image.ClipBoundaryVertices)
+			this._writer.Write(91, boundary.Count + 1, map);
+			foreach (XY bv in boundary)
 			{
 				this._writer.Write(14, bv, map);
 			}
 
-			this._writer.Write(14, image.ClipBoundaryVertices.First(), map);
+			this._writer.Write(14, boundary[0], map);
 		}
 		else
 		{
-			this._writer.Write(91, image.ClipBoundaryVertices.Count, map);
-			foreach (XY bv in image.ClipBoundaryVertices)
+			this._writer.Write(91, boundary.Count, map);
+			foreach (XY bv in boundary)
 			{
 				this._writer.Write(14, bv, map);
 			}


### PR DESCRIPTION
﻿
# Description

A `RasterImage` (or `Wipeout`) whose `ClipBoundaryVertices` list is empty - an image placed by code
and never clipped - is written as a record AutoCAD refuses:

- the DXF writer emits `71 = <type>`, `91 = 0` and no `14/24` pairs; AutoCAD 2027 opens the file
  with *"in IMAGE ... Xdata wasn't read. Invalid or incomplete DXF input -- drawing discarded"*;
- the DWG writer indexes `[0]` and `[1]` of the empty list and throws `ArgumentOutOfRangeException`.

AutoCAD itself never writes an image without a boundary. An unclipped image comes out with the
rectangle that covers the whole image in pixel space: `280 = 0`, `71 = 1`, `91 = 2`,
`(-0.5, -0.5)` and `(Size - 0.5)` - that is also what the remarks on `ClipBoundaryVertices` already
say is the default. Six unclipped images in a production drawing come back from AutoCAD's own DXF
of it in exactly that shape.

`CadWipeoutBase.GetEffectiveClipBoundary()` returns the stored vertices when there are any and that
default rectangle otherwise; both writers use it, and write `Rectangular` as the clip type when they
had to fall back. `ClippingState` is left alone: the image is not clipped, only well formed.

# Tasks done in this PR

* [x] `CadWipeoutBase.GetEffectiveClipBoundary()`.
* [x] DXF and DWG writers write the effective boundary; the DWG writer no longer throws on an
      empty list.
* [x] `ImageWithoutClipTests`: DXF and DWG round trip of an image with no clip, R2000 to R2018 -
      reads back rectangular, two vertices `(-0.5,-0.5)` / `(549.5,549.5)`, not clipped.

# Related Issues / Pull Requests

- Related to the polygonal-clip round-trip fix and its test in this stack; independent of them.

# Notes for reviewer

**Testing**

`dotnet test` on this branch: **2320 passed / 17 failed**, the same 17 failures as master
(2312 + 8 new).

AutoCAD 2027 (`accoreconsole`, `AUDIT`):

| file | before | after |
|---|---|---|
| `image_noclip.dxf` (one `RasterImage`, no clip) | `opened=False`, invalid file | `opened=True errors=0` |
| `image_noclip.dwg` | writer threw | `opened=True errors=0` |
| six DWG round trips of three production drawings (R2000 + R2018) | 0 errors | 0 errors |

