### PR TITLE
Fix SPATIAL_FILTER transforms: lost on DXF read, transposed between the two formats

### DIFF
--- a/src/ACadSharp.Tests/IO/SpatialFilterRoundTripTests.cs
+++ b/src/ACadSharp.Tests/IO/SpatialFilterRoundTripTests.cs
@@ -1,0 +1,125 @@
+namespace ACadSharp.Tests.IO;
+
+using ACadSharp.Entities;
+using ACadSharp.IO;
+using ACadSharp.Objects;
+using ACadSharp.Tables;
+using CSMath;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+/// <summary>
+/// An XCLIP boundary is a SPATIAL_FILTER, and it carries two matrices that say where the boundary
+/// sits. Both formats record them as three rows of four with the translation in the fourth column,
+/// which is the transpose of the layout Matrix4 itself uses - so every reader and writer has to
+/// turn them, and for a long time not all four did.
+///
+/// The existing single-object round trip could not see any of this: its fixture built the filter
+/// with identity matrices, and an identity survives being transposed, dropped or doubled. These
+/// tests use a matrix with a scale AND a translation, which nothing but a correct pairing returns
+/// unchanged.
+/// </summary>
+public class SpatialFilterRoundTripTests
+{
+	[Fact]
+	public void TheClipTransformSurvivesDxf()
+	{
+		CadDocument doc = this.docWithFilter(out Matrix4 inverse, out Matrix4 forward);
+
+		SpatialFilter back = this.filterOf(this.roundTripDxf(doc));
+
+		AssertMatrix(inverse, back.InverseInsertTransform);
+		AssertMatrix(forward, back.InsertTransform);
+	}
+
+	[Fact]
+	public void TheClipTransformSurvivesDwg()
+	{
+		CadDocument doc = this.docWithFilter(out Matrix4 inverse, out Matrix4 forward);
+
+		SpatialFilter back = this.filterOf(this.roundTripDwg(doc));
+
+		AssertMatrix(inverse, back.InverseInsertTransform);
+		AssertMatrix(forward, back.InsertTransform);
+	}
+
+	[Fact]
+	public void TheTwoFormatsAgreeWithEachOther()
+	{
+		//The one a per-format round trip cannot catch: each format can be self-consistent and still
+		//disagree with the other, and then a drawing read from a DWG and the same drawing read back
+		//out of our own DXF put the clip in different places.
+		CadDocument doc = this.docWithFilter(out _, out _);
+
+		SpatialFilter viaDxf = this.filterOf(this.roundTripDxf(doc));
+		SpatialFilter viaDwg = this.filterOf(this.roundTripDwg(doc));
+
+		AssertMatrix(viaDwg.InverseInsertTransform, viaDxf.InverseInsertTransform);
+		AssertMatrix(viaDwg.InsertTransform, viaDxf.InsertTransform);
+	}
+
+	private static void AssertMatrix(Matrix4 expected, Matrix4 actual)
+	{
+		for (int row = 0; row < 4; row++)
+		{
+			for (int col = 0; col < 4; col++)
+			{
+				Assert.Equal(expected[row, col], actual[row, col], 6);
+			}
+		}
+	}
+
+	private CadDocument docWithFilter(out Matrix4 inverse, out Matrix4 forward)
+	{
+		//A scale and a translation together: a pure scale survives a transpose, and so does an
+		//identity, so neither would prove anything.
+		inverse = Matrix4.CreateTranslation(new XYZ(-1087.9487, 942.61675, 0))
+			* Matrix4.CreateScale(new XYZ(25.4, 25.4, 25.4));
+		forward = Matrix4.CreateTranslation(new XYZ(3, -5, 7));
+
+		CadDocument doc = new CadDocument();
+		BlockRecord block = new BlockRecord("clipped_block");
+		block.Entities.Add(new Circle { Radius = 20 });
+		doc.BlockRecords.Add(block);
+
+		Insert insert = new Insert(block);
+		SpatialFilter filter = new SpatialFilter(SpatialFilter.SpatialFilterEntryName);
+		filter.BoundaryPoints.Add(new XY(5, 5));
+		filter.BoundaryPoints.Add(new XY(30, 30));
+		filter.InverseInsertTransform = inverse;
+		filter.InsertTransform = forward;
+		insert.SpatialFilter = filter;
+
+		doc.Entities.Add(insert);
+		return doc;
+	}
+
+	private SpatialFilter filterOf(CadDocument doc)
+	{
+		Insert insert = doc.Entities.OfType<Insert>().Single(i => i.SpatialFilter != null);
+		return insert.SpatialFilter;
+	}
+
+	private CadDocument roundTripDxf(CadDocument doc)
+	{
+		using MemoryStream stream = new();
+		using (DxfWriter writer = new(stream, doc, false))
+		{
+			writer.Write();
+		}
+
+		return DxfReader.Read(new MemoryStream(stream.ToArray()));
+	}
+
+	private CadDocument roundTripDwg(CadDocument doc)
+	{
+		using MemoryStream stream = new();
+		using (DwgWriter writer = new(stream, doc))
+		{
+			writer.Write();
+		}
+
+		return DwgReader.Read(new MemoryStream(stream.ToArray()));
+	}
+}

