### PR TITLE
Create layers referenced by DXF entities but missing from the LAYER table

### DIFF
--- a/src/ACadSharp/IO/Templates/CadEntityTemplate.cs
+++ b/src/ACadSharp/IO/Templates/CadEntityTemplate.cs
@@ -71,6 +71,11 @@ internal class CadEntityTemplate : CadTemplate<Entity>
 		{
 			this.CadObject.Layer = layer;
 		}
+		else if (!string.IsNullOrEmpty(this.LayerName))
+		{
+			builder.Notify($"Layer {this.LayerName} not found in the LAYER table, created for {this.CadObject.GetType().FullName} with handle {this.CadObject.Handle}", NotificationType.Warning);
+			this.CadObject.Layer = builder.Layers.TryAdd(new Layer(this.LayerName));
+		}
 
 		switch (this.LtypeFlags)
 		{


### PR DESCRIPTION
# Description

When a DXF entity references a layer by name (group code 8) that is not defined in the LAYER table, `CadEntityTemplate.build` only emitted a warning and left the entity on layer `0`. The layer name was lost in the document.

With this change the reader creates the missing layer with default properties, adds it to the document's `Layers` table and assigns it to the entity, which is what AutoCAD does when it opens such a file. The warning stays and now says that the layer was created.

- Only applies when the reference could not be resolved by handle or by name and a name is present. 
- `Layers.TryAdd` is used, so several entities on the same missing layer share one `Layer` instance.

# Tasks done in this PR
* [x] `CadEntityTemplate.build`: create a layer that is referenced by name but missing from the LAYER table.
* [x] Sample `missing_layer_AC1009.dxf` (LAYER table with `0` only, two lines on `Kanten`, one circle on `Bohrungen`).
* [x] Regression test `ReadMissingLayerTest`.

# Related Issues / Pull Requests
- Closes #1244

# Notes for reviewer
 - This changes the default behaviour for invalid files: entities that used to land on `0` now keep their layer name. If you would rather keep the old behaviour as default, the block can be gated by a new `CadReaderConfiguration` flag. Happy to add that.
 - The created layer has default color, line type and flags. Nothing else about it is known from the file.