### PR TITLE
Include a polyline's width in its bounding box

### DIFF
--- a/src/ACadSharp.Tests/Entities/CircleTests.cs
+++ b/src/ACadSharp.Tests/Entities/CircleTests.cs
@@ -18,6 +18,16 @@ public class CircleTests : CommonEntityTests<Circle>
 
 		Assert.Equal(new XYZ(-5, -5, 0), boundingBox.Min);
 		Assert.Equal(new XYZ(5, 5, 0), boundingBox.Max);
+
+		//The centre is stored in the circle's own object coordinate system, so the (0,0,-1)
+		//normal AutoCAD writes for mirrored geometry puts the circle at the negated X.
+		circle.Center = new XYZ(100, 50, 0);
+		circle.Normal = -XYZ.AxisZ;
+
+		boundingBox = circle.GetBoundingBox();
+
+		Assert.Equal(new XYZ(-105, 45, 0), boundingBox.Min);
+		Assert.Equal(new XYZ(-95, 55, 0), boundingBox.Max);
 	}
 
 	[Fact]

--- a/src/ACadSharp.Tests/Entities/LwPolylineTest.cs
+++ b/src/ACadSharp.Tests/Entities/LwPolylineTest.cs
@@ -117,5 +117,25 @@ public class LwPolylineTests : CommonEntityTests<LwPolyline>
 
 	public override void GetBoundingBoxTest()
 	{
+		LwPolyline lwPolyline = new LwPolyline();
+		foreach (XYZ p in this._points)
+		{
+			lwPolyline.Vertices.Add(new LwPolyline.Vertex((XY)p));
+		}
+
+		BoundingBox box = lwPolyline.GetBoundingBox();
+
+		Assert.Equal(new XYZ(0, 0, 0), box.Min);
+		Assert.Equal(new XYZ(1, 1, 0), box.Max);
+
+		//The vertices are stored in the polyline's own object coordinate system. AutoCAD writes a
+		//(0,0,-1) normal whenever geometry is mirrored, and the world position is then the negated X -
+		//not the stored one, which would place the polyline on the wrong side of the drawing.
+		lwPolyline.Normal = -XYZ.AxisZ;
+
+		box = lwPolyline.GetBoundingBox();
+
+		Assert.Equal(new XYZ(-1, 0, 0), box.Min);
+		Assert.Equal(new XYZ(0, 1, 0), box.Max);
 	}
 }

--- a/src/ACadSharp.Tests/Entities/LwPolylineTest.cs
+++ b/src/ACadSharp.Tests/Entities/LwPolylineTest.cs
@@ -138,4 +138,53 @@ public class LwPolylineTests : CommonEntityTests<LwPolyline>
 		Assert.Equal(new XYZ(-1, 0, 0), box.Min);
 		Assert.Equal(new XYZ(0, 1, 0), box.Max);
 	}
+
+	[Fact]
+	public void GetBoundingBoxIncludesAConstantWidth()
+	{
+		//A width is drawn half on each side of the centre line, and AutoCAD's extents include it:
+		//asked for this square of width 150, AutoCAD reports (-75,-75)..(1075,1075). Measuring the
+		//centre line alone left one real drawing's extents short by exactly 75 on all four sides.
+		LwPolyline polyline = new LwPolyline { ConstantWidth = 150, IsClosed = true };
+		polyline.Vertices.Add(new LwPolyline.Vertex(new XY(0, 0)));
+		polyline.Vertices.Add(new LwPolyline.Vertex(new XY(1000, 0)));
+		polyline.Vertices.Add(new LwPolyline.Vertex(new XY(1000, 1000)));
+		polyline.Vertices.Add(new LwPolyline.Vertex(new XY(0, 1000)));
+
+		BoundingBox box = polyline.GetBoundingBox();
+
+		Assert.Equal(new XYZ(-75, -75, 0), box.Min);
+		Assert.Equal(new XYZ(1075, 1075, 0), box.Max);
+	}
+
+	[Fact]
+	public void GetBoundingBoxCarriesAWidthAcrossTheSegmentAndNotBeyondItsEnds()
+	{
+		//The width goes perpendicular to the segment; the ends are flat caps. AutoCAD agrees: for
+		//these two segments tapering 0-200-400 it reports (0,-108.9)..(1200,1000), so the open ends
+		//stay at their vertexes and only the joint fill reaches slightly further than measured here.
+		LwPolyline polyline = new LwPolyline();
+		polyline.Vertices.Add(new LwPolyline.Vertex(new XY(0, 0)) { StartWidth = 0, EndWidth = 200 });
+		polyline.Vertices.Add(new LwPolyline.Vertex(new XY(1000, 0)) { StartWidth = 200, EndWidth = 400 });
+		polyline.Vertices.Add(new LwPolyline.Vertex(new XY(1000, 1000)) { StartWidth = 400, EndWidth = 0 });
+
+		BoundingBox box = polyline.GetBoundingBox();
+
+		Assert.Equal(new XYZ(0, -100, 0), box.Min);
+		Assert.Equal(new XYZ(1200, 1000, 0), box.Max);
+	}
+
+	[Fact]
+	public void GetBoundingBoxKeepsTheCentreLineWithoutAWidth()
+	{
+		LwPolyline polyline = new LwPolyline();
+		polyline.Vertices.Add(new LwPolyline.Vertex(new XY(0, 0)));
+		polyline.Vertices.Add(new LwPolyline.Vertex(new XY(1000, 500)));
+
+		BoundingBox box = polyline.GetBoundingBox();
+
+		Assert.Equal(new XYZ(0, 0, 0), box.Min);
+		Assert.Equal(new XYZ(1000, 500, 0), box.Max);
+	}
+
 }

