### PR TITLE
Fix hatch boundary bounding boxes: a weight is not a height, and a bulge is not either

### DIFF
--- a/src/ACadSharp.Tests/Entities/HatchSplineBoundingBoxTests.cs
+++ b/src/ACadSharp.Tests/Entities/HatchSplineBoundingBoxTests.cs
@@ -1,0 +1,65 @@
+namespace ACadSharp.Tests.Entities;
+
+using ACadSharp.Entities;
+using CSMath;
+using System.Linq;
+using Xunit;
+
+/// <summary>
+/// The control points of a hatch's spline boundary keep the WEIGHT in Z - the class says so on the
+/// property itself. Measuring a bounding box from them as if they were points gave the hatch a
+/// height made of weights, and every block and INSERT above it inherited that height.
+/// </summary>
+public class HatchSplineBoundingBoxTests
+{
+	[Fact]
+	public void AWeightIsNotAHeight()
+	{
+		Hatch.BoundaryPath.Spline edge = this.edge(weight: 1.0);
+
+		BoundingBox box = edge.GetBoundingBox();
+
+		Assert.Equal(0, box.Min.Z);
+		Assert.Equal(0, box.Max.Z);
+	}
+
+	[Theory]
+	[InlineData(1.0)]
+	[InlineData(0.5)]
+	[InlineData(7.25)]
+	public void TheBoxIsTheSameWhateverTheWeightsAre(double weight)
+	{
+		//The point of the fix: two hatches over the same outline occupy the same space, however
+		//their control points are weighted.
+		BoundingBox reference = this.edge(weight: 1.0).GetBoundingBox();
+
+		BoundingBox box = this.edge(weight).GetBoundingBox();
+
+		Assert.Equal(reference.Min, box.Min);
+		Assert.Equal(reference.Max, box.Max);
+	}
+
+	[Fact]
+	public void TheOutlineItselfStillMeasures()
+	{
+		Hatch.BoundaryPath.Spline edge = this.edge(weight: 1.0);
+
+		BoundingBox box = edge.GetBoundingBox();
+
+		Assert.Equal(0, box.Min.X);
+		Assert.Equal(0, box.Min.Y);
+		Assert.Equal(10, box.Max.X);
+		Assert.Equal(4, box.Max.Y);
+	}
+
+	private Hatch.BoundaryPath.Spline edge(double weight)
+	{
+		Hatch.BoundaryPath.Spline edge = new();
+		edge.Degree = 3;
+		edge.ControlPoints.Add(new XYZ(0, 0, weight));
+		edge.ControlPoints.Add(new XYZ(3, 4, weight));
+		edge.ControlPoints.Add(new XYZ(7, 1, weight));
+		edge.ControlPoints.Add(new XYZ(10, 2, weight));
+		return edge;
+	}
+}

