### PR TITLE
Writing a DXF as AC1014 says so instead of handing back a file AutoCAD refuses

### DIFF
--- a/src/ACadSharp.Tests/IO/DXF/DxfVersionWarningTests.cs
+++ b/src/ACadSharp.Tests/IO/DXF/DxfVersionWarningTests.cs
@@ -1,0 +1,57 @@
+using ACadSharp.Entities;
+using ACadSharp.IO;
+using CSMath;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace ACadSharp.Tests.IO.DXF
+{
+	/// <summary>
+	/// The DWG writer says plainly that an AC1014 file is not accepted by AutoCAD. The DXF writer
+	/// wrote the same version in silence, and the result is refused just as firmly: AutoCAD 2027
+	/// reports "Premature end of object" on the DIMSTYLE table header, and removing that group only
+	/// moves the refusal to the next object. A caller asking for that version gets a file that
+	/// cannot be opened, so it has to be told.
+	/// </summary>
+	public class DxfVersionWarningTests
+	{
+		[Theory]
+		[InlineData(ACadVersion.AC1014)]
+		public void OldVersionIsReportedAsNotAcceptedByAutoCad(ACadVersion version)
+		{
+			List<string> messages = write(version);
+
+			Assert.Contains(messages, m => m.Contains("not accepted by AutoCAD", System.StringComparison.OrdinalIgnoreCase));
+		}
+
+		[Theory]
+		[InlineData(ACadVersion.AC1015)]
+		[InlineData(ACadVersion.AC1018)]
+		[InlineData(ACadVersion.AC1032)]
+		public void SupportedVersionIsNotReported(ACadVersion version)
+		{
+			List<string> messages = write(version);
+
+			Assert.DoesNotContain(messages, m => m.Contains("not accepted by AutoCAD", System.StringComparison.OrdinalIgnoreCase));
+		}
+
+		private static List<string> write(ACadVersion version)
+		{
+			CadDocument doc = new CadDocument();
+			doc.Header.Version = version;
+			doc.ModelSpace.Entities.Add(new Line(new XYZ(0, 0, 0), new XYZ(10, 0, 0)));
+
+			List<string> messages = new List<string>();
+			using MemoryStream stream = new MemoryStream();
+			using (DxfWriter writer = new DxfWriter(stream, doc, false))
+			{
+				writer.OnNotification += (s, e) => messages.Add(e.Message);
+				writer.Write();
+			}
+
+			return messages;
+		}
+	}
+}

--- a/src/ACadSharp/IO/DxfWriter.cs
+++ b/src/ACadSharp/IO/DxfWriter.cs
@@ -87,6 +87,17 @@ public class DxfWriter : CadWriterBase<DxfWriterConfiguration>
 	{
 		base.Write();
 
+		//The DWG writer says the same of AC1014, and a DXF written as that version is refused just
+		//as firmly: AutoCAD reports "Premature end of object" on the DIMSTYLE table header, and
+		//removing that group only moves the refusal to the next object. Writing it in silence hands
+		//back a file that looks fine and cannot be opened, so say so.
+		if (this._document.Header.Version <= ACadVersion.AC1014)
+		{
+			this.triggerNotification(
+				$"A DXF written as {this._document.Header.Version} is not accepted by AutoCAD; the oldest version that opens is {ACadVersion.AC1015}",
+				NotificationType.Warning);
+		}
+
 		this.createStreamWriter();
 
 		this._objectHolder.Objects.Enqueue(this._document.RootDictionary);


### PR DESCRIPTION
﻿
# Description

`DwgWriter` already tells the caller that an `AC1014` file is not accepted by AutoCAD. `DxfWriter`
wrote the same version in silence, and the result is refused just as firmly. AutoCAD 2027 on a DXF
we wrote as AC1014:

```
Premature end of object on line 2906.        (the DIMSTYLE table header)
Invalid or incomplete DXF input -- drawing discarded.
```

Removing the group it stops on only moves the refusal to the next object (`ACDBPLACEHOLDER`
wanting its class separator), so the R14 DXF shape is wrong in more than one place.

Making an R14 DXF that opens is separate work, and there is no oracle for it: AutoCAD 2027 cannot
save that version either, so there is nothing to compare against. What this fixes is the silence -
a caller asking for a version whose output cannot be opened is now told, exactly as on the DWG side.

# Tasks done in this PR

* [x] `DxfWriter.Write` reports `AC1014` and older as not accepted by AutoCAD, naming `AC1015` as
      the oldest version that opens.
* [x] `DxfVersionWarningTests`: AC1014 is reported; AC1015, AC1018 and AC1032 are not.

# Related Issues / Pull Requests

- None.

# Notes for reviewer

**Testing**

`dotnet test` on this branch: **2316 passed / 17 failed**, the same 17 failures as master
(2312 + 4 new tests).

How it was found: one drawing written to every version, each result audited by AutoCAD.

| version | DWG | DXF |
|---|---|---|
| AC1014 | not opened (already warned) | **not opened, no warning** |
| AC1015, AC1018, AC1024, AC1027, AC1032 | opened, 0 errors | opened, 0 errors |
| AC1021 | write throws `CadNotSupportedException` | opened, 0 errors |