--- a/src/ACadSharp.Tests/Entities/Polyline2DTests.cs
+++ b/src/ACadSharp.Tests/Entities/Polyline2DTests.cs
@@ -14,4 +14,22 @@ public class Polyline2DTests : CommonPolylineTests<Polyline2D, Vertex2D>
 		Assert.False(polyline.Flags.HasFlag(PolylineFlags.PolygonMesh));
 		Assert.False(polyline.Flags.HasFlag(PolylineFlags.PolyfaceMesh));
 	}
+
+	[Fact]
+	public void GetBoundingBoxIncludesTheWidthTheVertexesCarry()
+	{
+		//AutoCAD's PLINE with a width of 150 measures 75 to each side of the centre line, and its
+		//extents say so; the old-style POLYLINE carries the width on the vertexes rather than in a
+		//single field, so both routes have to add it.
+		Polyline2D polyline = new Polyline2D();
+		polyline.Vertices.Add(new Vertex2D(new CSMath.XY(0, 0)) { StartWidth = 150, EndWidth = 150 });
+		polyline.Vertices.Add(new Vertex2D(new CSMath.XY(1000, 0)) { StartWidth = 150, EndWidth = 150 });
+		polyline.Vertices.Add(new Vertex2D(new CSMath.XY(1000, 1000)) { StartWidth = 150, EndWidth = 150 });
+
+		CSMath.BoundingBox box = polyline.GetBoundingBox();
+
+		Assert.Equal(new CSMath.XYZ(0, -75, 0), box.Min);
+		Assert.Equal(new CSMath.XYZ(1075, 1000, 0), box.Max);
+	}
+
 }

--- a/src/ACadSharp/Entities/Circle.cs
+++ b/src/ACadSharp/Entities/Circle.cs
@@ -101,8 +101,14 @@ public class Circle : Entity, ICurve, IOrientable
 	/// <inheritdoc/>
 	public override BoundingBox GetBoundingBox()
 	{
-		XYZ min = new XYZ(Math.Min(this.Center.X - this.Radius, this.Center.X + this.Radius), Math.Min(this.Center.Y - this.Radius, this.Center.Y + this.Radius), Math.Min(this.Center.Z, this.Center.Z));
-		XYZ max = new XYZ(Math.Max(this.Center.X - this.Radius, this.Center.X + this.Radius), Math.Max(this.Center.Y - this.Radius, this.Center.Y + this.Radius), Math.Max(this.Center.Z, this.Center.Z));
+		//The centre is in the circle's own object coordinate system. Read straight out it puts a
+		//mirrored circle - the (0,0,-1) normal AutoCAD writes for mirrored geometry - on the wrong
+		//side of the drawing, far enough to ruin the extents of everything around it.
+		XYZ center = Matrix4.GetArbitraryAxis(this.Normal) * this.Center;
+
+		XYZ min = new XYZ(center.X - this.Radius, center.Y - this.Radius, center.Z);
+		XYZ max = new XYZ(center.X + this.Radius, center.Y + this.Radius, center.Z);
+
 		return new BoundingBox(min, max);
 	}
 

