### PR TITLE
Fix the sampled domain of a periodic spline (bounding box reached the origin)

### DIFF
--- a/src/ACadSharp.Tests/Entities/SplineTests.cs
+++ b/src/ACadSharp.Tests/Entities/SplineTests.cs
@@ -37,6 +37,49 @@ public class SplineTests : CommonEntityTests<Spline>
 	}
 
 	[Fact]
+	public void GetBoundingBoxOfAPeriodicSplineStaysOnTheCurve()
+	{
+		//A periodic spline is flagged closed as well, and the domain of its unclamped knot vector
+		//starts at knots[degree] - not at knots[0], which lies outside it. Sampling below the
+		//domain makes every basis function vanish, and the zero vector that comes back used to
+		//drag the bounding box all the way to the origin.
+		Spline spline = new Spline();
+		spline.Degree = 3;
+
+		foreach (XYZ pt in new[]
+		{
+			new XYZ(1000, 2000, 0),
+			new XYZ(1010, 2000, 0),
+			new XYZ(1015, 2009, 0),
+			new XYZ(1010, 2017, 0),
+			new XYZ(1000, 2017, 0),
+			new XYZ(995, 2009, 0),
+			new XYZ(1000, 2000, 0),
+		})
+		{
+			spline.ControlPoints.Add(pt);
+		}
+
+		for (int i = 0; i < 11; i++)
+		{
+			spline.Knots.Add(i);
+		}
+
+		spline.IsClosed = true;
+		spline.IsPeriodic = true;
+
+		BoundingBox hull = BoundingBox.FromPoints(spline.ControlPoints);
+		BoundingBox box = spline.GetBoundingBox();
+
+		//A B-spline lies inside the convex hull of its control points, so the box cannot reach
+		//further out than they do - and certainly not back to (0,0).
+		Assert.True(box.Min.X >= hull.Min.X - 1, $"min X {box.Min.X} escaped the control hull {hull.Min.X}");
+		Assert.True(box.Min.Y >= hull.Min.Y - 1, $"min Y {box.Min.Y} escaped the control hull {hull.Min.Y}");
+		Assert.True(box.Max.X <= hull.Max.X + 1, $"max X {box.Max.X} escaped the control hull {hull.Max.X}");
+		Assert.True(box.Max.Y <= hull.Max.Y + 1, $"max Y {box.Max.Y} escaped the control hull {hull.Max.Y}");
+	}
+
+	[Fact]
 	public void CheckIsCloseFlag()
 	{
 		Spline spline = new Spline();

--- a/src/ACadSharp/Entities/Spline.cs
+++ b/src/ACadSharp/Entities/Spline.cs
@@ -1,4 +1,4 @@
-using ACadSharp.Attributes;
+﻿using ACadSharp.Attributes;
 using CSMath;
 using CSUtilities.Extensions;
 using System;
@@ -729,15 +729,19 @@ public class Spline : Entity, IOrientable
 
 	private void getStartAndEndKnots(double[] knots, out double uStart, out double uEnd)
 	{
-		if (this.IsClosed)
-		{
-			uStart = knots[0];
-			uEnd = knots[knots.Length - 1];
-		}
-		else if (this.IsPeriodic)
+		//Periodic first. A periodic spline forms a closed loop and so carries the closed flag as
+		//well, which meant this branch never ran: the domain of an unclamped knot vector starts at
+		//knots[degree], and evaluating below it makes every basis function vanish, so the first
+		//sampled point came back as the zero vector and dragged the bounding box to the origin.
+		if (this.IsPeriodic)
 		{
 			uStart = knots[this.Degree];
 			uEnd = knots[knots.Length - this.Degree - 1];
+		}
+		else if (this.IsClosed)
+		{
+			uStart = knots[0];
+			uEnd = knots[knots.Length - 1];
 		}
 		else
 		{


### PR DESCRIPTION
### The problem

`getStartAndEndKnots` tests `IsClosed` before `IsPeriodic`:

```csharp
if (this.IsClosed)          { uStart = knots[0];            uEnd = knots[^1]; }
else if (this.IsPeriodic)   { uStart = knots[this.Degree];  uEnd = knots[^(this.Degree + 1)]; }
```

A periodic spline forms a closed loop and therefore carries the closed flag too, so the periodic branch never runs and the domain is taken as `knots[0] .. knots[last]`.

For an unclamped knot vector the domain starts at `knots[degree]`. Evaluating below it makes every basis function vanish, and `PolygonalVertexes` returns the zero vector for that sample.

### What it costs

Measured on a periodic spline out of a real drawing — degree 3, 7 control points, 11 knots spanning 0..2, `IsClosed = IsPeriodic = true`:

```
CTRLBOX     (4021467.1, -9264141.7) .. (4021541.2, -9264045.6)
SAMPLED     256 points, zeros=1, at index [0]
BOX         (0, -9264141.7) .. (4021541.2, 0)
```

A spline about 59 by 74 units across reports a box four million by nine million, because one sample came back as `(0,0,0)` and `BoundingBox.FromPoints` honoured it. It lives inside a block, so every reference to that block inherited the box, and the drawing's extents with it.

After the fix, `zeros=0` and the box is the spline's own `(4021482.2, -9264138.8) .. (4021541.2, -9264067.2)`.

### The fix

Ask about periodic first. The knot vector decides the domain; the closed flag does not override it.

### Tests

New `GetBoundingBoxOfAPeriodicSplineStaysOnTheCurve` builds a periodic spline away from the origin and asserts the box stays within the convex hull of the control points — a property every B-spline has, and one the previous behaviour violated. It fails against the current implementation.

`dotnet test` on this branch: 2314 passed / 17 failed. `master` at 592d70a7 on this machine is 2313 passed / 17 failed — the same failures (SingleMLeader, GeoData, InsertWithSpatialFilter), plus the one test this PR adds.

### Related

Found while reconciling computed extents with the extents AutoCAD reports for eighteen architectural drawings, alongside #1223 and #1224.