### PR TITLE
Measure a raster image through its own axes, not the world's

### DIFF
--- a/src/ACadSharp.Tests/Entities/ImageBoundingBoxTests.cs
+++ b/src/ACadSharp.Tests/Entities/ImageBoundingBoxTests.cs
@@ -1,0 +1,105 @@
+using ACadSharp.Entities;
+using CSMath;
+using Xunit;
+
+namespace ACadSharp.Tests.Entities;
+
+public class ImageBoundingBoxTests
+{
+	[Fact]
+	public void ARotatedImageIsMeasuredThroughItsOwnAxes()
+	{
+		//Taken from a client drawing and checked against AutoCAD, which reports
+		//(664987.657, -42554.232)..(675578.740, -31963.149) for this image. The boundary is in the
+		//image's own pixel space; adding those pixel coordinates to the insertion point instead -
+		//which is what this used to do - claims a 500 x 500 square sitting at the insertion point,
+		//while the image is a 10,591-unit diamond hanging below it.
+		RasterImage image = new()
+		{
+			InsertPoint = new XYZ(670274.87890043925, -31963.148565297, 0),
+			Size = new XY(500, 500),
+			UVector = new XYZ(-10.574442749672151, -10.607724733996102, 0),
+			VVector = new XYZ(10.607724733996102, -10.574442749672151, 0),
+		};
+		image.ClipBoundaryVertices.Add(new XY(-0.5, -0.5));
+		image.ClipBoundaryVertices.Add(new XY(499.5, 499.5));
+
+		BoundingBox box = image.GetBoundingBox();
+
+		//Two decimals: AutoCAD prints its own extents to six significant figures, so that is as
+		//close as its number can be read.
+		Assert.Equal(664987.657, box.Min.X, 2);
+		Assert.Equal(-42554.232, box.Min.Y, 2);
+		Assert.Equal(675578.740, box.Max.X, 2);
+		Assert.Equal(-31963.149, box.Max.Y, 2);
+	}
+
+	[Fact]
+	public void AWipeoutHangsBelowItsInsertionPointBecauseTheBoundaryCountsFromTheTop()
+	{
+		//The case that tells the two directions apart. A wipeout is a 1 x 1 image whose vectors span
+		//the whole shape, and this boundary sits at the TOP of that unit square: AutoCAD draws the
+		//900 x 400 rectangle at the insertion point, not a whole V - here 4.5 million units - below
+		//it. Measured: AutoCAD reports (749966.684, -59623.691)..(750866.684, -59223.690).
+		Wipeout wipeout = new()
+		{
+			InsertPoint = new XYZ(749966.68417709228, -59223.690436399324, 0),
+			Size = new XY(1, 1),
+			UVector = new XYZ(4571087.5147777516, 0, 0),
+			VVector = new XYZ(0, -4571087.5147777516, 0),
+		};
+		wipeout.ClipBoundaryVertices.Add(new XY(-0.5, 0.5));
+		wipeout.ClipBoundaryVertices.Add(new XY(-0.5, 0.49991249347147548));
+		wipeout.ClipBoundaryVertices.Add(new XY(-0.49980311031082003, 0.49991249347147548));
+		wipeout.ClipBoundaryVertices.Add(new XY(-0.49980311031082003, 0.5));
+
+		BoundingBox box = wipeout.GetBoundingBox();
+
+		Assert.Equal(749966.684, box.Min.X, 2);
+		Assert.Equal(-59623.691, box.Min.Y, 2);
+		Assert.Equal(750866.684, box.Max.X, 2);
+		Assert.Equal(-59223.690, box.Max.Y, 2);
+	}
+
+	[Fact]
+	public void ARectangularBoundaryIsSquaredOffBeforeItIsMapped()
+	{
+		//Two vertexes are opposite corners, and the other two have to be built before the mapping:
+		//map only the diagonal and a rotated image is measured along it instead of around its edges.
+		RasterImage diagonal = new()
+		{
+			InsertPoint = XYZ.Zero,
+			Size = new XY(10, 10),
+			UVector = new XYZ(1, 1, 0),
+			VVector = new XYZ(-1, 1, 0),
+		};
+		diagonal.ClipBoundaryVertices.Add(new XY(-0.5, -0.5));
+		diagonal.ClipBoundaryVertices.Add(new XY(9.5, 9.5));
+
+		BoundingBox box = diagonal.GetBoundingBox();
+
+		Assert.Equal(-10, box.Min.X, 9);
+		Assert.Equal(0, box.Min.Y, 9);
+		Assert.Equal(10, box.Max.X, 9);
+		Assert.Equal(20, box.Max.Y, 9);
+	}
+
+	[Fact]
+	public void AnImageWithNoStoredBoundaryStillCoversItsOwnPixels()
+	{
+		//An unclipped image may carry no boundary at all in memory; the whole-image rectangle is
+		//what AutoCAD writes for it, and it is what the image covers.
+		RasterImage image = new()
+		{
+			InsertPoint = new XYZ(100, 200, 0),
+			Size = new XY(4, 3),
+			UVector = new XYZ(2, 0, 0),
+			VVector = new XYZ(0, 2, 0),
+		};
+
+		BoundingBox box = image.GetBoundingBox();
+
+		Assert.Equal(new XYZ(100, 200, 0), box.Min);
+		Assert.Equal(new XYZ(108, 206, 0), box.Max);
+	}
+}

