### PR TITLE
Fix the bounding box of radius and diameter dimensions

### DIFF
--- a/src/ACadSharp.Tests/Entities/DimensionDiameterTests.cs
+++ b/src/ACadSharp.Tests/Entities/DimensionDiameterTests.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Entities;
 using CSMath;
+using Xunit;
 
 namespace ACadSharp.Tests.Entities;
 
@@ -9,6 +10,20 @@ public class DimensionDiameterTests : CommonDimensionTests<DimensionDiameter>
 
 	public override void GetBoundingBoxTest()
 	{
+		//Laid out far from the origin, the way a real drawing is. AngleVertex is a point on the
+		//measured curve; treating it as a half-size used to return a box that straddled (0,0) and was
+		//as wide as the drawing is far from it, which is enough to wreck a whole drawing's extents.
+		DimensionDiameter dim = new DimensionDiameter
+		{
+			DefinitionPoint = new XYZ(1000, 2000, 0),
+			AngleVertex = new XYZ(1010, 2000, 0),
+			TextMiddlePoint = new XYZ(1005, 2005, 0),
+		};
+
+		BoundingBox box = dim.GetBoundingBox();
+
+		Assert.Equal(new XYZ(1000, 2000, 0), box.Min);
+		Assert.Equal(new XYZ(1010, 2005, 0), box.Max);
 	}
 
 	protected override DimensionDiameter createDim()

--- a/src/ACadSharp.Tests/Entities/DimensionRadiusTests.cs
+++ b/src/ACadSharp.Tests/Entities/DimensionRadiusTests.cs
@@ -1,4 +1,6 @@
 ﻿using ACadSharp.Entities;
+using CSMath;
+using Xunit;
 
 namespace ACadSharp.Tests.Entities;
 
@@ -8,6 +10,20 @@ public class DimensionRadiusTests : CommonDimensionTests<DimensionRadius>
 
 	public override void GetBoundingBoxTest()
 	{
+		//Laid out far from the origin, the way a real drawing is. AngleVertex is a point on the
+		//measured curve; treating it as a half-size used to return a box that straddled (0,0) and was
+		//as wide as the drawing is far from it, which is enough to wreck a whole drawing's extents.
+		DimensionRadius dim = new DimensionRadius
+		{
+			DefinitionPoint = new XYZ(1000, 2000, 0),
+			AngleVertex = new XYZ(1010, 2000, 0),
+			TextMiddlePoint = new XYZ(1005, 2005, 0),
+		};
+
+		BoundingBox box = dim.GetBoundingBox();
+
+		Assert.Equal(new XYZ(1000, 2000, 0), box.Min);
+		Assert.Equal(new XYZ(1010, 2005, 0), box.Max);
 	}
 
 	protected override DimensionRadius createDim()

--- a/src/ACadSharp/Entities/DimensionDiameter.cs
+++ b/src/ACadSharp/Entities/DimensionDiameter.cs
@@ -67,7 +67,12 @@ namespace ACadSharp.Entities
 		/// <inheritdoc/>
 		public override BoundingBox GetBoundingBox()
 		{
-			return new BoundingBox(this.InsertionPoint - this.AngleVertex, this.InsertionPoint + this.AngleVertex);
+			//AngleVertex is a point on the curve, not a half-size, and InsertionPoint is the group 12
+			//slot AutoCAD leaves at the origin unless the dimension was cloned by Baseline/Continue.
+			//Subtracting one from the other produced a box that straddled the origin and was as wide as
+			//the drawing is far from it - one such dimension puts a drawing's extents out by millions of
+			//units, which is what a viewer's zoom-extents then has to cope with.
+			return BoundingBox.FromPoints(new[] { this.DefinitionPoint, this.AngleVertex, this.TextMiddlePoint });
 		}
 
 		/// <inheritdoc/>

--- a/src/ACadSharp/Entities/DimensionRadius.cs
+++ b/src/ACadSharp/Entities/DimensionRadius.cs
@@ -59,7 +59,12 @@ namespace ACadSharp.Entities
 		/// <inheritdoc/>
 		public override BoundingBox GetBoundingBox()
 		{
-			return new BoundingBox(this.InsertionPoint - this.AngleVertex, this.InsertionPoint + this.AngleVertex);
+			//AngleVertex is a point on the curve, not a half-size, and InsertionPoint is the group 12
+			//slot AutoCAD leaves at the origin unless the dimension was cloned by Baseline/Continue.
+			//Subtracting one from the other produced a box that straddled the origin and was as wide as
+			//the drawing is far from it - one such dimension puts a drawing's extents out by millions of
+			//units, which is what a viewer's zoom-extents then has to cope with.
+			return BoundingBox.FromPoints(new[] { this.DefinitionPoint, this.AngleVertex, this.TextMiddlePoint });
 		}
 
 		/// <inheritdoc/>


### PR DESCRIPTION
### The problem

`DimensionRadius.GetBoundingBox()` and `DimensionDiameter.GetBoundingBox()` both do this:

```csharp
return new BoundingBox(this.InsertionPoint - this.AngleVertex, this.InsertionPoint + this.AngleVertex);
```

`AngleVertex` is a *point* on the measured curve (group 15), not an offset, and `InsertionPoint` is the group 12 slot that AutoCAD leaves at the origin unless the dimension was produced by `Baseline`/`Continue`. Subtracting one from the other returns a box centred on the origin and twice as wide as the dimension is far from it.

A radius dimension in a drawing laid out 4 million units from the origin reports:

```
(-4086548.9, -8510215.9) .. (4086548.9, 8510215.9)
```

— roughly 8 million by 17 million units, for a dimension a few hundred units across.

### Why it matters

One of these is enough to make a whole drawing's extents useless, so anything that frames a drawing from its geometry (a viewer's zoom-extents, for instance) has nothing to work with.

Measured over eighteen architectural drawings, against the extents AutoCAD itself reports after a regen: **223 radius and diameter dimensions** were producing such boxes, and they were the single largest contributor to the drawings whose computed extents did not match AutoCAD's. Fixing this alone brought two drawings into exact agreement and took others from 52x and 39x too large down to 8.8x and 3.0x (the rest of that residue has other causes, one of which is #1224).

### The fix

Take the box from the points the dimension is actually made of — the centre, the point on the curve, and the text position.

### Tests

`GetBoundingBoxTest()` was an empty method body in **both** `DimensionRadiusTests` and `DimensionDiameterTests`, which is why this survived. Both now assert the box of a dimension placed away from the origin; both fail against the previous implementation.

`dotnet test` on this branch: 2313 passed / 17 failed — byte for byte the same as `master` at 592d70a7 on this machine, so no regression is introduced here.