### PR TITLE
fix: correct face-list index advance in proxy shell reader

### DIFF
--- a/src/ACadSharp/Entities/ProxyGraphics/ProxyGeometryReader.cs
+++ b/src/ACadSharp/Entities/ProxyGraphics/ProxyGeometryReader.cs
@@ -623,7 +623,7 @@ public class ProxyGeometryReader
 		for (int i = 0; i < nfaces; i++)
 		{
 			int count = Math.Abs(stream.ReadInt());
-			i += count + 1;
+			i += count;
 
 			List<int> faceIndices = [];
 			for (int j = 0; j < count; j++)


### PR DESCRIPTION
# Description

The loop advanced the counter by `count + 1` *in addition to* the `for` loop's own `i++`, so every face over-counted by one. As a result the loop exited before the whole face list was consumed, leaving unread bytes in the stream. Edge/face traits and every subsequent proxy geometry in the same blob were then parsed from the wrong offset, producing garbage entities or read exceptions.

# Tasks done in this PR
* [ ] Something awesome.
* [x] An evil bug have been defeated.
* [ ] Code cleanup and maintenance has been done.

# Related Issues / Pull Requests
- Add the links of issues or PR related to this one.
# Notes for reviewer
 - Things to consider during the review of this PR.