### PR TITLE
Fix an insert's transform (base point) and its bounding box (two corners, null block)

### DIFF
--- a/src/ACadSharp.Tests/Entities/InsertTest.cs
+++ b/src/ACadSharp.Tests/Entities/InsertTest.cs
@@ -139,6 +139,67 @@ public class InsertTest
 	}
 
 	[Fact]
+	public void TheTransformCarriesTheBasePointOntoTheInsertPoint()
+	{
+		//Whatever a block's base point is, that is the spot that lands on the insertion point.
+		//Folding the base into the outer translation instead gives (insert - base) + R*S*p, which
+		//is off by (R*S - I)*base - invisible at unit scale, wrong as soon as the insert is scaled.
+		BlockRecord record = new BlockRecord(this._blockName);
+		record.BlockEntity.BasePoint = new XYZ(100, 0, 0);
+
+		Insert insert = new Insert(record)
+		{
+			InsertPoint = XYZ.Zero,
+			XScale = 2,
+			YScale = 2,
+			ZScale = 2,
+		};
+
+		XYZ mapped = insert.GetTransform().ApplyTransform(new XYZ(100, 0, 0));
+
+		Assert.Equal(XYZ.Zero, mapped);
+	}
+
+	[Fact]
+	public void GetBoundingBoxTransformsEveryCornerNotJustTwo()
+	{
+		//Rotation mixes the axes, so the images of two opposite corners no longer span the
+		//transformed box. At 45 degrees the pair collapses onto a diagonal and the box comes back
+		//with no width at all.
+		BlockRecord record = new BlockRecord(this._blockName);
+		record.Entities.Add(new Line(new XYZ(0, 0, 0), new XYZ(1, 0, 0)));
+		record.Entities.Add(new Line(new XYZ(0, 1, 0), new XYZ(1, 1, 0)));
+
+		Insert insert = new Insert(record)
+		{
+			InsertPoint = XYZ.Zero,
+			Rotation = Math.PI / 4,
+		};
+
+		BoundingBox box = insert.GetBoundingBox();
+
+		double h = Math.Sqrt(2) / 2;
+
+		Assert.Equal(-h, box.Min.X, 9);
+		Assert.Equal(h, box.Max.X, 9);
+		Assert.Equal(0, box.Min.Y, 9);
+		Assert.Equal(Math.Sqrt(2), box.Max.Y, 9);
+	}
+
+	[Fact]
+	public void GetBoundingBoxSurvivesABlockTheReaderCouldNotResolve()
+	{
+		//The reader warns and leaves Block null rather than refuse a file that names a block it
+		//cannot find, so measuring such an insert must not throw either.
+		Insert insert = new Insert { InsertPoint = new XYZ(5, 6, 7) };
+
+		BoundingBox box = insert.GetBoundingBox();
+
+		Assert.Equal(new XYZ(5, 6, 7), box.Min);
+		Assert.Equal(new XYZ(5, 6, 7), box.Max);
+	}
+
+	[Fact]
 	public void GetBoundingBoxTest()
 	{
 		var l = new Line(XYZ.Zero, new XYZ(10, 10, 0));

--- a/src/ACadSharp/Entities/Insert.cs
+++ b/src/ACadSharp/Entities/Insert.cs
@@ -362,14 +362,37 @@ public class Insert : Entity, IOrientable
 	/// <inheritdoc/>
 	public override BoundingBox GetBoundingBox()
 	{
+		//A file can name a block the reader failed to resolve; CadInsertTemplate warns and leaves
+		//Block null rather than refuse the file, so this has to survive the same way.
+		if (this.Block == null)
+		{
+			return new BoundingBox(this.InsertPoint);
+		}
+
 		BoundingBox box = this.Block.GetBoundingBox();
+
+		if (box.Extent == BoundingBoxExtent.Null)
+		{
+			return box;
+		}
 
 		var t = this.GetTransform();
 
-		var min = t.ApplyTransform(box.Min);
-		var max = t.ApplyTransform(box.Max);
-
-		return new BoundingBox(min, max);
+		//Rotation, and any normal other than +Z, mix the axes - so the images of two opposite
+		//corners no longer span the transformed box. At 45 degrees they collapse onto a diagonal
+		//and the box is reported with zero width. All eight corners have to travel; the extremes
+		//are taken afterwards.
+		return BoundingBox.FromPoints(new[]
+		{
+			t.ApplyTransform(new XYZ(box.Min.X, box.Min.Y, box.Min.Z)),
+			t.ApplyTransform(new XYZ(box.Max.X, box.Min.Y, box.Min.Z)),
+			t.ApplyTransform(new XYZ(box.Min.X, box.Max.Y, box.Min.Z)),
+			t.ApplyTransform(new XYZ(box.Max.X, box.Max.Y, box.Min.Z)),
+			t.ApplyTransform(new XYZ(box.Min.X, box.Min.Y, box.Max.Z)),
+			t.ApplyTransform(new XYZ(box.Max.X, box.Min.Y, box.Max.Z)),
+			t.ApplyTransform(new XYZ(box.Min.X, box.Max.Y, box.Max.Z)),
+			t.ApplyTransform(new XYZ(box.Max.X, box.Max.Y, box.Max.Z)),
+		});
 	}
 
 	/// <summary>
@@ -381,11 +404,18 @@ public class Insert : Entity, IOrientable
 	{
 		var world = Matrix4.GetArbitraryAxis(this.Normal);
 		XYZ basePoint = this.Block?.BlockEntity?.BasePoint ?? XYZ.Zero;
-		var translation = Transform.CreateTranslation(this.InsertPoint - basePoint);
+		var translation = Transform.CreateTranslation(this.InsertPoint);
 		var rotation = Transform.CreateRotation(XYZ.AxisZ, this.Rotation);
 		var scale = Transform.CreateScaling(new XYZ(this.XScale, this.YScale, this.ZScale));
 
-		return new Transform(world * translation.Matrix * rotation.Matrix * scale.Matrix);
+		//The base point is expressed in block space, so it has to come off BEFORE rotation and
+		//scale act on the point: p = insert + R*S*(p - base). Folding it into the outer
+		//translation instead computes (insert - base) + R*S*p, which differs by (R*S - I)*base -
+		//zero for a base point at the origin or an insert with no rotation and unit scale, which
+		//is why it survives most drawings, and wrong for every other one.
+		var toOrigin = Transform.CreateTranslation(-basePoint);
+
+		return new Transform(world * translation.Matrix * rotation.Matrix * scale.Matrix * toOrigin.Matrix);
 	}
 
 	/// <inheritdoc/>


### PR DESCRIPTION
Three faults in how a block reference is placed and measured. They are in one PR because they are all in `Insert` and the second is only visible once you trust the first.

### 1. The base point comes off at the wrong time

`GetTransform()` builds `world * T(insert - base) * R * S`, which applied to a block-space point gives

```
    ACadSharp:  (insert - base) + R*S*p
    AutoCAD:     insert + R*S*(p - base)
    difference:  (R*S - I) * base
```

So the two agree only when the base point is a fixed point of `R*S` — in practice, when the base is the origin, or the insert has no rotation and unit scale. That covers most inserts, which is why it survives.

The invariant it breaks is simple: **whatever a block's base point is, that spot must land on the insertion point.** With base `(100,0,0)`, insert at the origin and uniform scale 2, the base point currently lands at `(100,0,0)` instead of `(0,0,0)`.

### 2. Only two corners of the box were transformed

```csharp
var min = t.ApplyTransform(box.Min);
var max = t.ApplyTransform(box.Max);
return new BoundingBox(min, max);
```

Scale and translation act componentwise, so for an unrotated insert with a `+Z` normal this is exact — mirroring included, since `BoundingBox(min, max)` normalises. But rotation and an arbitrary normal mix the axes, and then the images of two opposite corners no longer span the transformed box. The result is always a **subset** of the truth: at 45° the pair collapses onto a diagonal and the box is reported with zero width.

Worth stating plainly for anyone checking this against drawing extents: because the error is an under-estimate, an extents measurement that agreed before this fix was **hiding** it, not contradicting it.

### 3. A null `Block` threw

`CadInsertTemplate` deliberately emits a warning and leaves `Insert.Block` null when a file names a block it cannot resolve, rather than refusing the file. `GetBoundingBox` then dereferenced it.

### Evidence

Measured across eighteen architectural drawings: **28 inserts** carry a non-zero base point together with a scale or rotation, worst discrepancy **77.7 drawing units** — small enough that the drawings' computed extents still matched AutoCAD's exactly. That is why this one needed the algebra rather than another measurement.

### Tests

Three new tests in `InsertTest`, each failing against the current code:
- the base point lands on the insertion point under scale
- a 45°-rotated block reports a box of the right width (currently zero)
- an insert whose block did not resolve reports its own point instead of throwing

`dotnet test`: 2316 passed / 17 failed, against `master` at 592d70a7 on this machine at 2313 / 17 — the same pre-existing failures (SingleMLeader, GeoData, InsertWithSpatialFilter) plus the three tests added here.

### Related

#1223, #1224, #1225, #1226 and DomCR/CSUtilities#23 — same family, same measurement.