### PR TITLE
Refactor: use CSMath.Extensions IsZero() throughout codebase

### DIFF
--- a/src/ACadSharp.Tests/Common/AssertUtils.cs
+++ b/src/ACadSharp.Tests/Common/AssertUtils.cs
@@ -1,4 +1,5 @@
 ﻿using CSMath;
+using CSMath.Extensions;
 using Xunit;
 
 namespace ACadSharp.Tests.Common;

--- a/src/ACadSharp.Tests/Entities/ArcTests.cs
+++ b/src/ACadSharp.Tests/Entities/ArcTests.cs
@@ -2,6 +2,7 @@
 using ACadSharp.Extensions;
 using ACadSharp.Tests.Common;
 using CSMath;
+using CSMath.Extensions;
 using System;
 using Xunit;
 

--- a/src/ACadSharp.Tests/Entities/CircleTests.cs
+++ b/src/ACadSharp.Tests/Entities/CircleTests.cs
@@ -1,6 +1,7 @@
 ﻿using ACadSharp.Entities;
 using ACadSharp.Tests.Common;
 using CSMath;
+using CSMath.Extensions;
 using System;
 using Xunit;
 

--- a/src/ACadSharp.Tests/Entities/CircleTests.cs
+++ b/src/ACadSharp.Tests/Entities/CircleTests.cs
@@ -33,7 +33,12 @@ public class CircleTests : CommonEntityTests<Circle>
 			Radius = 1,
 		};
 
-		var v = circle.PolygonalVertexes(4);
+		var v = circle.PolygonalVertexes(2);
+
+		AssertUtils.AreEqual<XYZ>(start, v[0], "start point");
+		AssertUtils.AreEqual<XYZ>(mid2, v[1], "end point");
+
+		v = circle.PolygonalVertexes(4);
 
 		AssertUtils.AreEqual<XYZ>(start, v[0], "start point");
 		AssertUtils.AreEqual<XYZ>(mid1, v[1], "mid point");
@@ -45,7 +50,6 @@ public class CircleTests : CommonEntityTests<Circle>
 			Radius = 1,
 			Center = new XYZ(20, 20, 0),
 		};
-
 
 		start += circle.Center;
 		mid1 += circle.Center;

--- a/src/ACadSharp.Tests/Entities/DimensionAlignedTests.cs
+++ b/src/ACadSharp.Tests/Entities/DimensionAlignedTests.cs
@@ -1,6 +1,7 @@
 ﻿using ACadSharp.Entities;
 using ACadSharp.Tests.Common;
 using CSMath;
+using CSMath.Extensions;
 using Xunit;
 
 namespace ACadSharp.Tests.Entities;

--- a/src/ACadSharp.Tests/Entities/DimensionAngular2LineTests.cs
+++ b/src/ACadSharp.Tests/Entities/DimensionAngular2LineTests.cs
@@ -1,6 +1,7 @@
 ﻿using ACadSharp.Entities;
 using ACadSharp.Tests.Common;
 using CSMath;
+using CSMath.Extensions;
 using Xunit;
 
 namespace ACadSharp.Tests.Entities;

--- a/src/ACadSharp.Tests/Entities/EllipseTests.cs
+++ b/src/ACadSharp.Tests/Entities/EllipseTests.cs
@@ -1,6 +1,7 @@
 ﻿using ACadSharp.Entities;
 using ACadSharp.Tests.Common;
 using CSMath;
+using CSMath.Extensions;
 using Xunit;
 
 namespace ACadSharp.Tests.Entities;

--- a/src/ACadSharp.Tests/Entities/HatchTests.cs
+++ b/src/ACadSharp.Tests/Entities/HatchTests.cs
@@ -148,8 +148,8 @@ public class HatchTests : CommonEntityTests<Hatch>
 			.ToList();
 
 		Assert.Single(lines);
-		AssertUtils.AreEqual(new XYZ(-1, 0, 0), lines[0].StartPoint);
-		AssertUtils.AreEqual(new XYZ(1, 0, 0), lines[0].EndPoint);
+		AssertUtils.AreEqual(new XYZ(-1, 0, 0), lines[0].StartPoint, 3);
+		AssertUtils.AreEqual(new XYZ(1, 0, 0), lines[0].EndPoint, 3);
 	}
 
 	[Fact]

--- a/src/ACadSharp.Tests/Entities/HatchTests.cs
+++ b/src/ACadSharp.Tests/Entities/HatchTests.cs
@@ -1,6 +1,7 @@
 ﻿using ACadSharp.Entities;
 using ACadSharp.Tests.Common;
 using CSMath;
