### PR TITLE
Do not throw on duplicated table entries when Failsafe is enabled

### DIFF
--- a/samples/duplicated_default_entries_AC1009.dxf
+++ b/samples/duplicated_default_entries_AC1009.dxf
@@ -1,0 +1,128 @@
+  0
+SECTION
+  2
+HEADER
+  9
+$ACADVER
+  1
+AC1009
+  0
+ENDSEC
+  0
+SECTION
+  2
+TABLES
+  0
+TABLE
+  2
+LAYER
+ 70
+2
+  0
+LAYER
+  2
+0
+ 70
+0
+ 62
+7
+  6
+CONTINUOUS
+  0
+LAYER
+  2
+0
+ 70
+0
+ 62
+7
+  6
+CONTINUOUS
+  0
+ENDTAB
+  0
+ENDSEC
+  0
+SECTION
+  2
+BLOCKS
+  0
+BLOCK
+  8
+0
+  2
+*D0
+ 70
+65
+ 10
+0.0
+ 20
+0.0
+  0
+LINE
+  5
+1
+  8
+Bemassung
+ 10
+0.0
+ 20
+5.0
+ 11
+100.0
+ 21
+5.0
+  0
+ENDBLK
+  8
+0
+  0
+ENDSEC
+  0
+SECTION
+  2
+ENTITIES
+  0
+LINE
+  5
+10
+  8
+Kanten
+ 10
+0.0
+ 20
+0.0
+ 11
+100.0
+ 21
+0.0
+  0
+DIMENSION
+  5
+11
+  8
+Konstruktion
+  2
+*D0
+ 10
+0.0
+ 20
+5.0
+ 11
+50.0
+ 21
+5.0
+ 70
+0
+ 13
+0.0
+ 23
+0.0
+ 14
+100.0
+ 24
+0.0
+  0
+ENDSEC
+  0
+EOF

--- a/samples/duplicated_entry_no_default_AC1009.dxf
+++ b/samples/duplicated_entry_no_default_AC1009.dxf
@@ -1,0 +1,66 @@
+  0
+SECTION
+  2
+HEADER
+  9
+$ACADVER
+  1
+AC1009
+  0
+ENDSEC
+  0
+SECTION
+  2
+TABLES
+  0
+TABLE
+  2
+LAYER
+ 70
+2
+  0
+LAYER
+  2
+A
+ 70
+0
+ 62
+7
+  6
+CONTINUOUS
+  0
+LAYER
+  2
+A
+ 70
+0
+ 62
+7
+  6
+CONTINUOUS
+  0
+ENDTAB
+  0
+ENDSEC
+  0
+SECTION
+  2
+ENTITIES
+  0
+LINE
+  5
+10
+  8
+A
+ 10
+0.0
+ 20
+0.0
+ 11
+100.0
+ 21
+0.0
+  0
+ENDSEC
+  0
+EOF

--- a/src/ACadSharp.Tests/IO/DXF/DxfReaderTests.cs
+++ b/src/ACadSharp.Tests/IO/DXF/DxfReaderTests.cs
@@ -2,6 +2,7 @@
 using ACadSharp.IO;
 using ACadSharp.Tests.TestModels;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -179,5 +180,40 @@ public class DxfReaderTests : CadReaderTestsBase<DxfReader>
 		Assert.NotNull(doc.UCSs);
 		Assert.NotNull(doc.Views);
 		Assert.NotNull(doc.VPorts);