--- a/src/ACadSharp/Entities/LwPolyLine.cs
+++ b/src/ACadSharp/Entities/LwPolyLine.cs
@@ -148,11 +148,15 @@ public partial class LwPolyline : Entity, IPolyline
 	/// <inheritdoc/>
 	public override BoundingBox GetBoundingBox()
 	{
-		if (this.Vertices.Any(v => v.Bulge != 0))
-		{
-			return BoundingBox.FromPoints(this.GetPoints<XYZ>(byte.MaxValue));
-		}
+		IEnumerable<XYZ> points = this.Vertices.Any(v => v.Bulge != 0)
+			? this.GetPoints<XYZ>(byte.MaxValue)
+			: this.Vertices.Select(v => v.Location.Convert<XYZ>());
 
-		return BoundingBox.FromPoints(this.Vertices.Select(v => v.Location.Convert<XYZ>()));
+		//The vertices are stored in the entity's own object coordinate system. A caller asking for a
+		//bounding box is asking where the thing sits in the world, and for the (0,0,-1) normal AutoCAD
+		//writes whenever geometry is mirrored the two differ by the sign of X - which is enough to put
+		//a drawing's extents out by millions of units and make a viewer's zoom-extents useless.
+		Matrix4 toWorld = Matrix4.GetArbitraryAxis(this.Normal);
+		return BoundingBox.FromPoints(points.Select(p => toWorld * p));
 	}
 }

--- a/src/ACadSharp/Entities/LwPolyLine.cs
+++ b/src/ACadSharp/Entities/LwPolyLine.cs
@@ -148,15 +148,66 @@ public partial class LwPolyline : Entity, IPolyline
 	/// <inheritdoc/>
 	public override BoundingBox GetBoundingBox()
 	{
-		IEnumerable<XYZ> points = this.Vertices.Any(v => v.Bulge != 0)
-			? this.GetPoints<XYZ>(byte.MaxValue)
-			: this.Vertices.Select(v => v.Location.Convert<XYZ>());
-
 		//The vertices are stored in the entity's own object coordinate system. A caller asking for a
 		//bounding box is asking where the thing sits in the world, and for the (0,0,-1) normal AutoCAD
 		//writes whenever geometry is mirrored the two differ by the sign of X - which is enough to put
 		//a drawing's extents out by millions of units and make a viewer's zoom-extents useless.
 		Matrix4 toWorld = Matrix4.GetArbitraryAxis(this.Normal);
+
+		//A width is drawn half on each side of the centre line and AutoCAD's extents include it, so
+		//the widened area is measured in the plane first and only then taken to the world.
+		BoundingBox widened = PolylineWidthBounds.InPlane(this.widthSegments());
+		if (widened.Extent != BoundingBoxExtent.Null)
+		{
+			return BoundingBox.FromPoints(corners(widened).Select(p => toWorld * p));
+		}
+
+		IEnumerable<XYZ> points = this.Vertices.Any(v => v.Bulge != 0)
+			? this.GetPoints<XYZ>(byte.MaxValue)
+			: this.Vertices.Select(v => v.Location.Convert<XYZ>());
+
 		return BoundingBox.FromPoints(points.Select(p => toWorld * p));
+
+		static IEnumerable<XYZ> corners(BoundingBox box)
+		{
+			yield return new XYZ(box.Min.X, box.Min.Y, box.Min.Z);
+			yield return new XYZ(box.Max.X, box.Min.Y, box.Min.Z);
+			yield return new XYZ(box.Min.X, box.Max.Y, box.Min.Z);
+			yield return new XYZ(box.Max.X, box.Max.Y, box.Min.Z);
+			yield return new XYZ(box.Min.X, box.Min.Y, box.Max.Z);
+			yield return new XYZ(box.Max.X, box.Min.Y, box.Max.Z);
+			yield return new XYZ(box.Min.X, box.Max.Y, box.Max.Z);
+			yield return new XYZ(box.Max.X, box.Max.Y, box.Max.Z);
+		}
+	}
+
+	//Constant width (code 43) applies wherever a vertex does not carry one of its own, which is how
+	//AutoCAD writes a uniformly wide polyline.
+	private IEnumerable<PolylineWidthBounds.Segment> widthSegments()
+	{
+		for (int i = 0; i < this.Vertices.Count; i++)
+		{
+			Vertex current = this.Vertices[i];
+			Vertex next;
+			if (i + 1 < this.Vertices.Count)
+			{
+				next = this.Vertices[i + 1];
+			}
+			else if (this.IsClosed && this.Vertices.Count > 1)
+			{
+				next = this.Vertices[0];
+			}
+			else
+			{
+				yield break;
+			}
+
+			yield return new PolylineWidthBounds.Segment(
+				current.Location,
+				next.Location,
+				current.Bulge,
+				current.StartWidth != 0 ? current.StartWidth : this.ConstantWidth,
+				current.EndWidth != 0 ? current.EndWidth : this.ConstantWidth);
+		}
 	}
 }

