### PR TITLE
Fix the bounding box of mirrored polylines and circles (OCS is not WCS)

### DIFF
--- a/src/ACadSharp.Tests/Entities/CircleTests.cs
+++ b/src/ACadSharp.Tests/Entities/CircleTests.cs
@@ -18,6 +18,16 @@ public class CircleTests : CommonEntityTests<Circle>
 
 		Assert.Equal(new XYZ(-5, -5, 0), boundingBox.Min);
 		Assert.Equal(new XYZ(5, 5, 0), boundingBox.Max);
+
+		//The centre is stored in the circle's own object coordinate system, so the (0,0,-1)
+		//normal AutoCAD writes for mirrored geometry puts the circle at the negated X.
+		circle.Center = new XYZ(100, 50, 0);
+		circle.Normal = -XYZ.AxisZ;
+
+		boundingBox = circle.GetBoundingBox();
+
+		Assert.Equal(new XYZ(-105, 45, 0), boundingBox.Min);
+		Assert.Equal(new XYZ(-95, 55, 0), boundingBox.Max);
 	}
 
 	[Fact]

--- a/src/ACadSharp.Tests/Entities/LwPolylineTest.cs
+++ b/src/ACadSharp.Tests/Entities/LwPolylineTest.cs
@@ -117,5 +117,25 @@ public class LwPolylineTests : CommonEntityTests<LwPolyline>
 
 	public override void GetBoundingBoxTest()
 	{
+		LwPolyline lwPolyline = new LwPolyline();
+		foreach (XYZ p in this._points)
+		{
+			lwPolyline.Vertices.Add(new LwPolyline.Vertex((XY)p));
+		}
+
+		BoundingBox box = lwPolyline.GetBoundingBox();
+
+		Assert.Equal(new XYZ(0, 0, 0), box.Min);
+		Assert.Equal(new XYZ(1, 1, 0), box.Max);
+
+		//The vertices are stored in the polyline's own object coordinate system. AutoCAD writes a
+		//(0,0,-1) normal whenever geometry is mirrored, and the world position is then the negated X -
+		//not the stored one, which would place the polyline on the wrong side of the drawing.
+		lwPolyline.Normal = -XYZ.AxisZ;
+
+		box = lwPolyline.GetBoundingBox();
+
+		Assert.Equal(new XYZ(-1, 0, 0), box.Min);
+		Assert.Equal(new XYZ(0, 1, 0), box.Max);
 	}
 }

--- a/src/ACadSharp/Entities/Circle.cs
+++ b/src/ACadSharp/Entities/Circle.cs
@@ -101,8 +101,14 @@ public class Circle : Entity, ICurve, IOrientable
 	/// <inheritdoc/>
 	public override BoundingBox GetBoundingBox()
 	{
-		XYZ min = new XYZ(Math.Min(this.Center.X - this.Radius, this.Center.X + this.Radius), Math.Min(this.Center.Y - this.Radius, this.Center.Y + this.Radius), Math.Min(this.Center.Z, this.Center.Z));
-		XYZ max = new XYZ(Math.Max(this.Center.X - this.Radius, this.Center.X + this.Radius), Math.Max(this.Center.Y - this.Radius, this.Center.Y + this.Radius), Math.Max(this.Center.Z, this.Center.Z));
+		//The centre is in the circle's own object coordinate system. Read straight out it puts a
+		//mirrored circle - the (0,0,-1) normal AutoCAD writes for mirrored geometry - on the wrong
+		//side of the drawing, far enough to ruin the extents of everything around it.
+		XYZ center = Matrix4.GetArbitraryAxis(this.Normal) * this.Center;
+
+		XYZ min = new XYZ(center.X - this.Radius, center.Y - this.Radius, center.Z);
+		XYZ max = new XYZ(center.X + this.Radius, center.Y + this.Radius, center.Z);
+
 		return new BoundingBox(min, max);
 	}
 

--- a/src/ACadSharp/Entities/LwPolyLine.cs
+++ b/src/ACadSharp/Entities/LwPolyLine.cs
@@ -148,11 +148,15 @@ public partial class LwPolyline : Entity, IPolyline
 	/// <inheritdoc/>
 	public override BoundingBox GetBoundingBox()
 	{
-		if (this.Vertices.Any(v => v.Bulge != 0))
-		{
-			return BoundingBox.FromPoints(this.GetPoints<XYZ>(byte.MaxValue));
-		}
+		IEnumerable<XYZ> points = this.Vertices.Any(v => v.Bulge != 0)
+			? this.GetPoints<XYZ>(byte.MaxValue)
+			: this.Vertices.Select(v => v.Location.Convert<XYZ>());
 
-		return BoundingBox.FromPoints(this.Vertices.Select(v => v.Location.Convert<XYZ>()));
+		//The vertices are stored in the entity's own object coordinate system. A caller asking for a
+		//bounding box is asking where the thing sits in the world, and for the (0,0,-1) normal AutoCAD
+		//writes whenever geometry is mirrored the two differ by the sign of X - which is enough to put
+		//a drawing's extents out by millions of units and make a viewer's zoom-extents useless.
+		Matrix4 toWorld = Matrix4.GetArbitraryAxis(this.Normal);
+		return BoundingBox.FromPoints(points.Select(p => toWorld * p));
 	}
 }

