### PR TITLE
Fix OCS bounding boxes for TEXT, SOLID and HATCH (and pin ELLIPSE as WCS)

### DIFF
--- a/src/ACadSharp.Tests/Entities/EllipseTests.cs
+++ b/src/ACadSharp.Tests/Entities/EllipseTests.cs
@@ -22,6 +22,26 @@ public class EllipseTests : CommonEntityTests<Ellipse>
 	}
 
 	[Fact]
+	public void MirroredEllipseCentreIsAlreadyInWorldCoordinates()
+	{
+		//An ellipse's centre and major axis are WCS in both DWG and DXF - unlike a circle's,
+		//which is OCS. A (0,0,-1) normal must NOT relocate it. This test exists to stop anyone
+		//"fixing" Ellipse the way Circle had to be fixed.
+		Ellipse ellipse = new Ellipse
+		{
+			Center = new XYZ(10, 0, 0),
+			MajorAxisEndPoint = new XYZ(5, 0, 0),
+			RadiusRatio = 0.5,
+			Normal = new XYZ(0, 0, -1),
+		};
+
+		BoundingBox box = ellipse.GetBoundingBox();
+
+		Assert.Equal(5.0, box.Min.X, 6);
+		Assert.Equal(15.0, box.Max.X, 6);
+	}
+
+	[Fact]
 	public void GetEndVerticesTest()
 	{
 		Ellipse ellipse = new Ellipse();

--- a/src/ACadSharp.Tests/Entities/HatchTests.cs
+++ b/src/ACadSharp.Tests/Entities/HatchTests.cs
@@ -10,7 +10,32 @@ namespace ACadSharp.Tests.Entities;
 
 public class HatchTests : CommonEntityTests<Hatch>
 {
-	[Fact]
+[Fact]
+	public void MirroredHatchIsBoxedThroughItsNormal()
+	{
+		//The boundary is flat in the hatch's own object coordinate system and the height of its
+		//plane is carried apart in Elevation, so the (0,0,-1) normal AutoCAD writes for mirrored
+		//geometry puts the boundary at the negated X - and the plane at the negated elevation.
+		Hatch hatch = new Hatch
+		{
+			Normal = new XYZ(0, 0, -1),
+			Elevation = 3.0,
+		};
+
+		Hatch.BoundaryPath path = new Hatch.BoundaryPath();
+		path.Edges.Add(new Hatch.BoundaryPath.Line { Start = new XY(9, 0), End = new XY(11, 4) });
+		hatch.Paths.Add(path);
+
+		BoundingBox box = hatch.GetBoundingBox();
+
+		Assert.Equal(-11.0, box.Min.X, 6);
+		Assert.Equal(-9.0, box.Max.X, 6);
+		Assert.Equal(0.0, box.Min.Y, 6);
+		Assert.Equal(4.0, box.Max.Y, 6);
+		Assert.Equal(-3.0, box.Min.Z, 6);
+	}
+
+		[Fact]
 	public void BoundaryPathToEntityTest()
 	{
 		var a = new Hatch.BoundaryPath.Arc

--- a/src/ACadSharp.Tests/Entities/SolidTests.cs
+++ b/src/ACadSharp.Tests/Entities/SolidTests.cs
@@ -1,0 +1,48 @@
+﻿using ACadSharp.Entities;
+using CSMath;
+using Xunit;
+
+namespace ACadSharp.Tests.Entities
+{
+	public class SolidTests : CommonEntityTests<Solid>
+	{
+		[Fact]
+		public override void GetBoundingBoxTest()
+		{
+			Solid solid = new Solid
+			{
+				FirstCorner = new XYZ(1, 1, 5),
+				SecondCorner = new XYZ(3, 1, 5),
+				ThirdCorner = new XYZ(1, 2, 5),
+				FourthCorner = new XYZ(3, 2, 5),
+			};
+
+			BoundingBox box = solid.GetBoundingBox();
+
+			Assert.Equal(new XYZ(1, 1, 5), box.Min);
+			Assert.Equal(new XYZ(3, 2, 5), box.Max);
+		}
+
+		[Fact]
+		public void MirroredSolidIsBoxedThroughItsNormal()
+		{
+			//The corners are in the solid's own object coordinate system, so a mirrored solid -
+			//the (0,0,-1) normal AutoCAD writes for one - draws at the negated X of the stored
+			//values, and at the negated Z.
+			Solid solid = new Solid
+			{
+				FirstCorner = new XYZ(1, 1, 5),
+				SecondCorner = new XYZ(3, 1, 5),
+				ThirdCorner = new XYZ(1, 2, 5),
+				FourthCorner = new XYZ(3, 2, 5),
+				Normal = new XYZ(0, 0, -1),
+			};
+
+			BoundingBox box = solid.GetBoundingBox();
+
+			Assert.Equal(-3.0, box.Min.X, 6);
+			Assert.Equal(-1.0, box.Max.X, 6);
+			Assert.Equal(-5.0, box.Max.Z, 6);
+		}
+	}
+}

--- a/src/ACadSharp.Tests/Entities/TextTests.cs
+++ b/src/ACadSharp.Tests/Entities/TextTests.cs
@@ -17,6 +17,22 @@ public class TextTests : CommonEntityTests<TextEntity>
 	}
 
 	[Fact]
+	public void MirroredTextIsBoxedThroughItsNormal()
+	{
+		//The insertion point is stored in the text's own object coordinate system, so the
+		//(0,0,-1) normal AutoCAD writes for mirrored text puts it at the negated X.
+		TextEntity text = new TextEntity
+		{
+			InsertPoint = new XYZ(10, 5, 2),
+			Normal = new XYZ(0, 0, -1),
+		};
+
+		BoundingBox box = text.GetBoundingBox();
+
+		AssertUtils.AreEqual(new XYZ(-10, 5, -2), box.Min);
+	}
+
+	[Fact]
 	public void TranslationTest()
 	{
 		XYZ newLocation = this._random.NextXYZ();

--- a/src/ACadSharp/Entities/Hatch.cs
+++ b/src/ACadSharp/Entities/Hatch.cs
@@ -336,11 +336,39 @@ public partial class Hatch : Entity, IOrientable
 	/// <inheritdoc/>
 	public override BoundingBox GetBoundingBox()
 	{
+		//The boundary is recorded flat in the hatch's own object coordinate system, with the height
+		//of its plane carried apart in Elevation. Only the arbitrary-axis mapping puts it in the
+		//world, and for the (0,0,-1) normal AutoCAD writes for mirrored geometry that flips the
+		//sign of X - enough to box a hatch on the far side of the drawing from where it draws.
+		Matrix4 toWorld = Matrix4.GetArbitraryAxis(this.Normal);
+
 		BoundingBox box = BoundingBox.Null;
 
 		foreach (BoundaryPath bp in this.Paths)
 		{
-			box = box.Merge(bp.GetBoundingBox());
+			foreach (BoundaryPath.Edge edge in bp.Edges)
+			{
+				BoundingBox eb = edge.GetBoundingBox();
+				if (eb.Extent == BoundingBoxExtent.Null)
+				{
+					continue;
+				}
+
+				box = box.Merge(BoundingBox.FromPoints(new[]
+				{
+					toWorld * new XYZ(eb.Min.X, eb.Min.Y, this.Elevation),
+					toWorld * new XYZ(eb.Max.X, eb.Min.Y, this.Elevation),
+					toWorld * new XYZ(eb.Min.X, eb.Max.Y, this.Elevation),
+					toWorld * new XYZ(eb.Max.X, eb.Max.Y, this.Elevation)
+				}));
+			}
+
+			//A derived boundary holds whole entities, each carrying its own extrusion, so those are
+			//already in world coordinates and must not be mapped a second time.
+			foreach (Entity entity in bp.Entities)
+			{
+				box = box.Merge(entity.GetBoundingBox());
+			}
 		}
 
 		return box;

--- a/src/ACadSharp/Entities/Solid.cs
+++ b/src/ACadSharp/Entities/Solid.cs
@@ -109,6 +109,16 @@ public class Solid : Entity, IOrientable
 	/// <inheritdoc/>
 	public override BoundingBox GetBoundingBox()
 	{
-		return BoundingBox.FromPoints(new[] { this.FirstCorner, this.SecondCorner, this.ThirdCorner, this.FourthCorner });
+		//The corners are in the solid's own object coordinate system; without the arbitrary-axis
+		//mapping a mirrored solid - normal (0,0,-1) - is boxed at the negated X of where it draws.
+		Matrix4 toWorld = Matrix4.GetArbitraryAxis(this.Normal);
+
+		return BoundingBox.FromPoints(new[]
+		{
+			toWorld * this.FirstCorner,
+			toWorld * this.SecondCorner,
+			toWorld * this.ThirdCorner,
+			toWorld * this.FourthCorner
+		});
 	}
 }

--- a/src/ACadSharp/Entities/TextEntity.cs
+++ b/src/ACadSharp/Entities/TextEntity.cs
@@ -288,7 +288,10 @@ public class TextEntity : Entity, IText
 	/// <inheritdoc/>
 	public override BoundingBox GetBoundingBox()
 	{
-		return new BoundingBox(this.InsertPoint);
+		//The insertion point is in the text's own object coordinate system - the DWG stream carries
+		//it as a 2D point plus an elevation about the extrusion - so a mirrored text, which AutoCAD
+		//records with a (0,0,-1) normal, sits at the negated X of the stored value.
+		return new BoundingBox(Matrix4.GetArbitraryAxis(this.Normal) * this.InsertPoint);
 	}
 
 	internal override void AssignDocument(CadDocument doc)


### PR DESCRIPTION
The same fault as #1224, in three more places — and a test asserting that a fourth type must **not** be changed.

### The three

`TEXT`'s insertion point, `SOLID`'s four corners and a `HATCH`'s boundary are all recorded in the entity's own object coordinate system. Each `GetBoundingBox()` returned them untouched, so for the `(0,0,-1)` extrusion AutoCAD writes whenever geometry is mirrored, all three were boxed at the negated X of where they draw.

The hatch also ignored `Elevation` entirely, boxing a boundary that sits on a plane at Z as though it sat at zero.

A hatch's *derived* boundary (`BoundaryPath.Entities`) holds whole entities, each carrying its own extrusion, so those are left on their own path rather than mapped a second time.

### The one that must stay as it is

**ELLIPSE is deliberately not changed**, and this PR adds a test saying so.

Unlike a circle's, an ellipse's centre and major-axis endpoint are WCS in both DWG and DXF — this repo's own reader says so (`//Center 3BD 10 (WCS)`, `//SM axis vec 3BD 11 ... (WCS)` in `DwgObjectReader.readEllipse`, against a bare `//Center 3BD 10` for circle and arc). And `CurveExtensions` has two `PolygonalVertexes` overloads: the radius one (circle/arc) applies the arbitrary-axis matrix to `center + offset`, while the ellipse one — the one taking a major-axis point and a ratio — is pure WCS vector maths and never builds the matrix at all.

So an ellipse is already right, and "fixing" it the way `Circle` had to be fixed would break it. The corpus this came from has **666 mirrored ellipses** currently in the correct place. `MirroredEllipseCentreIsAlreadyInWorldCoordinates` exists to stop that.

### What I could not settle

The **sign of `Elevation` under a flipped normal**. The fix maps `(x, y, Elevation)` through the arbitrary axis, which is the consistent reading, but I have no AutoCAD measurement pinning it: the eighteen drawings I have contain no mirrored hatch that also carries a non-zero elevation. For the overwhelmingly common `+Z` case the mapping is the identity and using `Elevation` instead of zero is unambiguously an improvement. Flagging it rather than quietly asserting it.

### Tests

New, each failing against the current code: `MirroredTextIsBoxedThroughItsNormal`, `MirroredSolidIsBoxedThroughItsNormal`, `MirroredHatchIsBoxedThroughItsNormal`. `SolidTests` is new and also fills in the `GetBoundingBoxTest` the common base requires. Plus the ellipse guard described above, which passes both before and after — that is its point.

`dotnet test`: 2329 passed / 17 failed, against `master` at 592d70a7 on this machine at 2313 / 17 — the same pre-existing failures, plus the tests added here and the inherited ones the new `SolidTests` class brings with it.

### Related

#1223, #1224, #1225, #1226, #1227 and DomCR/CSUtilities#23.