+using CSMath.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ACadSharp.Tests/Entities/LineTests.cs
+++ b/src/ACadSharp.Tests/Entities/LineTests.cs
@@ -1,6 +1,7 @@
 ﻿using ACadSharp.Entities;
 using ACadSharp.Tests.Common;
 using CSMath;
+using CSMath.Extensions;
 using Xunit;
 
 namespace ACadSharp.Tests.Entities;

--- a/src/ACadSharp.Tests/Entities/SplineTests.cs
+++ b/src/ACadSharp.Tests/Entities/SplineTests.cs
@@ -2,6 +2,7 @@
 using ACadSharp.Extensions;
 using ACadSharp.Tests.Common;
 using CSMath;
+using CSMath.Extensions;
 using Xunit;
 
 namespace ACadSharp.Tests.Entities;

--- a/src/ACadSharp.Tests/IO/LoadPatternsTests.cs
+++ b/src/ACadSharp.Tests/IO/LoadPatternsTests.cs
@@ -1,6 +1,7 @@
 ﻿using ACadSharp.Entities;
 using ACadSharp.Tests.TestModels;
 using CSMath;
+using CSMath.Extensions;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/ACadSharp/ACadSharp.csproj
+++ b/src/ACadSharp/ACadSharp.csproj
@@ -17,7 +17,7 @@
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>3.7.13</Version>
+		<Version>3.7.14</Version>
 		<PackageOutputPath>../nupkg</PackageOutputPath>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>../ACadSharp.snk</AssemblyOriginatorKeyFile>

--- a/src/ACadSharp/CadObject.cs
+++ b/src/ACadSharp/CadObject.cs
@@ -7,6 +7,7 @@ using ACadSharp.Tables;
 using ACadSharp.Tables.Collections;
 using ACadSharp.XData;
 using CSMath;
+using CSMath.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ACadSharp/CadValue.cs
+++ b/src/ACadSharp/CadValue.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Extensions;
 using System;
 
 namespace ACadSharp;

--- a/src/ACadSharp/Entities/Arc.cs
+++ b/src/ACadSharp/Entities/Arc.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Extensions;
 using CSMath.Geometry;
 using System;
 using System.Collections.Generic;

--- a/src/ACadSharp/Entities/Circle.cs
+++ b/src/ACadSharp/Entities/Circle.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Extensions;
 using CSMath.Geometry;
 using System;
 using System.Collections.Generic;

--- a/src/ACadSharp/Entities/Dimension.cs
+++ b/src/ACadSharp/Entities/Dimension.cs
@@ -4,6 +4,7 @@ using ACadSharp.Tables;
 using ACadSharp.Types.Units;
 using ACadSharp.XData;
 using CSMath;
+using CSMath.Extensions;
 using CSUtilities.Extensions;
 using System;
 using System.Collections.Generic;
@@ -638,7 +639,7 @@ public abstract class Dimension : Entity, IOrientable
 		}
 
 		// center cross
-		if (!MathHelper.IsZero(this.Style.CenterMarkSize))
+		if (!this.Style.CenterMarkSize.IsZero())
 		{
 			this._block.Entities.AddRange(centerCross(centerRef.Convert<XYZ>(), radius, this.Style));
 		}
@@ -670,7 +671,7 @@ public abstract class Dimension : Entity, IOrientable
 	protected List<Entity> centerCross(XYZ center, double radius, DimensionStyle style)
 	{
 		List<Entity> lines = new();
-		if (MathHelper.IsZero(style.CenterMarkSize))
+		if (style.CenterMarkSize.IsZero())
 		{
 			return lines;
 		}

--- a/src/ACadSharp/Entities/DimensionAligned.cs
+++ b/src/ACadSharp/Entities/DimensionAligned.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Extensions;
 using System;
 
 namespace ACadSharp.Entities

--- a/src/ACadSharp/Entities/DimensionAngular2Line.cs
+++ b/src/ACadSharp/Entities/DimensionAngular2Line.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Extensions;
 using CSMath.Geometry;
 
 namespace ACadSharp.Entities

--- a/src/ACadSharp/Entities/DimensionAngular3Pt.cs
+++ b/src/ACadSharp/Entities/DimensionAngular3Pt.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Extensions;
 using System;
 
 namespace ACadSharp.Entities

--- a/src/ACadSharp/Entities/DimensionArc.cs
+++ b/src/ACadSharp/Entities/DimensionArc.cs
@@ -1,6 +1,7 @@
 using ACadSharp.Attributes;
 using ACadSharp.Classes;
 using CSMath;
+using CSMath.Extensions;
 using System;
 
 namespace ACadSharp.Entities;

--- a/src/ACadSharp/Entities/DimensionDiameter.cs
+++ b/src/ACadSharp/Entities/DimensionDiameter.cs
@@ -1,6 +1,7 @@
 ﻿using ACadSharp.Attributes;
 using ACadSharp.Tables;
 using CSMath;
+using CSMath.Extensions;
 using System;
 
 namespace ACadSharp.Entities
@@ -130,7 +131,7 @@ namespace ACadSharp.Entities
 			}
 
 			// center cross