--- a/src/ACadSharp/Entities/PolyLine.cs
+++ b/src/ACadSharp/Entities/PolyLine.cs
@@ -92,6 +92,14 @@ public abstract class Polyline<T> : Entity, IPolyline
 	[DxfCodeValue(210, 220, 230)]
 	public XYZ Normal { get; set; } = XYZ.AxisZ;
 
+	/// <summary>
+	/// Whether the vertexes of this polyline are expressed in the entity's own object coordinate
+	/// system, in which case <see cref="Normal"/> is needed to place them in the world. True for
+	/// the 2D form, which is how AutoCAD records mirrored geometry; false for the 3D form, whose
+	/// vertexes are already world coordinates.
+	/// </summary>
+	protected virtual bool VertexesAreInObjectCoordinates { get; } = true;
+
 	/// <inheritdoc/>
 	public override string ObjectName => DxfFileToken.EntityPolyline;
 
@@ -176,12 +184,18 @@ public abstract class Polyline<T> : Entity, IPolyline
 	/// <inheritdoc/>
 	public override BoundingBox GetBoundingBox()
 	{
-		if (this.Vertices.Any(v => v.Bulge != 0))
-		{
-			return BoundingBox.FromPoints(this.GetPoints<XYZ>(byte.MaxValue));
-		}
+		IEnumerable<XYZ> points = this.Vertices.Any(v => v.Bulge != 0)
+			? this.GetPoints<XYZ>(byte.MaxValue)
+			: this.Vertices.Select(v => v.Location.Convert<XYZ>());
 
-		return BoundingBox.FromPoints(this.Vertices.Select(v => v.Location.Convert<XYZ>()));
+		//The vertices are stored in the entity's own object coordinate system. A caller asking for a
+		//bounding box is asking where the thing sits in the world, and for the (0,0,-1) normal AutoCAD
+		//writes whenever geometry is mirrored the two differ by the sign of X - which is enough to put
+		//a drawing's extents out by millions of units and make a viewer's zoom-extents useless.
+		Matrix4 toWorld = this.VertexesAreInObjectCoordinates
+			? Matrix4.GetArbitraryAxis(this.Normal)
+			: Matrix4.Identity;
+		return BoundingBox.FromPoints(points.Select(p => toWorld * p));
 	}
 
 	internal static IEnumerable<Entity> Explode(IPolyline polyline)

