### PR TITLE
Fix a bulge over a zero-length segment discarding the whole polyline

### DIFF
--- a/src/ACadSharp.Tests/Entities/LwPolylineTest.cs
+++ b/src/ACadSharp.Tests/Entities/LwPolylineTest.cs
@@ -115,6 +115,26 @@ public class LwPolylineTests : CommonEntityTests<LwPolyline>
 		}
 	}
 
+	[Fact]
+	public void ABulgeOverAZeroLengthSegmentDoesNotThrow()
+	{
+		//A repeated vertex that still carries a bulge is an arc over a chord of no length.
+		//There is no radius to recover, and Arc refuses the zero its own maths produces - so
+		//one such vertex, which real exports are full of, used to discard the whole polyline.
+		LwPolyline lwPolyline = new LwPolyline();
+		lwPolyline.Vertices.Add(new LwPolyline.Vertex(new XY(0, 0)));
+		lwPolyline.Vertices.Add(new LwPolyline.Vertex(new XY(10, 0)) { Bulge = 0.5 });
+		lwPolyline.Vertices.Add(new LwPolyline.Vertex(new XY(10, 0)));
+		lwPolyline.Vertices.Add(new LwPolyline.Vertex(new XY(10, 8)));
+
+		BoundingBox box = lwPolyline.GetBoundingBox();
+
+		Assert.Equal(0.0, box.Min.X, 6);
+		Assert.Equal(0.0, box.Min.Y, 6);
+		Assert.Equal(10.0, box.Max.X, 6);
+		Assert.Equal(8.0, box.Max.Y, 6);
+	}
+
 	public override void GetBoundingBoxTest()
 	{
 	}

--- a/src/ACadSharp/Extensions/PolylineExtensions.cs
+++ b/src/ACadSharp/Extensions/PolylineExtensions.cs
@@ -128,6 +128,22 @@ namespace ACadSharp.Extensions
 					XY p1 = curr.Location.Convert<XY>();
 					XY p2 = next.Location.Convert<XY>();
 
+					//A repeated vertex that still carries a bulge describes an arc over a chord of
+					//zero length: there is no radius to recover, and Arc refuses the zero its own
+					//maths produces. The segment covers no ground, so it contributes its endpoints
+					//and nothing else - throwing here would discard the whole polyline over one
+					//degenerate vertex, and real exports are full of them.
+					if (p1.Equals(p2))
+					{
+						if (i == 0)
+						{
+							points.Add(curr.Location.Convert<T>());
+						}
+
+						points.Add(next.Location.Convert<T>());
+						continue;
+					}
+
 					IEnumerable<T> lst = Arc.CreateFromBulge(p1, p2, curr.Bulge)
 						.PolygonalVertexes(precision)
 						.Select(p => p.Convert<T>());


### PR DESCRIPTION
### The problem

When any vertex carries a bulge, a polyline's bounding box is computed by tessellating each segment through `Arc.CreateFromBulge`.

A repeated vertex that still carries a bulge describes an arc over a chord of no length. `Arc.GetCenter` computes `c = start.DistanceFrom(end) / 2.0` — zero — so `radius = c / sin(theta/2)` is exactly zero, and `Circle`'s `Radius` setter throws:

```csharp
if (value <= 0)
	throw new ArgumentOutOfRangeException(nameof(value), value, "The radius must be greater than 0.");
```

One such vertex therefore threw away the measurement of the **entire** polyline — and, because polylines live inside blocks, of every insert of that block.

Duplicated vertices are common in real exports.

### The fix

Such a segment covers no ground, so it contributes its endpoints and nothing else.

### Evidence

Across eighteen architectural drawings: two zero-length bulged segments, one of them throwing. After this, **no entity in the corpus fails to report a box**. The only remaining non-measurable entities are `Region`s, which return `BoundingBox.Null` by design because modeler geometry is not tessellated — that is not a defect and is left alone.

### Adjacent, not fixed here

Three more paths can throw out of `GetBoundingBox` for the same reason — a raw value the readers store faithfully and an entity setter refuses:

- `Hatch.BoundaryPath.Arc.GetBoundingBox` builds an `Arc` entity, so an edge with radius ≤ 0 throws. (The *entity* reader already clamps this — `DwgObjectReader` maps `radius <= 0` to `MathHelper.Epsilon` — but the boundary-edge reader does not.)
- `Hatch.BoundaryPath.Ellipse.GetBoundingBox` builds an `Ellipse`, so an edge ratio of 0 or above 1 throws.
- `BlockRecord.GetBoundingBox` evaluates every child's box twice, once for the infinite check and once for the merge — quadratic through nested blocks.

None of the three occurs in my corpus (measured: 0, 0, and the double evaluation is a cost not a fault), so I have left them out rather than ship unexercised code. Raising them in case they are worth a separate look.

### Tests

`ABulgeOverAZeroLengthSegmentDoesNotThrow` fails against the current code with `ArgumentOutOfRangeException`.

`dotnet test`: 2314 passed / 17 failed, against `master` at 592d70a7 on this machine at 2313 / 17.

### Related

#1223, #1224, #1225, #1226, #1227 and DomCR/CSUtilities#23.