### PR TITLE
Allow xref-dependent DXF table names

### DIFF
--- a/src/ACadSharp.Tests/Tables/TableEntryCommonTests.cs
+++ b/src/ACadSharp.Tests/Tables/TableEntryCommonTests.cs
@@ -55,6 +55,15 @@ public abstract class TableEntryCommonTests<T>
 	}
 
 	[Fact]
+	public void XrefDependentNameAllowsPipe()
+	{
+		T entry = this.createEntry("xref|name");
+		entry.Flags |= StandardFlags.XrefDependent;
+
+		Assert.True(entry.HasValidDxfName());
+	}
+
+	[Fact]
 	public void SetFlagUsingMapper()
 	{
 		T entry = this.createEntry();

--- a/src/ACadSharp/Extensions/INamedCadObjectExtensions.cs
+++ b/src/ACadSharp/Extensions/INamedCadObjectExtensions.cs
@@ -33,6 +33,13 @@ public static class INamedCadObjectExtensions
 			return false;
 		}
 
-		return namedCadObject.Name.IndexOfAny(InvalidCharacters.Skip(1).ToArray()) == -1;
+		var invalidCharacters = InvalidCharacters.Skip(1);
+		if (namedCadObject is Tables.TableEntry entry
+			&& entry.Flags.HasFlag(Tables.StandardFlags.XrefDependent))
+		{
+			invalidCharacters = invalidCharacters.Where(c => c != '|');
+		}
+
+		return namedCadObject.Name.IndexOfAny(invalidCharacters.ToArray()) == -1;
 	}
 }


### PR DESCRIPTION
# Description

`HasValidDxfName` rejected `|` for every named object. This also rejected valid xref-dependent table record names such as `xref|name`, causing those records to fail DXF validation.

This change permits `|` only for `TableEntry` instances marked with `StandardFlags.XrefDependent`. The existing invalid-character test continues to reject `|` for non-dependent entries.

# Tasks done in this PR

* [x] Allow the xref name separator for xref-dependent table records.
* [x] Cover dependent and non-dependent validation across the existing table entry tests.

# Related Issues / Pull Requests

- None.

# Notes for reviewer

- AutoCAD reference: [About Names in External References](https://help.autodesk.com/view/ACD/2026/ENU/?caas=caas%2Fdocumentation%2FACDLT%2F2014%2FENU%2Ffiles%2FGUID-C3391298-3F46-4CA3-BFB9-B0EEB75E292D-htm.html)
- DXF reference: [LAYER group codes](https://help.autodesk.com/cloudhelp/2018/ENU/AutoCAD-DXF/files/GUID-D94802B0-8BE8-4AC9-8054-17197688AFDB.htm)
- Test: `dotnet test ACadSharp.Tests/ACadSharp.Tests.csproj --framework net9.0 --filter 'FullyQualifiedName~XrefDependentNameAllowsPipe|FullyQualifiedName~IsValidNameTest'`