--- a/src/ACadSharp/Entities/PolyLine.cs
+++ b/src/ACadSharp/Entities/PolyLine.cs
@@ -184,10 +184,6 @@ public abstract class Polyline<T> : Entity, IPolyline
 	/// <inheritdoc/>
 	public override BoundingBox GetBoundingBox()
 	{
-		IEnumerable<XYZ> points = this.Vertices.Any(v => v.Bulge != 0)
-			? this.GetPoints<XYZ>(byte.MaxValue)
-			: this.Vertices.Select(v => v.Location.Convert<XYZ>());
-
 		//The vertices are stored in the entity's own object coordinate system. A caller asking for a
 		//bounding box is asking where the thing sits in the world, and for the (0,0,-1) normal AutoCAD
 		//writes whenever geometry is mirrored the two differ by the sign of X - which is enough to put
@@ -195,7 +191,73 @@ public abstract class Polyline<T> : Entity, IPolyline
 		Matrix4 toWorld = this.VertexesAreInObjectCoordinates
 			? Matrix4.GetArbitraryAxis(this.Normal)
 			: Matrix4.Identity;
+
+		//A width is drawn half on each side of the centre line and AutoCAD's extents include it. It
+		//only means anything for a polyline that lies in a plane; a 3D polyline carries the fields
+		//but no width, so it keeps the centre line.
+		if (this.VertexesAreInObjectCoordinates)
+		{
+			BoundingBox widened = PolylineWidthBounds.InPlane(this.widthSegments());
+			if (widened.Extent != BoundingBoxExtent.Null)
+			{
+				return BoundingBox.FromPoints(corners(widened).Select(p => toWorld * p));
+			}
+		}
+
+		IEnumerable<XYZ> points = this.Vertices.Any(v => v.Bulge != 0)
+			? this.GetPoints<XYZ>(byte.MaxValue)
+			: this.Vertices.Select(v => v.Location.Convert<XYZ>());
+
 		return BoundingBox.FromPoints(points.Select(p => toWorld * p));
+
+		static IEnumerable<XYZ> corners(BoundingBox box)
+		{
+			yield return new XYZ(box.Min.X, box.Min.Y, box.Min.Z);
+			yield return new XYZ(box.Max.X, box.Min.Y, box.Min.Z);
+			yield return new XYZ(box.Min.X, box.Max.Y, box.Min.Z);
+			yield return new XYZ(box.Max.X, box.Max.Y, box.Min.Z);
+			yield return new XYZ(box.Min.X, box.Min.Y, box.Max.Z);
+			yield return new XYZ(box.Max.X, box.Min.Y, box.Max.Z);
+			yield return new XYZ(box.Min.X, box.Max.Y, box.Max.Z);
+			yield return new XYZ(box.Max.X, box.Max.Y, box.Max.Z);
+		}
+	}
+
+	//The polyline's own start and end width (codes 40 and 41) are the default for a vertex that
+	//does not carry one, which is how AutoCAD writes a uniformly wide POLYLINE.
+	private IEnumerable<PolylineWidthBounds.Segment> widthSegments()
+	{
+		for (int i = 0; i < this.Vertices.Count; i++)
+		{
+			T current = this.Vertices[i];
+			T next;
+			if (i + 1 < this.Vertices.Count)
+			{
+				next = this.Vertices[i + 1];
+			}
+			else if (this.IsClosed && this.Vertices.Count > 1)
+			{
+				next = this.Vertices[0];
+			}
+			else
+			{
+				yield break;
+			}
+
+			//IVertex carries no width; only the concrete vertex does, and a 3D one leaves it at zero.
+			Vertex vertex = current as Vertex;
+			double startWidth = vertex != null && vertex.StartWidth != 0 ? vertex.StartWidth : this.StartWidth;
+			double endWidth = vertex != null && vertex.EndWidth != 0 ? vertex.EndWidth : this.EndWidth;
+
+			yield return new PolylineWidthBounds.Segment(
+				current.Location.Convert<XY>(),
+				next.Location.Convert<XY>(),
+				current.Bulge,
+				startWidth,
+				endWidth,
+				current.Location.Convert<XYZ>().Z,
+				next.Location.Convert<XYZ>().Z);
+		}
 	}
 
 	internal static IEnumerable<Entity> Explode(IPolyline polyline)

