### PR TITLE
Fix an insert's bounding box to respect its XCLIP boundary

### DIFF
--- a/src/ACadSharp.Tests/Entities/InsertTest.cs
+++ b/src/ACadSharp.Tests/Entities/InsertTest.cs
@@ -1,4 +1,5 @@
 ﻿using ACadSharp.Entities;
+using ACadSharp.Objects;
 using ACadSharp.Extensions;
 using ACadSharp.Tables;
 using ACadSharp.Tests.Common;
@@ -136,6 +137,33 @@ public class InsertTest
 
 		Assert.Equal(XYZ.Zero, box.Min);
 		Assert.Equal(new XYZ(20, 10, 0), box.Max);
+	}
+
+	[Fact]
+	public void GetBoundingBoxIsClippedByTheSpatialFilter()
+	{
+		//An XCLIP takes everything outside the boundary out of the drawing, and AutoCAD measures its
+		//extents from what survives, so the box has to be the intersection and not the whole block.
+		BlockRecord record = new BlockRecord(this._blockName);
+		record.Entities.Add(new Line(XYZ.Zero, new XYZ(100, 100, 0)));
+
+		Insert insert = new Insert(record);
+
+		SpatialFilter filter = new SpatialFilter(SpatialFilter.SpatialFilterEntryName);
+		filter.BoundaryPoints.Add(new XY(20, 20));
+		filter.BoundaryPoints.Add(new XY(60, 60));
+
+		//Both formats record this matrix with the translation in the fourth column, which is the
+		//transpose of the layout Matrix4's own operators read. Building it the same way here keeps
+		//the test honest about what a file actually holds.
+		filter.InverseInsertTransform = Matrix4.CreateTranslation(new XYZ(-5, -5, 0)).Transpose();
+
+		insert.SpatialFilter = filter;
+
+		BoundingBox box = insert.GetBoundingBox();
+
+		Assert.Equal(new XYZ(15, 15, 0), box.Min);
+		Assert.Equal(new XYZ(55, 55, 0), box.Max);
 	}
 
 	[Fact]

--- a/src/ACadSharp/Entities/Insert.cs
+++ b/src/ACadSharp/Entities/Insert.cs
@@ -364,6 +364,33 @@ public class Insert : Entity, IOrientable
 	{
 		BoundingBox box = this.Block.GetBoundingBox();
 
+		//An XCLIP boundary takes everything outside it out of the drawing, and AutoCAD's own extents
+		//are measured from what survives - so a box that ignores the clip claims the insert covers
+		//ground the drawing does not. The boundary is recorded in the space it was defined in;
+		//InverseInsertTransform brings it back into the block's own, which is where it can meet the
+		//block's box. An empty intersection is left alone rather than trusted.
+		SpatialFilter filter = this.SpatialFilter;
+		if (filter != null && filter.BoundaryPoints.Count > 1)
+		{
+			//Both DWG and DXF record this matrix as three rows of four with the translation in the
+			//fourth column, and the readers store it exactly so. Matrix4 multiplies a point with the
+			//translation read from the fourth ROW, so the stored matrix has to be transposed before
+			//it means anything - applied as it stands it silently drops the translation, which is
+			//the whole of what this particular matrix carries.
+			Matrix4 toBlock = filter.InverseInsertTransform.Transpose();
+
+			BoundingBox clip = BoundingBox.FromPoints(
+				filter.BoundaryPoints.Select(p => toBlock * new XYZ(p.X, p.Y, 0)));
+
+			XYZ clipMin = new XYZ(Math.Max(box.Min.X, clip.Min.X), Math.Max(box.Min.Y, clip.Min.Y), box.Min.Z);
+			XYZ clipMax = new XYZ(Math.Min(box.Max.X, clip.Max.X), Math.Min(box.Max.Y, clip.Max.Y), box.Max.Z);
+
+			if (clipMin.X <= clipMax.X && clipMin.Y <= clipMax.Y)
+			{
+				box = new BoundingBox(clipMin, clipMax);
+			}
+		}
+
 		var t = this.GetTransform();
 
 		var min = t.ApplyTransform(box.Min);


### PR DESCRIPTION
### The problem

A clipped block reference shows only what falls inside its `SPATIAL_FILTER` boundary, and AutoCAD measures the drawing's extents from what survives the clip. `Insert.GetBoundingBox()` returned the whole block, so a clipped insert claimed ground the drawing does not occupy.

Measured on a drawing where the block `he cot chuan` is xclipped:

```
insert box (before)  (4412478.9, -5391945.3) .. (4441002.3, -5379854.4)
insert box (after)   (4438300.9, -5385917.1) .. (4441002.3, -5379854.4)
AutoCAD's EXTMIN/MAX (4436170,   -5392340)   .. (4477960,   -5362940)
```

The unclipped box reached about 23,700 units past AutoCAD's own extents, in a drawing only 42,000 units across.

### The fix

Intersect the clip boundary with the block's box before the insert transform is applied. An empty intersection is left alone rather than trusted.

### One thing worth flagging separately

`InverseInsertTransform` cannot be used as it is stored.

Both DWG and DXF record it as three rows of four with the translation in the fourth column, and `read4x3Matrix` / the DXF reader store it exactly that way. `Matrix4`'s own multiplication reads the translation from the fourth **row** — `GetRows()` returns the columns of the `Mrc` grid, and `Matrix4.CreateTranslation` writes `M30/M31/M32`.

So `matrix * point` silently drops the translation, which for a clip boundary is the whole of what the matrix carries. In the drawing above it is a pure translation of `(-730293.09, +197002.18, 0)`, and ignoring it left the boundary a million units from the block, producing an empty intersection and no clip at all.

This PR transposes at the point of use and says why in a comment. Normalising the two matrices at read and write time would be tidier, but it changes a persisted convention in four places (DWG reader and writer, DXF reader and writer) and a per-format round-trip test would not catch a mismatch introduced between the two formats — so it seemed better raised than bundled in here. Nothing else in the library consumes either matrix, which is presumably why this has gone unnoticed.

### Tests

New `GetBoundingBoxIsClippedByTheSpatialFilter` clips a 100x100 block to a 20..60 boundary and gives the filter a translation stored the way a file stores it, so the transpose is exercised rather than assumed. It fails against the current implementation.

`dotnet test` on this branch: 2314 passed / 17 failed, against 2313 / 17 for `master` at 592d70a7 on this machine — the same pre-existing failures plus the one test this PR adds.

### Related

#1223, #1224, #1225. With all of them plus DomCR/CSUtilities#23, the computed extents of all eighteen drawings in the sample now agree with AutoCAD's, once entities on frozen layers are excluded as AutoCAD excludes them.