--- a/src/ACadSharp.Tests/Entities/HatchTests.cs
+++ b/src/ACadSharp.Tests/Entities/HatchTests.cs
@@ -10,7 +10,31 @@ namespace ACadSharp.Tests.Entities;
 
 public class HatchTests : CommonEntityTests<Hatch>
 {
-	[Fact]
+[Fact]
+	public void APolylineBoundaryIsBoxedFlatAndFollowsItsBulge()
+	{
+		//Z on a polyline boundary's vertices is the BULGE, not a height - the remark on the
+		//property says so. Handing them to FromPoints as points gave the box a Z range that was a
+		//range of bulges, and ignored the arc the bulge describes, which bows outside its chord.
+		Hatch.BoundaryPath.Polyline edge = new Hatch.BoundaryPath.Polyline();
+		edge.Vertices.Add(new XYZ(0, 0, 1));
+		edge.Vertices.Add(new XYZ(10, 0, 0));
+
+		BoundingBox box = edge.GetBoundingBox();
+
+		//A boundary is planar. Before the fix this box ran from Z 0 to Z 1.
+		Assert.Equal(0.0, box.Min.Z, 9);
+		Assert.Equal(0.0, box.Max.Z, 9);
+
+		//Bulge 1 over a chord of 10 is a semicircle of radius 5, so the arc reaches 5 off the
+		//chord. Taken from the two vertices alone the box would be flat in Y as well.
+		//Measured through Arc, which samples the curve at 256 points, so the apex is approached
+		//rather than hit exactly - the same approximation Arc.GetBoundingBox itself makes.
+		Assert.Equal(10.0, box.Max.X - box.Min.X, 6);
+		Assert.Equal(5.0, box.Max.Y - box.Min.Y, 3);
+	}
+
+		[Fact]
 	public void BoundaryPathToEntityTest()
 	{
 		var a = new Hatch.BoundaryPath.Arc

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.Polyline.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.Polyline.cs
@@ -136,7 +136,77 @@ public partial class Hatch
 			/// <inheritdoc/>
 			public override BoundingBox GetBoundingBox()
 			{
-				return BoundingBox.FromPoints(this.Vertices);
+				//"The vertex bulge is stored in the Z component" - the remark on Vertices, a few
+				//lines up. Handing them to FromPoints as if they were points built a box whose Z
+				//range was a range of BULGES, so a hatch with a polyline boundary reported a height
+				//it does not have. The spline edge carried the identical fault with its weights and
+				//was fixed; this one was missed. Measured on the client corpus: 2,106 of 17,315
+				//polyline boundary edges reported such a range.
+				//
+				//The bulges are not merely discarded either: a bulged segment bows outside its own
+				//chord, so a box taken from the vertices alone is too small in X and Y as well. Each
+				//one is measured through Arc, which is how the rest of the library measures an arc.
+				BoundingBox box = BoundingBox.FromPoints(this.Vertices.Select(v => new XYZ(v.X, v.Y, 0)));
+
+				for (int i = 0; i < this.Vertices.Count; i++)
+				{
+					XYZ curr = this.Vertices[i];
+					bool last = i == this.Vertices.Count - 1;
+					if (last && !this.IsClosed)
+					{
+						break;
+					}
+
+					XYZ next = this.Vertices[last ? 0 : i + 1];
+
+					//A repeated vertex leaves no chord for an arc to span, and Arc refuses the zero
+					//radius its own maths then produces.
+					if (curr.Z == 0 || (curr.X == next.X && curr.Y == next.Y))
+					{
+						continue;
+					}
+
+					BoundingBox arc = ACadSharp.Entities.Arc
+						.CreateFromBulge(new XY(curr.X, curr.Y), new XY(next.X, next.Y), curr.Z)
+						.GetBoundingBox();
+
+					box = box.Merge(new BoundingBox(
+						new XYZ(arc.Min.X, arc.Min.Y, 0),
+						new XYZ(arc.Max.X, arc.Max.Y, 0)));
+				}
+
+				return box;
+			}
+
+			private IEnumerable<XYZ> arcAwarePoints()
+			{
+				for (int i = 0; i < this.Vertices.Count; i++)
+				{
+					XYZ curr = this.Vertices[i];
+					yield return new XYZ(curr.X, curr.Y, 0);
+
+					bool last = i == this.Vertices.Count - 1;
+					if (last && !this.IsClosed)
+					{
+						continue;
+					}
+
+					XYZ next = this.Vertices[last ? 0 : i + 1];
+
+					//A repeated vertex leaves no chord for an arc to span, and Arc refuses the zero
+					//radius its own maths then produces.
+					if (curr.Z == 0 || (curr.X == next.X && curr.Y == next.Y))
+					{
+						continue;
+					}
+
+					foreach (XYZ p in ACadSharp.Entities.Arc
+						.CreateFromBulge(new XY(curr.X, curr.Y), new XY(next.X, next.Y), curr.Z)
+						.PolygonalVertexes(16))
+					{
+						yield return new XYZ(p.X, p.Y, 0);
+					}
+				}
 			}
 
 			/// <inheritdoc/>

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.Spline.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.Spline.cs
@@ -165,7 +165,13 @@ public partial class Hatch
 			/// <inheritdoc/>
 			public override BoundingBox GetBoundingBox()
 			{
-				return BoundingBox.FromPoints(this.ControlPoints);
+				//"Position values are only X and Y, Z represents the weight" - the remark on
+				//ControlPoints, a few lines up. Handing them to FromPoints as if they were points
+				//builds a box whose Z range is a range of WEIGHTS, so a hatch with a spline boundary
+				//reports a height it does not have, every block holding one inherits it, and every
+				//INSERT of that block inherits it again. A hatch boundary is planar, so the box is
+				//flat.
+				return BoundingBox.FromPoints(this.ControlPoints.Select(c => new XYZ(c.X, c.Y, 0)));
 			}
 
 			/// <summary>


### PR DESCRIPTION
Two edge types, the same mistake, and both are documented against themselves a few lines above the fault.

### Spline edge

```csharp
/// Position values are only X and Y, Z represents the weight.
public List<XYZ> ControlPoints { get; private set; }
...
public override BoundingBox GetBoundingBox()
{
    return BoundingBox.FromPoints(this.ControlPoints);
}
```

So the box's Z range is a range of **weights**.

### Polyline edge

```csharp
/// The vertex bulge is stored in the Z component.
public List<XYZ> Vertices { get; private set; }
...
public override BoundingBox GetBoundingBox()
{
    return BoundingBox.FromPoints(this.Vertices);
}
```

So the box's Z range is a range of **bulges**.

A hatch boundary is planar; both boxes are flat. And a hatch lives inside a block as often as not, so the false height propagates: the block inherits it, and every `INSERT` of that block inherits it again.

### The polyline edge also lost real geometry

A bulged segment bows outside its own chord. The bulges were not merely misplaced into Z — they were never used as geometry at all, so the box was too small in X and Y as well. Each bulged segment is now measured through `Arc`, which is how the rest of the library measures an arc.

A repeated vertex that still carries a bulge is skipped: it leaves no chord for an arc to span, and `Arc` refuses the zero radius its own maths then produces (`Circle.Radius`'s setter throws).

### Evidence

Measured over eighteen architectural drawings: **17,315** polyline boundary edges, of which **2,302** carry a bulge and **2,106** were reporting a false Z range. After the fix, zero.

The drawings' computed extents still agree with AutoCAD's on all eighteen, so the larger X and Y boxes are geometry AutoCAD had already accounted for — the fix does not overshoot.

### Tests

`HatchSplineBoundingBoxTests` (new file) pins the spline case, including that the box is unchanged whatever the weights are. `HatchTests.APolylineBoundaryIsBoxedFlatAndFollowsItsBulge` pins the polyline case: a bulge of 1 over a chord of 10 is a semicircle of radius 5, so the box must be flat in Z and reach 5 off the chord — taken from the two vertices alone it would be flat in Y too.

`dotnet test`: 2319 passed / 17 failed, against `master` at 592d70a7 on this machine at 2313 / 17 — the same pre-existing failures, plus the tests added here.

### Related

#1223-#1230, DomCR/CSUtilities#23 — all found by comparing computed extents against the extents AutoCAD reports.