--- a/src/ACadSharp/Entities/PolyLine3D.cs
+++ b/src/ACadSharp/Entities/PolyLine3D.cs
@@ -17,6 +17,9 @@ namespace ACadSharp.Entities
 	public class Polyline3D : Polyline<Vertex3D>
 	{
 		/// <inheritdoc/>
+		protected override bool VertexesAreInObjectCoordinates { get; } = false;
+
+		/// <inheritdoc/>
 		public override PolylineFlags Flags { get => base.Flags | (PolylineFlags.Polyline3D); set => base.Flags = value; }
 
 		/// <inheritdoc/>

--- a/src/ACadSharp/Entities/PolylineWidthBounds.cs
+++ b/src/ACadSharp/Entities/PolylineWidthBounds.cs
@@ -1,0 +1,134 @@
+using CSMath;
+using System;
+using System.Collections.Generic;
+
+namespace ACadSharp.Entities;
+
+/// <summary>
+/// Bounds for the area a wide polyline actually covers, in the polyline's own plane.
+/// </summary>
+/// <remarks>
+/// A polyline with width covers half of it on each side of the centre line, and AutoCAD's extents
+/// say so: a closed square drawn with a constant width of 150 measures 75 further out on every
+/// side. Bounding the centre line alone therefore reports a drawing as smaller than it is - on one
+/// real drawing the extents came out exactly 75 units short on all four sides, which is enough to
+/// clip a viewer's zoom.
+///
+/// Each segment is bounded on its own, so a taper is paid for only where it occurs: the straight
+/// case is exact, and a segment carrying a bulge is padded by the larger of its two half widths,
+/// which contains the sweep. What is left over is the fill AutoCAD adds at a joint, which reaches a
+/// little further than the two segments meeting there.
+/// </remarks>
+internal static class PolylineWidthBounds
+{
+	/// <summary>
+	/// The box the segments cover in the plane, or <see cref="BoundingBox.Null"/> when none of them
+	/// carries a width.
+	/// </summary>
+	internal static BoundingBox InPlane(IEnumerable<Segment> segments)
+	{
+		BoundingBox box = BoundingBox.Null;
+		bool anyWidth = false;
+		foreach (Segment segment in segments)
+		{
+			double half = Math.Max(segment.StartWidth, segment.EndWidth) / 2.0;
+			if (half > 0)
+			{
+				anyWidth = true;
+			}
+
+			BoundingBox padded;
+			if (segment.Bulge == 0)
+			{
+				//A straight segment sweeps the strip between its two offset edges, and the width is
+				//carried PERPENDICULAR to it: padding in every direction instead would push the box
+				//past the flat end cap, and AutoCAD's extents stop at the cap. Measured on an open
+				//polyline of width 150: AutoCAD reports the ends at the vertices, not 75 beyond.
+				XY direction = segment.End - segment.Start;
+				double length = direction.GetLength();
+				XY normal = length > 0
+					? new XY(-direction.Y / length, direction.X / length)
+					: new XY(1, 0);
+				double halfStart = segment.StartWidth / 2.0;
+				double halfEnd = segment.EndWidth / 2.0;
+
+				padded = BoundingBox.FromPoints(new[]
+				{
+					corner(segment.Start, normal, halfStart, segment.StartZ),
+					corner(segment.Start, normal, -halfStart, segment.StartZ),
+					corner(segment.End, normal, halfEnd, segment.EndZ),
+					corner(segment.End, normal, -halfEnd, segment.EndZ),
+				});
+			}
+			else if (segment.Start == segment.End)
+			{
+				//A bulge over a segment of no length describes no arc - Arc.CreateFromBulge refuses
+				//the zero radius - so it contributes the point it sits on, widened.
+				padded = new BoundingBox(
+					new XYZ(segment.Start.X - half, segment.Start.Y - half, segment.StartZ),
+					new XYZ(segment.Start.X + half, segment.Start.Y + half, segment.EndZ));
+			}
+			else
+			{
+				//The same arc the polyline explodes into, measured in the plane: its own normal is
+				//left at +Z so the box stays in the polyline's coordinates and one transform at the
+				//end takes the whole thing to the world. The width is added on every side here,
+				//which contains the sweep without working out where the arc's own normal points.
+				Arc arc = Arc.CreateFromBulge(segment.Start, segment.End, segment.Bulge);
+				arc.Center = new XYZ(arc.Center.X, arc.Center.Y, segment.StartZ);
+				BoundingBox centre = arc.GetBoundingBox();
+				padded = half == 0
+					? centre
+					: new BoundingBox(
+						new XYZ(centre.Min.X - half, centre.Min.Y - half, centre.Min.Z),
+						new XYZ(centre.Max.X + half, centre.Max.Y + half, centre.Max.Z));
+			}
+
+			box = box.Extent == BoundingBoxExtent.Null ? padded : box.Merge(padded);
+		}
+
+		return anyWidth ? box : BoundingBox.Null;
+	}
+
+	private static XYZ corner(XY point, XY normal, double offset, double elevation) =>
+		new XYZ(point.X + (normal.X * offset), point.Y + (normal.Y * offset), elevation);
+
+	/// <summary>One segment of a polyline, in the polyline's own plane.</summary>
+	internal readonly struct Segment
+	{
+		internal Segment(
+			XY start,
+			XY end,
+			double bulge,
+			double startWidth,
+			double endWidth,
+			double startZ = 0,
+			double endZ = 0)
+		{
+			this.Start = start;
+			this.End = end;
+			this.Bulge = bulge;
+			this.StartWidth = startWidth;
+			this.EndWidth = endWidth;
+			this.StartZ = startZ;
+			this.EndZ = endZ;
+		}
+
+		internal double Bulge { get; }
+
+		internal XY End { get; }
+
+		internal double EndWidth { get; }
+
+		internal XY Start { get; }
+
+		internal double StartWidth { get; }
+
+		//The height each end sits at, so the widened box keeps whatever the centre line had: an
+		//LWPOLYLINE stores its vertexes as XY and the box comes out flat at zero, while a POLYLINE
+		//vertex carries its own Z.
+		internal double StartZ { get; }
+
+		internal double EndZ { get; }
+	}
+}


### PR DESCRIPTION
**Stacked on #1224.** The first commit on this branch belongs to that pull request - a mirrored polyline reporting its bounding box in object coordinates - because this change touches the same two methods and would conflict with it otherwise. Review only the second commit, or take this one after #1224 lands.

### The problem

A polyline can carry a width, and it is drawn half on each side of the centre line. `LwPolyline.GetBoundingBox` and `Polyline<T>.GetBoundingBox` measure the centre line only:

```csharp
IEnumerable<XYZ> points = this.Vertices.Any(v => v.Bulge != 0)
    ? this.GetPoints<XYZ>(byte.MaxValue)
    : this.Vertices.Select(v => v.Location.Convert<XYZ>());

return BoundingBox.FromPoints(points.Select(p => toWorld * p));
```

So an entity that covers a strip is reported as the line down its middle, and a drawing whose outermost geometry is a wide polyline measures smaller than it is.

### How it was found

Asking AutoCAD for the extents of a 17.6 MB client drawing and comparing:

```
AutoCAD   (457057.490, -121881.651) .. (1147751.416, 251826.623)
ACadSharp (457132.493, -121806.650) .. (1147676.421, 251751.625)
```

Exactly **75 units short on all four sides** — and the entity at the edge is one `LWPOLYLINE` with `ConstantWidth = 150`.

### The fix

Bound each segment on its own, so a taper is paid for only where it occurs:

* a straight segment sweeps the strip between its two offset edges, and the offset goes **perpendicular** to it. Padding in every direction instead would push the box past the flat end cap, and AutoCAD stops at the cap;
* a segment with a bulge is padded by the larger of its two half widths, which contains the arc's sweep;
* a bulge over a segment of no length has no arc (`Arc.CreateFromBulge` refuses the zero radius), so it contributes the point it sits on, widened.

The widened area is measured in the polyline's own plane and taken to the world afterwards, so a mirrored polyline still lands on the correct side. `ConstantWidth` (code 43) applies wherever a vertex carries none of its own; for the old-style `POLYLINE` the polyline's own start and end width (40 and 41) play that role. A 3D polyline carries the fields but no width and is untouched.

### Measured against AutoCAD, on drawings it minted itself

| fixture | AutoCAD | before | after |
|---|---|---|---|
| closed square, `ConstantWidth` 150 | `(-75,-75)..(1075,1075)` | `(0,0)..(1000,1000)` | **exact** |
| open `PLINE`, width 150 | `(0,-75)..(1075,1000)` | `(0,0)..(1000,1000)` | **exact** |
| open, widths tapering 0-200-400 | `(0,-108.9)..(1200,1000)` | `(0,0)..(1000,1000)` | `(0,-100)..(1200,1000)` |

What is left in the third row is the fill AutoCAD adds where two segments meet, which reaches a little further than either segment does.

On the drawing that prompted this, the extents now match AutoCAD to `3e-06`. On nineteen other client drawings **not one extent moves**, and a polyline with no width keeps exactly the path it had.

### Tests

`GetBoundingBoxIncludesAConstantWidth`, `GetBoundingBoxCarriesAWidthAcrossTheSegmentAndNotBeyondItsEnds`, `GetBoundingBoxKeepsTheCentreLineWithoutAWidth`, and `GetBoundingBoxIncludesTheWidthTheVertexesCarry` for the old-style polyline. Suite 2900 / 0.
