### PR TITLE
A block measured every child's bounding box twice

### DIFF
--- a/src/ACadSharp/Tables/BlockRecord.cs
+++ b/src/ACadSharp/Tables/BlockRecord.cs
@@ -447,13 +447,16 @@ public class BlockRecord : TableEntry, IGeometricEntity
 		BoundingBox box = BoundingBox.Null;
 		foreach (var item in this.Entities)
 		{
-			if (item.GetBoundingBox().Extent == BoundingBoxExtent.Infinite
-				&& ignoreInfinite)
+			//Once per entity. Asking twice - once to test the extent, once to merge - doubles the
+			//work at every level of nesting, so a block three deep was measured eight times over.
+			BoundingBox itemBox = item.GetBoundingBox();
+
+			if (itemBox.Extent == BoundingBoxExtent.Infinite && ignoreInfinite)
 			{
 				continue;
 			}
 
-			box = box.Merge(item.GetBoundingBox());
+			box = box.Merge(itemBox);
 		}
 
 		return box;

--- a/src/ACadSharp/Tables/BlockRecord.cs
+++ b/src/ACadSharp/Tables/BlockRecord.cs
@@ -447,8 +447,6 @@ public class BlockRecord : TableEntry, IGeometricEntity
 		BoundingBox box = BoundingBox.Null;
 		foreach (var item in this.Entities)
 		{
-			//Once per entity. Asking twice - once to test the extent, once to merge - doubles the
-			//work at every level of nesting, so a block three deep was measured eight times over.
 			BoundingBox itemBox = item.GetBoundingBox();
 
 			if (itemBox.Extent == BoundingBoxExtent.Infinite && ignoreInfinite)


### PR DESCRIPTION
```csharp
foreach (var item in this.Entities)
{
    if (item.GetBoundingBox().Extent == BoundingBoxExtent.Infinite && ignoreInfinite)
    {
        continue;
    }

    box = box.Merge(item.GetBoundingBox());
}
```

`item.GetBoundingBox()` is called once to test the extent and again to merge it.

That is twice per entity at one level — but **blocks nest**. `Insert.GetBoundingBox()` calls `Block.GetBoundingBox()`, so a block whose children are inserts of blocks whose children are inserts costs `2^depth` evaluations of the same boxes. Some of those evaluations are not cheap: `Arc` and `Circle` sample 256 points, `Ellipse` 100, `Spline` up to 256.

### Measurement

An architectural drawing of 188,000 entities, warm file cache, three runs each, reading the file and computing every model-space entity's box:

```
before   8s   8s   8s
after    5s   5s   4s
```

That is whole-run wall clock **including parsing a 19 MB DWG**, so the share actually spent measuring boxes fell by considerably more than the 40% the total shows.

### Behaviour

Unchanged. The same box is computed, once, and used for both the test and the merge.

`dotnet test`: 2313 passed / 17 failed — identical to `master` at 592d70a7 on this machine, as expected for a change that adds no tests and alters no results.