### PR TITLE
Adding a CadObject hashes it once instead of twice

### DIFF
--- a/src/ACadSharp/CadObjectCollection.cs
+++ b/src/ACadSharp/CadObjectCollection.cs
@@ -61,10 +61,13 @@ public class CadObjectCollection<T> : IObservableCadCollection<T>
 		if (item.Owner != null)
 			throw new ArgumentException($"Item {item.GetType().FullName} already has an owner", nameof(item));
 
-		if (this._entries.Contains(item))
+		//HashSet.Add already reports whether the item was there, and leaves the set untouched when
+		//it was, so the separate Contains costs a second reference hash of every object added.
+		//Reading a 17.6 MB drawing adds about half a million entities to these collections, and
+		//RuntimeHelpers.GetHashCode was 463 ms of that read.
+		if (!this._entries.Add(item))
 			throw new ArgumentException($"Item {item.GetType().FullName} is already in the collection", nameof(item));
 
-		this._entries.Add(item);
 		item.Owner = this.Owner;
 
 		OnAdd?.Invoke(this, new CollectionChangedEventArgs(item));


### PR DESCRIPTION
﻿
# Description

`CadObjectCollection<T>.Add` asked the backing `HashSet<T>` whether the item was already there and
then added it:

```csharp
if (this._entries.Contains(item))
    throw new ArgumentException(...);

this._entries.Add(item);
```

`HashSet<T>.Add` already returns exactly what `Contains` would have said, and leaves the set
untouched when the item is present, so the two calls collapse into one and the behaviour - including
the exception and the state of the collection when it is thrown - is identical:

```csharp
if (!this._entries.Add(item))
    throw new ArgumentException(...);
```

The reason it is worth a patch is how often it runs. These collections hold every entity of every
block, and the objects are compared by reference, so each add costs two `RuntimeHelpers.GetHashCode`
calls. Reading one real 17.6 MB drawing (46,449 model-space entities, 40,843 block records, 447,084
entities inside blocks) adds about half a million objects.

# Measurement

Three reads of that drawing in one process, sampled with `dotnet-trace`, same machine, same build
except for this change:

| | before | after |
|---|---|---|
| `RuntimeHelpers.GetHashCode` (self, 3 reads) | 1,303 ms | 1,080 ms |
| `DwgReader.Read` (inclusive, per read) | 3,901 ms | 3,576 ms |

Median of five untraced reads: 3,513 ms to 3,159 ms.

# Tasks done in this PR

* [x] Use the result of `HashSet.Add` instead of a separate `Contains`.

# Test suite

`2312 passed / 17 failed` on this branch, the same as upstream master at `8a527826`.