-			if (!MathHelper.IsZero(this.Style.CenterMarkSize))
+			if (!this.Style.CenterMarkSize.IsZero())
 			{
 				this._block.Entities.AddRange(centerCross(this.Center, radius, this.Style));
 			}

--- a/src/ACadSharp/Entities/DimensionLinear.cs
+++ b/src/ACadSharp/Entities/DimensionLinear.cs
@@ -1,6 +1,7 @@
 ﻿using ACadSharp.Attributes;
 using ACadSharp.Tables;
 using CSMath;
+using CSMath.Extensions;
 using CSMath.Geometry;
 using System;
 

--- a/src/ACadSharp/Entities/DimensionOrdinate.cs
+++ b/src/ACadSharp/Entities/DimensionOrdinate.cs
@@ -1,6 +1,7 @@
 ﻿using ACadSharp.Attributes;
 using ACadSharp.Tables;
 using CSMath;
+using CSMath.Extensions;
 using CSUtilities.Extensions;
 using System;
 

--- a/src/ACadSharp/Entities/DimensionRadius.cs
+++ b/src/ACadSharp/Entities/DimensionRadius.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Extensions;
 
 namespace ACadSharp.Entities
 {

--- a/src/ACadSharp/Entities/Ellipse.cs
+++ b/src/ACadSharp/Entities/Ellipse.cs
@@ -1,6 +1,7 @@
 ﻿using ACadSharp.Attributes;
 using ACadSharp.IO;
 using CSMath;
+using CSMath.Extensions;
 using CSMath.Geometry;
 using System;
 using System.Collections.Generic;

--- a/src/ACadSharp/Entities/Entity.cs
+++ b/src/ACadSharp/Entities/Entity.cs
@@ -3,6 +3,7 @@ using ACadSharp.Entities.ProxyGraphics;
 using ACadSharp.Objects;
 using ACadSharp.Tables;
 using CSMath;
+using CSMath.Extensions;
 using System;
 using System.Collections.Generic;
 
@@ -293,7 +294,7 @@ public abstract class Entity : CadObject, IEntity
 			throw new ArgumentNullException(nameof(points));
 		}
 
-		if (MathHelper.IsZero(rotation))
+		if (rotation.IsZero())
 		{
 			return new List<XY>(points);
 		}

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.Arc.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.Arc.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Extensions;
 using CSMath.Geometry;
 using System;
 using System.Collections.Generic;

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.Ellipse.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.Ellipse.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Extensions;
 using CSMath.Geometry;
 using System;
 using System.Collections.Generic;

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.Line.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.Line.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Extensions;
 using CSMath.Geometry;
 using System.Collections.Generic;
 

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.Polyline.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.Polyline.cs
@@ -1,6 +1,7 @@
 ﻿using ACadSharp.Attributes;
 using ACadSharp.Extensions;
 using CSMath;
+using CSMath.Extensions;
 using CSMath.Geometry;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ACadSharp/Entities/Hatch.BoundaryPath.Spline.cs
+++ b/src/ACadSharp/Entities/Hatch.BoundaryPath.Spline.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Extensions;
 using CSMath.Geometry;
 using System;
 using System.Collections.Generic;

--- a/src/ACadSharp/Entities/Hatch.cs
+++ b/src/ACadSharp/Entities/Hatch.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Extensions;
 using CSMath.Geometry;
 using System.Collections.Generic;
 using System.Linq;
@@ -177,7 +178,7 @@ public partial class Hatch : Entity, IOrientable
 		this._patternAngle = axis.GetAngle();
 
 		double patScale = axis.GetLength();
-		this._patternScale = MathHelper.IsZero(patScale) ? MathHelper.Epsilon : patScale;
+		this._patternScale = patScale.IsZero() ? MathHelper.Epsilon : patScale;
 
 		this.Pattern?.Update(transform.Translation.Convert<XY>(), this._patternAngle, this._patternScale);
 		this.Normal = newNormal;

--- a/src/ACadSharp/Entities/HatchPattern.cs
+++ b/src/ACadSharp/Entities/HatchPattern.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Extensions;
 using CSUtilities.Extensions;
 using System;
 using System.Collections.Generic;