--- a/src/ACadSharp.Tests/IO/WriterSingleObjectTests.cs
+++ b/src/ACadSharp.Tests/IO/WriterSingleObjectTests.cs
@@ -1331,6 +1331,14 @@ public abstract class WriterSingleObjectTests : IOTestsBase
 			filter.BoundaryPoints.Add(new XY(50, 50));
 			filter.DisplayBoundary = true;
 
+			//Not identity, deliberately. Both formats record these two matrices transposed with
+			//respect to how the library holds them, and an identity survives being transposed - so
+			//a fixture built from identities cannot tell a correct writer from one that drops the
+			//translation entirely, which is what this case used to do.
+			filter.InverseInsertTransform = Matrix4.CreateTranslation(new XYZ(-7, 11, 3))
+				* Matrix4.CreateScale(new XYZ(25.4, 25.4, 25.4));
+			filter.InsertTransform = Matrix4.CreateTranslation(new XYZ(2, -4, 6));
+
 			insert.SpatialFilter = filter;
 
 			this.Document.Entities.Add(insert);

--- a/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamReaders/DwgObjectReader.cs
@@ -5815,7 +5815,7 @@ namespace ACadSharp.IO.DWG
 			{
 				for (int j = 0; j < 4; j++)
 				{
-					identity[i, j] = this._mergedReaders.ReadBitDouble();
+					identity[j, i] = this._mergedReaders.ReadBitDouble();
 				}
 			}
 			return identity;

--- a/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
+++ b/src/ACadSharp/IO/DWG/DwgStreamWriters/DwgObjectWriter.Objects.cs
@@ -65,7 +65,7 @@ internal partial class DwgObjectWriter : DwgSectionIO
 		{
 			for (int j = 0; j < 4; j++)
 			{
-				this._writer.WriteBitDouble(matrix[i, j]);
+				this._writer.WriteBitDouble(matrix[j, i]);
 			}
 		}
 	}

--- a/src/ACadSharp/IO/DXF/DxfStreamReader/DxfObjectsSectionReader.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamReader/DxfObjectsSectionReader.cs
@@ -2654,14 +2654,18 @@ internal class DxfObjectsSectionReader : DxfSectionReaderBase
 					}
 				}
 
+				//The writer emits the inverse first and the transform second, and this flag is what
+				//tells the two apart. It was being set inside the branch that already required it to
+				//be true, so it never became true: both matrices went into InverseInsertTransform,
+				//the second overwriting the first, and InsertTransform was never assigned at all.
 				if (tmp.InsertTransformRead)
 				{
 					filter.InsertTransform = new Matrix4(array);
-					tmp.InsertTransformRead = true;
 				}
 				else
 				{
 					filter.InverseInsertTransform = new Matrix4(array);
+					tmp.InsertTransformRead = true;
 				}
 
 				return true;

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
@@ -1722,12 +1722,12 @@ internal class DxfObjectsSectionWriter : DxfSectionWriterBase
 
 		double[] array = new double[24]
 		{
-			filter.InverseInsertTransform.M00, filter.InverseInsertTransform.M01, filter.InverseInsertTransform.M02, filter.InverseInsertTransform.M03,
-			filter.InverseInsertTransform.M10, filter.InverseInsertTransform.M11, filter.InverseInsertTransform.M12, filter.InverseInsertTransform.M13,
-			filter.InverseInsertTransform.M20, filter.InverseInsertTransform.M21, filter.InverseInsertTransform.M22, filter.InverseInsertTransform.M23,
-			filter.InsertTransform.M00, filter.InsertTransform.M01, filter.InsertTransform.M02, filter.InsertTransform.M03,
-			filter.InsertTransform.M10, filter.InsertTransform.M11, filter.InsertTransform.M12, filter.InsertTransform.M13,
-			filter.InsertTransform.M20, filter.InsertTransform.M21, filter.InsertTransform.M22, filter.InsertTransform.M23
+			filter.InverseInsertTransform.M00, filter.InverseInsertTransform.M10, filter.InverseInsertTransform.M20, filter.InverseInsertTransform.M30,
+			filter.InverseInsertTransform.M01, filter.InverseInsertTransform.M11, filter.InverseInsertTransform.M21, filter.InverseInsertTransform.M31,
+			filter.InverseInsertTransform.M02, filter.InverseInsertTransform.M12, filter.InverseInsertTransform.M22, filter.InverseInsertTransform.M32,
+			filter.InsertTransform.M00, filter.InsertTransform.M10, filter.InsertTransform.M20, filter.InsertTransform.M30,
+			filter.InsertTransform.M01, filter.InsertTransform.M11, filter.InsertTransform.M21, filter.InsertTransform.M31,
+			filter.InsertTransform.M02, filter.InsertTransform.M12, filter.InsertTransform.M22, filter.InsertTransform.M32
 		};
 
 		for (int i = 0; i < array.Length; i++)