--- a/src/ACadSharp/Entities/CadWipeoutBase.cs
+++ b/src/ACadSharp/Entities/CadWipeoutBase.cs
@@ -223,24 +223,45 @@ public abstract class CadWipeoutBase : Entity
 	}
 
 	/// <inheritdoc/>
+	/// <remarks>
+	/// The boundary is in the image's OWN pixel space, measured from pixel centres - which is why an
+	/// unclipped image stores (-0.5, -0.5) to (Size - 0.5) - and <see cref="UVector"/> and
+	/// <see cref="VVector"/> are what map one pixel into the world. Adding those pixel coordinates
+	/// straight to the insertion point describes a rectangle the image does not occupy as soon as
+	/// the vectors are not the world axes: on a client drawing an image placed with U and V rotated
+	/// 45 degrees, 10.6 units to the pixel, was reported as a 500x500 square at the insertion point
+	/// while AutoCAD measures a 10,591 x 10,591 diamond hanging below it.
+	/// </remarks>
 	public override BoundingBox GetBoundingBox()
 	{
-		if (!this.ClipBoundaryVertices.Any())
+		IReadOnlyList<XY> boundary = this.GetEffectiveClipBoundary();
+		if (boundary.Count < 2)
 		{
 			return BoundingBox.Null;
 		}
 
-		double minX = this.ClipBoundaryVertices.Select(v => v.X).Min();
-		double minY = this.ClipBoundaryVertices.Select(v => v.Y).Min();
-		XYZ min = new XYZ(minX, minY, 0) + this.InsertPoint;
+		//Two vertices are the opposite corners of a rectangle, and the other two have to be built
+		//before the mapping: mapping only the diagonal measures a rotated image along that diagonal
+		//instead of around its edges.
+		IEnumerable<XY> corners = boundary.Count == 2
+			? new[]
+			{
+				boundary[0],
+				new XY(boundary[1].X, boundary[0].Y),
+				boundary[1],
+				new XY(boundary[0].X, boundary[1].Y),
+			}
+			: boundary;
 
-		double maxX = this.ClipBoundaryVertices.Select(v => v.X).Max();
-		double maxY = this.ClipBoundaryVertices.Select(v => v.Y).Max();
-		XYZ max = new XYZ(maxX, maxY, 0) + this.InsertPoint;
-
-		BoundingBox box = new BoundingBox(min, max);
-
-		return box;
+		//X counts rightwards from the left edge and Y DOWNWARDS from the top, which is why an
+		//unclipped image - whose boundary is the whole rectangle either way - cannot tell the two
+		//apart, and a wipeout can: its boundary sits at the top of a 1x1 image, and AutoCAD draws it
+		//at the insertion point rather than a whole V below it. Measured on both, to 1e-3 of what
+		//AutoCAD reports for the same entity.
+		return BoundingBox.FromPoints(corners.Select(vertex =>
+			this.InsertPoint
+			+ ((vertex.X + 0.5) * this.UVector)
+			+ ((this.Size.Y - 0.5 - vertex.Y) * this.VVector)));
 	}
 
 	/// <inheritdoc/>