--- a/src/ACadSharp/Entities/Insert.cs
+++ b/src/ACadSharp/Entities/Insert.cs
@@ -4,6 +4,7 @@ using ACadSharp.IO;
 using ACadSharp.Objects;
 using ACadSharp.Tables;
 using CSMath;
+using CSMath.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -275,9 +276,9 @@ public class Insert : Entity, IOrientable
 		s = transformation * s;
 		s = transWO * s;
 		XYZ newScale = new XYZ(
-			MathHelper.IsZero(s.X) ? MathHelper.Epsilon : s.X,
-			MathHelper.IsZero(s.Y) ? MathHelper.Epsilon : s.Y,
-			MathHelper.IsZero(s.Z) ? MathHelper.Epsilon : s.Z);
+			s.X.IsZero() ? MathHelper.Epsilon : s.X,
+			s.Y.IsZero() ? MathHelper.Epsilon : s.Y,
+			s.Z.IsZero() ? MathHelper.Epsilon : s.Z);
 
 		this.Normal = newNormal;
 		this.InsertPoint = newPosition;

--- a/src/ACadSharp/Entities/Leader.cs
+++ b/src/ACadSharp/Entities/Leader.cs
@@ -2,6 +2,7 @@
 using ACadSharp.Tables;
 using ACadSharp.XData;
 using CSMath;
+using CSMath.Extensions;
 using System;
 using System.Collections.Generic;
 
@@ -69,7 +70,7 @@ public class Leader : Entity, IOrientable
 			}
 
 			double angle = (this.Vertices[this.Vertices.Count - 2] - this.Vertices[this.Vertices.Count - 1]).AngleBetweenVectors(this.HorizontalDirection);
-			return MathHelper.IsZero(angle);
+			return angle.IsZero();
 		}
 	}
 

--- a/src/ACadSharp/Entities/Line.cs
+++ b/src/ACadSharp/Entities/Line.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Extensions;
 using CSMath.Geometry;
 
 namespace ACadSharp.Entities;

--- a/src/ACadSharp/Entities/LwPolyLine.cs
+++ b/src/ACadSharp/Entities/LwPolyLine.cs
@@ -1,6 +1,7 @@
 ﻿using ACadSharp.Attributes;
 using ACadSharp.Extensions;
 using CSMath;
+using CSMath.Extensions;
 using CSUtilities.Extensions;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ACadSharp/Entities/LwPolyline.Vertex.cs
+++ b/src/ACadSharp/Entities/LwPolyline.Vertex.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Extensions;
 
 namespace ACadSharp.Entities;
 

--- a/src/ACadSharp/Entities/MLine.Vertex.cs
+++ b/src/ACadSharp/Entities/MLine.Vertex.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Extensions;
 using System.Collections.Generic;
 
 namespace ACadSharp.Entities

--- a/src/ACadSharp/Entities/MText.cs
+++ b/src/ACadSharp/Entities/MText.cs
@@ -2,6 +2,7 @@
 using ACadSharp.Tables;
 using ACadSharp.Text;
 using CSMath;
+using CSMath.Extensions;
 using System;
 using System.Collections.Generic;
 
@@ -296,7 +297,7 @@ public partial class MText : Entity, IText
 		}
 
 		double newHeight = this.Height * scale;
-		newHeight = MathHelper.IsZero(newHeight) ? MathHelper.Epsilon : newHeight;
+		newHeight = newHeight.IsZero() ? MathHelper.Epsilon : newHeight;
 
 		this.InsertPoint = newInsert;
 		this.Normal = newNormal;

--- a/src/ACadSharp/Entities/PolyLine.cs
+++ b/src/ACadSharp/Entities/PolyLine.cs
@@ -2,6 +2,7 @@
 using ACadSharp.Extensions;
 using ACadSharp.Tables;
 using CSMath;
+using CSMath.Extensions;
 using CSUtilities.Extensions;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ACadSharp/Entities/Spline.cs
+++ b/src/ACadSharp/Entities/Spline.cs
@@ -1,5 +1,6 @@
 using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Extensions;
 using CSUtilities.Extensions;
 using System;
 using System.Collections.Generic;

--- a/src/ACadSharp/Entities/TextEntity.cs
+++ b/src/ACadSharp/Entities/TextEntity.cs
@@ -1,6 +1,7 @@
 ﻿using ACadSharp.Attributes;
 using ACadSharp.Tables;
 using CSMath;
+using CSMath.Extensions;
 using CSUtilities.Extensions;
 using System;
 using System.Collections.Generic;