+	}
+
+	[Fact]
+	public void ReadDuplicatedDefaultLayerTest()
+	{
+		//https://github.com/DomCR/ACadSharp/issues/1242
+		string path = System.IO.Path.Combine(TestVariables.SamplesFolder, "duplicated_default_entries_AC1009.dxf");
+
+		CadDocument doc;
+		using (DxfReader reader = new DxfReader(path))
+		{
+			doc = reader.Read();
+		}
+
+		Assert.True(doc.Layers.Contains("0"));
+		Assert.Single(doc.Layers.Where(l => l.Name == "0"));
+		Assert.Single(doc.Entities.OfType<Line>());
+		Assert.Single(doc.Entities.OfType<Dimension>());
+	}
+
+	[Fact]
+	public void ReadDuplicatedEntryWithoutDefaultTest()
+	{
+		//https://github.com/DomCR/ACadSharp/issues/1239
+		string path = System.IO.Path.Combine(TestVariables.SamplesFolder, "duplicated_entry_no_default_AC1009.dxf");
+
+		CadDocument doc;
+		using (DxfReader reader = new DxfReader(path))
+		{
+			doc = reader.Read();
+		}
+
+		Assert.True(doc.Layers.Contains("A"));
+		Assert.Single(doc.Layers.Where(l => l.Name == "A"));
+		Assert.Equal("A", doc.Entities.OfType<Line>().Single().Layer.Name);
 	}
 }

--- a/src/ACadSharp/IO/DXF/DxfStreamReader/DxfTablesSectionReader.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamReader/DxfTablesSectionReader.cs
@@ -225,7 +225,12 @@ internal class DxfTablesSectionReader : DxfSectionReaderBase
 			{
 				this._builder.Notify($"Duplicated entry with name {template.Name} found in {template.CadObject.ObjectName}", NotificationType.Warning);
 
-				tableTemplate.CadObject.Remove(template.Name);
+				if (tableTemplate.CadObject.Remove(template.Name) == null)
+				{
+					//Default entries (layer "0", "Continuous", "Standard"...) cannot be removed, keep the first definition
+					continue;
+				}
+
 				tableTemplate.CadObject.Add((T)template.CadObject);
 			}
 			else

--- a/src/ACadSharp/Tables/Collections/Table.cs
+++ b/src/ACadSharp/Tables/Collections/Table.cs
@@ -250,6 +250,12 @@ public abstract class Table<T> : CadObject, ITable, ICadCollection<T>, IObservab
 
 	private void assignToDefault(string name)
 	{
+		//While the table is being read the default entries may not exist yet, there is nothing to reassign to
+		if (!this.getDefaultEntries().All(this.entries.ContainsKey))
+		{
+			return;
+		}
+
 		this._referenceHandler.RemoveReference(name, this.GetDefaultEntry());
 	}
 


### PR DESCRIPTION
# Description

Two guards in the DXF table reader so that a duplicated table entry no longer aborts the read when `Failsafe` is enabled.

- `DxfTablesSectionReader.readEntries` already detects a duplicated entry and replaces it ("last one wins"). `Table<T>.Remove` refuses default entries (`0`, `Continuous`, `Standard`, ...) and returns `null` without removing anything, so the following `Add` threw `ArgumentException`. The duplicate is now skipped and the first definition is kept. With `Failsafe = false` the reader still throws.
- `Table<T>.assignToDefault` resolved the default entry through the indexer while the table was still being read. When the default entry did not exist yet this threw `KeyNotFoundException`. There are no references to reassign at that point, so it now returns early.

Both cases are independent of the DXF version (reproduced with AC1009 and AC1015).

# Tasks done in this PR
* [x] `DxfTablesSectionReader.readEntries`: skip a duplicated default entry instead of throwing.
* [x] `Table<T>.assignToDefault`: return early while the default entries do not exist yet.
* [x] Samples `duplicated_default_entries_AC1009.dxf` and `duplicated_entry_no_default_AC1009.dxf`.
* [x] Regression tests `ReadDuplicatedDefaultLayerTest` and `ReadDuplicatedEntryWithoutDefaultTest`.

# Related Issues / Pull Requests
- Fixes #1242
- Fixes #1239

# Notes for reviewer
 - "Keep the first definition" was chosen for duplicated default entries because `Remove` cannot hand them out. For all other duplicates the existing "last one wins" behaviour is unchanged.
 - The `All(...)` check in `assignToDefault` is deliberately strict: it only skips the reassignment while the table is incomplete, i.e. during the read. On a fully built document the behaviour is unchanged.
 - `DxfReaderTests`, `DimensionTests`, `TableEntityTests` and `IOTests` pass locally on net9.0 (313 tests).