### PR DESCRIPTION
### The problem

A raster image's clip boundary is stored in the image's **own pixel space**, and `UVector` / `VVector` are what map one pixel into the world. `CadWipeoutBase.GetBoundingBox` added those pixel coordinates straight to the insertion point:

```csharp
double minX = this.ClipBoundaryVertices.Select(v => v.X).Min();
double minY = this.ClipBoundaryVertices.Select(v => v.Y).Min();
XYZ min = new XYZ(minX, minY, 0) + this.InsertPoint;
```

So the box describes a rectangle the image does not occupy as soon as U and V are not the world axes — and it is also `BoundingBox.Null` for an image that carries no boundary in memory, even though such an image is written with the whole-image rectangle and drawn in full.

### How it was found

A client drawing's extents sat 500 units above AutoCAD's. The entity at that edge is one `IMAGE` placed with U and V rotated 45° at 10.6 units to the pixel:

```
insert (670274.879, -31963.149)   size 500 x 500
U (-10.574, -10.608)   V (10.608, -10.574)   boundary (-0.5,-0.5) .. (499.5,499.5)

ACadSharp (670274.379, -31963.649) .. (670774.379, -31463.649)   a 500 x 500 square at the insert
AutoCAD   (664987.657, -42554.232) .. (675578.740, -31963.149)   a 10,591-unit diamond below it
```

### The fix

Map every boundary vertex through the image's own axes. X counts rightwards from the left edge and **Y downwards from the top**:

```csharp
this.InsertPoint + ((vertex.X + 0.5) * this.UVector) + ((this.Size.Y - 0.5 - vertex.Y) * this.VVector)
```

An unclipped image cannot tell the two Y directions apart — its boundary is the whole rectangle either way — but **a wipeout can**. A wipeout is a 1×1 image whose vectors span the whole shape, and its boundary sits at the top of that unit square:

```
insert (749966.684, -59223.690)   size 1 x 1   U (4571087.5, 0)   V (0, -4571087.5)
boundary  x in [-0.5, -0.49980]   y in [0.49991, 0.5]

reading Y upwards   (749966.684, -4630311.205) .. (750866.684, -4629911.205)
reading Y downwards (749966.684, -59623.690)   .. (750866.684, -59223.690)
AutoCAD             (749966.684, -59623.691)   .. (750866.684, -59223.690)
```

Two vertices are the opposite corners of a rectangle, so the other two are built **before** the mapping; mapping only the diagonal measures a rotated image along it instead of around its edges. An image with no boundary in memory falls back to `GetEffectiveClipBoundary`, the whole-image rectangle it would be written with.

### An independent derivation agrees

A consumer that had already worked this out from AutoCAD - the MAutocad importer - maps image
boundaries with exactly the same expression, and says so in its own words:

```csharp
// Clip vertices live in image space: pixel units from the top-left corner shifted by
// -0.5, with Y growing downward while the insert point anchors the bottom-left corner.
Point2 MapImagePoint(double x, double y) => new(
    insert.X + (u.X * (x + 0.5)) + (v.X * (height - y - 0.5)),
    insert.Y + (u.Y * (x + 0.5)) + (v.Y * (height - y - 0.5)));
```

That was written without reference to this change, and derived from the same oracle.

### Result

Both entities above now match AutoCAD's own box for them to the six significant figures AutoCAD prints. The drawing's extents move from `2.93e-03` of its span away from AutoCAD to `2.21e-06`, and **eighteen other client drawings do not move at all**.

### Tests

`ARotatedImageIsMeasuredThroughItsOwnAxes`, `AWipeoutHangsBelowItsInsertionPointBecauseTheBoundaryCountsFromTheTop`, `ARectangularBoundaryIsSquaredOffBeforeItIsMapped`, `AnImageWithNoStoredBoundaryStillCoversItsOwnPixels`. Suite 2904 / 0.