@@ -256,7 +257,7 @@ public class TextEntity : Entity, IText
 
 		// the height must be greater than zero, the cos is always positive between -85 and 85
 		double newHeight = newVvector.GetLength() * Math.Cos(newObliqueAngle);
-		newHeight = MathHelper.IsZero(newHeight) ? MathHelper.Epsilon : newHeight;
+		newHeight = newHeight.IsZero() ? MathHelper.Epsilon : newHeight;
 
 		// the width factor is defined between 0.01 and 100
 		double newWidthFactor = newUvector.GetLength() / newHeight;

--- a/src/ACadSharp/Entities/Vertex.cs
+++ b/src/ACadSharp/Entities/Vertex.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Attributes;
 using CSMath;
+using CSMath.Extensions;
 
 namespace ACadSharp.Entities;
 

--- a/src/ACadSharp/Extensions/PolylineExtensions.cs
+++ b/src/ACadSharp/Extensions/PolylineExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Entities;
 using CSMath;
+using CSMath.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamReader/DxfSectionReaderBase.cs
@@ -4,6 +4,7 @@ using ACadSharp.Objects;
 using ACadSharp.Tables;
 using ACadSharp.XData;
 using CSMath;
+using CSMath.Extensions;
 using CSUtilities.Extensions;
 using System;
 using System.Collections.Generic;

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfObjectsSectionWriter.cs
@@ -5,6 +5,7 @@ using ACadSharp.Objects.AEC;
 using ACadSharp.Objects.Evaluations;
 using ACadSharp.Tables;
 using CSMath;
+using CSMath.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
+++ b/src/ACadSharp/IO/DXF/DxfStreamWriter/DxfSectionWriterBase.Entities.cs
@@ -3,6 +3,7 @@ using ACadSharp.Entities.AecObjects;
 using ACadSharp.Entities.Mechanical;
 using ACadSharp.Objects;
 using CSMath;
+using CSMath.Extensions;
 using System;
 using System.Linq;
 

--- a/src/ACadSharp/IO/SVG/SvgDocumentBuilder.cs
+++ b/src/ACadSharp/IO/SVG/SvgDocumentBuilder.cs
@@ -2,6 +2,7 @@
 using ACadSharp.Objects;
 using ACadSharp.Tables;
 using CSMath;
+using CSMath.Extensions;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/ACadSharp/IO/SVG/SvgXmlWriter.cs
+++ b/src/ACadSharp/IO/SVG/SvgXmlWriter.cs
@@ -4,6 +4,7 @@ using ACadSharp.Objects;
 using ACadSharp.Tables;
 using ACadSharp.Types.Units;
 using CSMath;
+using CSMath.Extensions;
 using CSUtilities.Extensions;
 using System;
 using System.Collections.Generic;

--- a/src/ACadSharp/Tables/LineType.cs
+++ b/src/ACadSharp/Tables/LineType.cs
@@ -2,6 +2,7 @@
 using ACadSharp.Entities;
 using ACadSharp.Extensions;
 using CSMath;
+using CSMath.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/ACadSharp/Tables/VPort.cs
+++ b/src/ACadSharp/Tables/VPort.cs
@@ -1,6 +1,7 @@
 ﻿using ACadSharp.Attributes;
 using ACadSharp.Objects;
 using CSMath;
+using CSMath.Extensions;
 using System;
 
 namespace ACadSharp.Tables

--- a/src/ACadSharp/Types/Units/UnitStyleFormat.cs
+++ b/src/ACadSharp/Types/Units/UnitStyleFormat.cs
@@ -1,5 +1,6 @@
 ﻿using ACadSharp.Tables;
 using CSMath;
+using CSMath.Extensions;
 using System;
 using System.Globalization;
 using System.Text;
@@ -278,7 +279,7 @@ namespace ACadSharp.Types.Units
 			double inchesDec = value - 12 * feet;
 			int inches = (int)inchesDec;
 
-			if (MathHelper.IsZero(inchesDec))
+			if (inchesDec.IsZero())
 			{
 				if (feet == 0)
 				{
@@ -453,7 +454,7 @@ namespace ACadSharp.Types.Units
 			int feet = (int)(value / 12);
 			double inches = value - 12 * feet;
 
-			if (MathHelper.IsZero(inches))
+			if (inches.IsZero())
 			{
 				if (feet == 0)
 				{


### PR DESCRIPTION
# Description

Replaced MathHelper.IsZero() with the IsZero() extension method from CSMath.Extensions for improved readability and consistency.
Added using directives for CSMath.Extensions where needed. 
Updated CSUtilities submodule to support these changes. 
Affects entity transforms, dimensions, text, and formatting logic.