--- a/src/ACadSharp/Entities/PolyLine.cs
+++ b/src/ACadSharp/Entities/PolyLine.cs
@@ -92,6 +92,14 @@ public abstract class Polyline<T> : Entity, IPolyline
 	[DxfCodeValue(210, 220, 230)]
 	public XYZ Normal { get; set; } = XYZ.AxisZ;
 
+	/// <summary>
+	/// Whether the vertexes of this polyline are expressed in the entity's own object coordinate
+	/// system, in which case <see cref="Normal"/> is needed to place them in the world. True for
+	/// the 2D form, which is how AutoCAD records mirrored geometry; false for the 3D form, whose
+	/// vertexes are already world coordinates.
+	/// </summary>
+	protected virtual bool VertexesAreInObjectCoordinates { get; } = true;
+
 	/// <inheritdoc/>
 	public override string ObjectName => DxfFileToken.EntityPolyline;
 
@@ -176,12 +184,18 @@ public abstract class Polyline<T> : Entity, IPolyline
 	/// <inheritdoc/>
 	public override BoundingBox GetBoundingBox()
 	{
-		if (this.Vertices.Any(v => v.Bulge != 0))
-		{
-			return BoundingBox.FromPoints(this.GetPoints<XYZ>(byte.MaxValue));
-		}
+		IEnumerable<XYZ> points = this.Vertices.Any(v => v.Bulge != 0)
+			? this.GetPoints<XYZ>(byte.MaxValue)
+			: this.Vertices.Select(v => v.Location.Convert<XYZ>());
 
-		return BoundingBox.FromPoints(this.Vertices.Select(v => v.Location.Convert<XYZ>()));
+		//The vertices are stored in the entity's own object coordinate system. A caller asking for a
+		//bounding box is asking where the thing sits in the world, and for the (0,0,-1) normal AutoCAD
+		//writes whenever geometry is mirrored the two differ by the sign of X - which is enough to put
+		//a drawing's extents out by millions of units and make a viewer's zoom-extents useless.
+		Matrix4 toWorld = this.VertexesAreInObjectCoordinates
+			? Matrix4.GetArbitraryAxis(this.Normal)
+			: Matrix4.Identity;
+		return BoundingBox.FromPoints(points.Select(p => toWorld * p));
 	}
 
 	internal static IEnumerable<Entity> Explode(IPolyline polyline)

--- a/src/ACadSharp/Entities/PolyLine3D.cs
+++ b/src/ACadSharp/Entities/PolyLine3D.cs
@@ -17,6 +17,9 @@ namespace ACadSharp.Entities
 	public class Polyline3D : Polyline<Vertex3D>
 	{
 		/// <inheritdoc/>
+		protected override bool VertexesAreInObjectCoordinates { get; } = false;
+
+		/// <inheritdoc/>
 		public override PolylineFlags Flags { get => base.Flags | (PolylineFlags.Polyline3D); set => base.Flags = value; }
 
 		/// <inheritdoc/>


### PR DESCRIPTION
### The problem

The vertexes of an `LWPOLYLINE` and a 2D `POLYLINE`, and the centre of a `CIRCLE`, are stored in the entity's own **object coordinate system**. `GetBoundingBox()` returned them unchanged.

For the `(0,0,-1)` extrusion AutoCAD writes whenever geometry is mirrored, the world X is the negated stored X — so the box comes back with the entity on the opposite side of the drawing.

`Insert` and `Arc` already route through `Matrix4.GetArbitraryAxis` for exactly this reason; these three did not.

### Confirmed against AutoCAD

For one `LWPOLYLINE` in a real drawing, AutoCAD's own `entget` gives:

```
(0 . LWPOLYLINE) (5 . A11A) ... (10 -4.2675e+06 -8.03408e+06) ... (210 0.0 0.0 -1.0)
```

The stored X is `-4.2675e+06` and the extrusion is `(0,0,-1)`, so the entity's world X is `+4.2675e+06` — alongside the other 20 entities in that block, all of which sit at `+4.2674xx`. Reading the stored value as a world coordinate is what puts it on the far side.

### Why it matters

One mirrored polyline does real damage because it is usually inside a block. In the drawing above, that single vertex list made its block's bounding box **8.5 million units wide instead of 208**, and with it every one of the **44** references to that block, each landing about 12.4 million units from where it belongs.

### The fix

Map the points through `Matrix4.GetArbitraryAxis(Normal)` before taking the box.

`Polyline3D` is deliberately left alone — its vertexes are already world coordinates. That is expressed as a flag on the shared `Polyline<T>` base rather than by relying on its `Normal` happening to stay `+Z`.

### Tests

`LwPolylineTests.GetBoundingBoxTest()` was an empty method body; it now covers the plain and the mirrored case. `CircleTests.GetBoundingBoxTest()` gained the mirrored case. Both fail against the previous implementation.

`dotnet test` on this branch: 2313 passed / 17 failed — identical to `master` at 592d70a7 on this machine, so no regression is introduced here.

### Related

Companion to #1223. Both were found while comparing computed extents against the extents AutoCAD reports for eighteen architectural drawings.