### PR DESCRIPTION
A `SPATIAL_FILTER` (an XCLIP boundary) carries two matrices that place the boundary. Four faults between the four ends that read and write them.

### 1. The DXF reader threw one away

```csharp
if (tmp.InsertTransformRead)
{
    filter.InsertTransform = new Matrix4(array);
    tmp.InsertTransformRead = true;      // already true here; no effect
}
else
{
    filter.InverseInsertTransform = new Matrix4(array);
    // never sets the flag
}
```

The flag starts `false` and is only assigned inside the branch that already requires it to be `true`. So both twelve-double blocks take the `else`: `InverseInsertTransform` is written twice, the second overwriting the first, and `InsertTransform` is never assigned at all.

### 2. The two formats disagreed about the layout

Both DWG and DXF record these as three rows of four with the translation in the **fourth column**. That is the transpose of how `Matrix4` holds one: `CreateTranslation` writes `M30/M31/M32`, and `operator *(Matrix4, XYZ)` reads the translation from there.

The DXF path already landed in the library's convention — `Matrix4(double[])` maps `elements[0..3]` to `M00, M10, M20, M30`, so the file's rows become the matrix's columns. The DWG reader and writer kept the file's layout instead.

The consequence is quiet and total: **the same matrix read from a DWG dropped its own translation when applied to a point**, while read from a DXF it did not. For a clip boundary, translation is most of what these matrices carry.

### The fix

`read4x3Matrix` and `write4x3Matrix` transpose, so the DWG path lands where the DXF path already was; and the DXF writer emits each file row from a matrix **column**, which is exactly what `Matrix4(double[])` undoes on the way back in. All four ends now agree, and `SpatialFilter.InverseInsertTransform` can be used with `Matrix4`'s own operators without the caller knowing any of this.

### Why nothing caught it

`SingleCaseGenerator.InsertWithSpatialFilter` builds its filter with **identity** matrices — and an identity survives being transposed, dropped, or applied twice. The fixture now carries a scale together with a translation.

That alone is still not enough: the single-object comparison does not reach these properties (I checked — with the fixture strengthened and the writer fix reverted, it still passed). So `SpatialFilterRoundTripTests` asserts them directly, including the one case a per-format round trip **structurally cannot see**: that DWG and DXF agree *with each other*. A format can be perfectly self-consistent and still disagree with the other.

All three new tests fail against the current code.

### Evidence

`samples/sample_AC1032.dwg` holds a clip whose inverse transform is a 25.4 scale with a translation of `(-1087.9487, 942.61675, 0)`. Through this library's own DXF it came back as the identity — so a clipped insert reported the whole block instead of the clipped part.

`dotnet test` on this branch: 2316 passed / 17 failed, against `master` at 592d70a7 on this machine at 2313 / 17 — the same pre-existing failures, plus the three tests added here.

### Related

Found while checking a fidelity gate that flagged a lost entity after #1226 made something finally consume these matrices. #1226 transposes at the point of use and explicitly leaves this normalisation as a separate question; this PR is that answer, and #1226 should drop its `.Transpose()` if both land.

Same family: #1223, #1224, #1225, #1226, #1227, #1228, #1229, DomCR/CSUtilities#23.